### PR TITLE
security: fix STARTTLS panic, client memory DoS, ESEARCH RFC 7377 vio…

### DIFF
--- a/imapclient/client.go
+++ b/imapclient/client.go
@@ -43,6 +43,14 @@ const (
 	respReadTimeout    = 30 * time.Second
 	literalReadTimeout = 5 * time.Minute
 
+	// maxResponseSize bounds the non-literal bytes of a single server response.
+	// It defends against a hostile server that streams an unterminated
+	// continuation or status-text line to exhaust client memory. Literals
+	// (message bodies) are excluded from this budget and keep their own caps, so
+	// this only limits response metadata (tags, ENVELOPE, BODYSTRUCTURE, SASL
+	// challenges), which never legitimately approaches this size.
+	maxResponseSize = 8 << 20 // 8 MiB
+
 	cmdWriteTimeout     = 30 * time.Second
 	literalWriteTimeout = 5 * time.Minute
 
@@ -190,12 +198,17 @@ func New(conn net.Conn, options *Options) *Client {
 	br := bufio.NewReader(rw)
 	bw := bufio.NewWriter(rw)
 
+	dec := imapwire.NewDecoder(br, imapwire.ConnSideClient)
+	// Bound per-response memory against a hostile server. The counter is reset
+	// at the start of each response in readResponse.
+	dec.MaxSize = maxResponseSize
+
 	client := &Client{
 		conn:       conn,
 		options:    *options,
 		br:         br,
 		bw:         bw,
-		dec:        imapwire.NewDecoder(br, imapwire.ConnSideClient),
+		dec:        dec,
 		greetingCh: make(chan struct{}),
 		decCh:      make(chan struct{}),
 		state:      imap.ConnStateNone,
@@ -211,6 +224,16 @@ func New(conn net.Conn, options *Options) *Client {
 func NewStartTLS(conn net.Conn, options *Options) (*Client, error) {
 	if options == nil {
 		options = &Options{}
+	}
+
+	// A net.Conn carries no intended hostname, so unlike DialStartTLS we cannot
+	// derive ServerName here. Without it crypto/tls fails the handshake closed,
+	// which tends to push callers toward InsecureSkipVerify. Refuse up front with
+	// actionable guidance instead, so the trust decision is never silent.
+	if options.TLSConfig == nil ||
+		(options.TLSConfig.ServerName == "" && !options.TLSConfig.InsecureSkipVerify) {
+		return nil, fmt.Errorf("imapclient: NewStartTLS requires TLSConfig.ServerName " +
+			"(use DialStartTLS to derive it from the address, or set InsecureSkipVerify to opt out)")
 	}
 
 	client := New(conn, options)
@@ -627,6 +650,9 @@ func (c *Client) read() {
 func (c *Client) readResponse() error {
 	c.setReadTimeout(respReadTimeout)
 	defer c.setReadTimeout(idleReadTimeout)
+
+	// Apply the MaxSize budget per response rather than cumulatively.
+	c.dec.ResetCount()
 
 	if c.dec.Special('+') {
 		if err := c.readContinueReq(); err != nil {

--- a/imapclient/starttls.go
+++ b/imapclient/starttls.go
@@ -30,6 +30,14 @@ func (c *Client) startTLS(config *tls.Config) error {
 	// The decoder goroutine will invoke Client.upgradeStartTLS
 	<-upgradeDone
 
+	// upgradeStartTLS may have refused the upgrade (e.g. the server sent
+	// buffered data before the OK response) and left tlsConn nil. Surface that
+	// error instead of dereferencing a nil *tls.Conn. upgradeErr is written by
+	// the decoder goroutine before it closes upgradeDone, so the receive above
+	// establishes the happens-before that makes this read race-free.
+	if cmd.upgradeErr != nil {
+		return cmd.upgradeErr
+	}
 	return cmd.tlsConn.Handshake()
 }
 
@@ -41,7 +49,7 @@ func (c *Client) upgradeStartTLS(startTLS *startTLSCommand) {
 	// Refuse STARTTLS if server sent buffered data before the OK response.
 	// This is the canonical defense against smuggling attacks.
 	if c.br.Buffered() > 0 {
-		startTLS.err = fmt.Errorf("STARTTLS refused: server sent buffered data before TLS")
+		startTLS.upgradeErr = fmt.Errorf("STARTTLS refused: server sent buffered data before TLS")
 		return
 	}
 
@@ -62,4 +70,8 @@ type startTLSCommand struct {
 
 	upgradeDone chan<- struct{}
 	tlsConn     *tls.Conn
+	// upgradeErr carries a failure from upgradeStartTLS (decoder goroutine) back
+	// to startTLS (caller goroutine). It is kept separate from commandBase.err,
+	// which wait() mutates, to avoid a data race on that field.
+	upgradeErr error
 }

--- a/imapclient/starttls_test.go
+++ b/imapclient/starttls_test.go
@@ -1,7 +1,11 @@
 package imapclient_test
 
 import (
+	"bufio"
 	"crypto/tls"
+	"io"
+	"net"
+	"strings"
 	"testing"
 
 	"github.com/emersion/go-imap/v2/imapclient"
@@ -23,5 +27,60 @@ func TestStartTLS(t *testing.T) {
 
 	if err := client.Noop().Wait(); err != nil {
 		t.Fatalf("Noop().Wait() = %v", err)
+	}
+}
+
+// TestStartTLS_ServerBufferedDataBeforeOK exercises the anti-smuggling defense:
+// a server that pipelines plaintext before the STARTTLS OK must be refused with
+// an error — and, as a regression guard, must NOT panic on a nil *tls.Conn.
+func TestStartTLS_ServerBufferedDataBeforeOK(t *testing.T) {
+	clientConn, serverConn := net.Pipe()
+	defer clientConn.Close()
+
+	go func() {
+		br := bufio.NewReader(serverConn)
+		io.WriteString(serverConn, "* OK [CAPABILITY IMAP4rev2 STARTTLS] ready\r\n")
+		line, err := br.ReadString('\n')
+		if err != nil {
+			return
+		}
+		fields := strings.Fields(line)
+		if len(fields) == 0 {
+			return
+		}
+		tag := fields[0]
+		// OK plus smuggled plaintext in a single write, so it lands buffered in
+		// the client's reader before the TLS handshake.
+		io.WriteString(serverConn, tag+" OK begin TLS now\r\n* BYE injected\r\n")
+		io.Copy(io.Discard, br)
+	}()
+
+	_, err := imapclient.NewStartTLS(clientConn, &imapclient.Options{
+		TLSConfig: &tls.Config{InsecureSkipVerify: true},
+	})
+	if err == nil {
+		t.Fatal("NewStartTLS() should fail when the server buffers data before the OK")
+	}
+	if !strings.Contains(err.Error(), "buffered data") {
+		t.Fatalf("NewStartTLS() error = %v, want a buffered-data refusal", err)
+	}
+}
+
+// TestNewStartTLS_RequiresServerName guards against silently unverified TLS:
+// NewStartTLS must refuse a config that neither sets ServerName nor opts into
+// InsecureSkipVerify, rather than proceeding to an opaque fail-closed handshake.
+func TestNewStartTLS_RequiresServerName(t *testing.T) {
+	clientConn, serverConn := net.Pipe()
+	defer clientConn.Close()
+	defer serverConn.Close()
+
+	_, err := imapclient.NewStartTLS(clientConn, &imapclient.Options{
+		TLSConfig: &tls.Config{},
+	})
+	if err == nil {
+		t.Fatal("NewStartTLS() with empty ServerName and no InsecureSkipVerify should error")
+	}
+	if !strings.Contains(err.Error(), "ServerName") {
+		t.Fatalf("NewStartTLS() error = %v, want a ServerName requirement", err)
 	}
 }

--- a/imapserver/authenticate.go
+++ b/imapserver/authenticate.go
@@ -24,8 +24,12 @@ func (c *Conn) handleAuthenticate(tag string, dec *imapwire.Decoder) error {
 		if !dec.ExpectText(&initialRespStr) {
 			return dec.Err()
 		}
+		// Use decodeSASL (not internal.DecodeSASL) so a malformed initial
+		// response is reported as a client error (BAD "Malformed SASL response")
+		// rather than falling through to NO [SERVERBUG], matching the
+		// continuation path below.
 		var err error
-		initialResp, err = internal.DecodeSASL(initialRespStr)
+		initialResp, err = decodeSASL(initialRespStr)
 		if err != nil {
 			return err
 		}

--- a/imapserver/conn.go
+++ b/imapserver/conn.go
@@ -104,7 +104,12 @@ func (c *Conn) Bye(text string) error {
 		Type: imap.StatusResponseTypeBye,
 		Text: text,
 	})
-	closeErr := c.conn.Close()
+	// Read c.conn under the mutex: STARTTLS reassigns it and forceCloseConns
+	// closes it from other goroutines.
+	c.mutex.Lock()
+	conn := c.conn
+	c.mutex.Unlock()
+	closeErr := conn.Close()
 	if respErr != nil {
 		return respErr
 	}

--- a/imapserver/esearch.go
+++ b/imapserver/esearch.go
@@ -146,12 +146,37 @@ func (c *Conn) handleESearch(tag string, dec *imapwire.Decoder) error {
 	}
 
 	for _, data := range results {
+		// RFC 7377 §2.1: "An ESEARCH response MUST NOT be returned for mailboxes
+		// that contain no matching messages. This is true even when result
+		// options such as MIN, MAX, and COUNT are specified."
+		if multiSearchDataIsEmpty(data, &options) {
+			continue
+		}
 		if err := c.writeESearch(tag, data, &options, NumKindUID); err != nil {
 			return err
 		}
 	}
 
 	return nil
+}
+
+// multiSearchDataIsEmpty reports whether a per-mailbox multi-search result
+// matched no messages, in which case RFC 7377 §2.1 forbids emitting an ESEARCH
+// response for that mailbox — regardless of which return options were requested.
+func multiSearchDataIsEmpty(data *imap.SearchData, options *imap.SearchOptions) bool {
+	if options.ReturnMin && data.Min > 0 {
+		return false
+	}
+	if options.ReturnMax && data.Max > 0 {
+		return false
+	}
+	if options.ReturnCount && data.Count > 0 {
+		return false
+	}
+	if options.ReturnAll && data.All != nil && !isNumSetEmpty(data.All) {
+		return false
+	}
+	return true
 }
 
 // readSearchSource parses the parenthesized source-mbox of an ESEARCH "IN (...)"

--- a/imapserver/esearch_test.go
+++ b/imapserver/esearch_test.go
@@ -1,0 +1,84 @@
+package imapserver
+
+import (
+	"testing"
+
+	"github.com/emersion/go-imap/v2"
+)
+
+// TestMultiSearchDataIsEmpty locks in RFC 7377 §2.1: an ESEARCH response MUST
+// NOT be returned for a mailbox with no matching messages, regardless of the
+// requested return options (including COUNT 0).
+func TestMultiSearchDataIsEmpty(t *testing.T) {
+	nonEmpty := imap.UIDSet{{Start: 1, Stop: 3}}
+
+	tests := []struct {
+		name    string
+		data    imap.SearchData
+		options imap.SearchOptions
+		want    bool
+	}{
+		{
+			name:    "count zero is empty (MUST NOT emit)",
+			data:    imap.SearchData{Count: 0},
+			options: imap.SearchOptions{ReturnCount: true},
+			want:    true,
+		},
+		{
+			name:    "count non-zero is not empty",
+			data:    imap.SearchData{Count: 5},
+			options: imap.SearchOptions{ReturnCount: true},
+			want:    false,
+		},
+		{
+			name:    "all empty is empty",
+			data:    imap.SearchData{All: imap.UIDSet{}},
+			options: imap.SearchOptions{ReturnAll: true},
+			want:    true,
+		},
+		{
+			name:    "all nil is empty",
+			data:    imap.SearchData{All: nil},
+			options: imap.SearchOptions{ReturnAll: true},
+			want:    true,
+		},
+		{
+			name:    "all non-empty is not empty",
+			data:    imap.SearchData{All: nonEmpty},
+			options: imap.SearchOptions{ReturnAll: true},
+			want:    false,
+		},
+		{
+			name:    "min hit is not empty",
+			data:    imap.SearchData{Min: 2},
+			options: imap.SearchOptions{ReturnMin: true},
+			want:    false,
+		},
+		{
+			name:    "min zero (no hit) is empty",
+			data:    imap.SearchData{Min: 0},
+			options: imap.SearchOptions{ReturnMin: true},
+			want:    true,
+		},
+		{
+			name:    "max hit is not empty",
+			data:    imap.SearchData{Max: 9},
+			options: imap.SearchOptions{ReturnMax: true},
+			want:    false,
+		},
+		{
+			name:    "min+max both zero is empty",
+			data:    imap.SearchData{Min: 0, Max: 0},
+			options: imap.SearchOptions{ReturnMin: true, ReturnMax: true},
+			want:    true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := multiSearchDataIsEmpty(&tt.data, &tt.options); got != tt.want {
+				t.Errorf("multiSearchDataIsEmpty() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/imapwire/decoder.go
+++ b/internal/imapwire/decoder.go
@@ -85,6 +85,17 @@ func (dec *Decoder) Err() error {
 	return dec.err
 }
 
+// ResetCount resets the running byte counter used by MaxSize.
+//
+// A long-lived decoder (e.g. the client's, which is reused for every response
+// on a connection) must call this at the start of each logical unit so that
+// MaxSize acts as a per-unit budget rather than a cumulative cap that would
+// eventually trip on a healthy connection. Literal bytes are not counted, so
+// this does not affect large streamed payloads.
+func (dec *Decoder) ResetCount() {
+	dec.readBytes = 0
+}
+
 func (dec *Decoder) returnErr(err error) bool {
 	if err == nil {
 		return true

--- a/internal/imapwire/decoder_test.go
+++ b/internal/imapwire/decoder_test.go
@@ -1,0 +1,46 @@
+package imapwire
+
+import (
+	"bufio"
+	"strings"
+	"testing"
+)
+
+// TestDecoderMaxSizeText ensures a long unterminated line is rejected once
+// MaxSize is exceeded, rather than buffered unboundedly (hostile-peer DoS).
+func TestDecoderMaxSizeText(t *testing.T) {
+	input := strings.Repeat("A", 1000) + "\r\n"
+	dec := NewDecoder(bufio.NewReader(strings.NewReader(input)), ConnSideClient)
+	dec.MaxSize = 10
+
+	var s string
+	if dec.Text(&s) {
+		t.Fatal("Text() should fail once MaxSize is exceeded")
+	}
+	if dec.Err() == nil {
+		t.Fatal("expected a decoder error after exceeding MaxSize")
+	}
+}
+
+// TestDecoderResetCount ensures ResetCount makes MaxSize a per-unit budget on a
+// reused (long-lived) decoder instead of a cumulative cap.
+func TestDecoderResetCount(t *testing.T) {
+	input := "AAAAA\r\nBBBBB\r\n"
+	dec := NewDecoder(bufio.NewReader(strings.NewReader(input)), ConnSideClient)
+	// Enough for one line + CRLF, but not for both lines cumulatively.
+	dec.MaxSize = 8
+
+	var s string
+	if !dec.Text(&s) || s != "AAAAA" {
+		t.Fatalf("first Text() = %q (err=%v); want AAAAA", s, dec.Err())
+	}
+	if !dec.CRLF() {
+		t.Fatalf("CRLF() failed: %v", dec.Err())
+	}
+
+	dec.ResetCount()
+
+	if !dec.Text(&s) || s != "BBBBB" {
+		t.Fatalf("second Text() after ResetCount = %q (err=%v); want BBBBB", s, dec.Err())
+	}
+}


### PR DESCRIPTION
…lation, and 3 hardening issues

Findings from a client+server audit (report in audit-artifacts/findings.md).

H1 imapclient/starttls.go: the anti-smuggling check left tlsConn nil and the
    error was written to commandBase.err (which wait() also mutates, a data
    race) but never re-read, so startTLS() called Handshake() on a nil
    *tls.Conn -> a hostile/buggy server that pipelined bytes before the STARTTLS
    OK panicked the client. Carry the failure on a dedicated upgradeErr field
    synchronized by upgradeDone, and surface it before dereferencing tlsConn.

H2 imapclient/client.go: the client decoder had no MaxSize, so a hostile server
    could stream an unterminated continuation/status line and OOM the client.
    Cap non-literal response bytes at 8 MiB via Decoder.MaxSize; add
    Decoder.ResetCount and call it per response so the long-lived client decoder
    applies the cap per-response, not cumulatively.

H3 imapserver/esearch.go: multi-mailbox ESEARCH emitted a response (incl.
    COUNT 0) for mailboxes with no matches, violating RFC 7377 s2.1's MUST NOT.
    Suppress empty per-mailbox results.

M1 imapserver/authenticate.go: a malformed AUTHENTICATE initial response
    returned NO [SERVERBUG] and logged, instead of BAD. Route it through
    decodeSASL like the continuation path.

M2 imapclient/client.go: NewStartTLS never set ServerName, silently failing
    closed and nudging callers toward InsecureSkipVerify. Refuse a config with
    neither ServerName nor InsecureSkipVerify, with actionable guidance.

M3 imapserver/conn.go: Bye() read/closed c.conn without c.mutex, racing STARTTLS
    reassignment and forceCloseConns. Snapshot under the lock.

Regression tests added for H1, H2, H3, M2; full suite passes under -race.