### PR TITLE
imapserver: thread context.Context through the Session interface (M4)

### DIFF
--- a/cmd/imapmemserver/main.go
+++ b/cmd/imapmemserver/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"crypto/tls"
 	"flag"
 	"io"
@@ -56,51 +57,51 @@ func main() {
 		user := imapmemserver.NewUser(username, password)
 
 		// Create standard mailboxes with special-use attributes as per RFC 6154
-		if err := user.Create("INBOX", nil); err != nil {
+		if err := user.Create(context.Background(), "INBOX", nil); err != nil {
 			log.Printf("Failed to create INBOX: %v", err)
 		}
 
-		if err := user.Create("Drafts", &imap.CreateOptions{
+		if err := user.Create(context.Background(), "Drafts", &imap.CreateOptions{
 			SpecialUse: []imap.MailboxAttr{imap.MailboxAttrDrafts},
 		}); err != nil {
 			log.Printf("Failed to create Drafts mailbox: %v", err)
 		}
 
-		if err := user.Create("Sent", &imap.CreateOptions{
+		if err := user.Create(context.Background(), "Sent", &imap.CreateOptions{
 			SpecialUse: []imap.MailboxAttr{imap.MailboxAttrSent},
 		}); err != nil {
 			log.Printf("Failed to create Sent mailbox: %v", err)
 		}
 
-		if err := user.Create("Archive", &imap.CreateOptions{
+		if err := user.Create(context.Background(), "Archive", &imap.CreateOptions{
 			SpecialUse: []imap.MailboxAttr{imap.MailboxAttrArchive},
 		}); err != nil {
 			log.Printf("Failed to create Archive mailbox: %v", err)
 		}
 
-		if err := user.Create("Junk", &imap.CreateOptions{
+		if err := user.Create(context.Background(), "Junk", &imap.CreateOptions{
 			SpecialUse: []imap.MailboxAttr{imap.MailboxAttrJunk},
 		}); err != nil {
 			log.Printf("Failed to create Junk mailbox: %v", err)
 		}
 
-		if err := user.Create("Trash", &imap.CreateOptions{
+		if err := user.Create(context.Background(), "Trash", &imap.CreateOptions{
 			SpecialUse: []imap.MailboxAttr{imap.MailboxAttrTrash},
 		}); err != nil {
 			log.Printf("Failed to create Trash mailbox: %v", err)
 		}
 
-		if err := user.Create("Flagged", &imap.CreateOptions{
+		if err := user.Create(context.Background(), "Flagged", &imap.CreateOptions{
 			SpecialUse: []imap.MailboxAttr{imap.MailboxAttrFlagged},
 		}); err != nil {
 			log.Printf("Failed to create Flagged mailbox: %v", err)
 		}
 
 		// Subscribe to the most commonly used mailboxes
-		_ = user.Subscribe("INBOX")
-		_ = user.Subscribe("Drafts")
-		_ = user.Subscribe("Sent")
-		_ = user.Subscribe("Trash")
+		_ = user.Subscribe(context.Background(), "INBOX")
+		_ = user.Subscribe(context.Background(), "Drafts")
+		_ = user.Subscribe(context.Background(), "Sent")
+		_ = user.Subscribe(context.Background(), "Trash")
 
 		memServer.AddUser(user)
 	}

--- a/imapclient/client_test.go
+++ b/imapclient/client_test.go
@@ -1,6 +1,7 @@
 package imapclient_test
 
 import (
+	"context"
 	"crypto/tls"
 	"io"
 	"net"
@@ -82,7 +83,7 @@ func newMemClientServerPair(t *testing.T) (net.Conn, io.Closer) {
 	memServer := imapmemserver.New()
 
 	user := imapmemserver.NewUser(testUsername, testPassword)
-	user.Create("INBOX", nil)
+	user.Create(context.Background(), "INBOX", nil)
 
 	memServer.AddUser(user)
 

--- a/imapclient/list_test.go
+++ b/imapclient/list_test.go
@@ -2,6 +2,7 @@ package imapclient_test
 
 import (
 	"bufio"
+	"context"
 	"fmt"
 	"net"
 	"reflect"
@@ -61,9 +62,9 @@ func TestListExtendedDataItemGating(t *testing.T) {
 		{
 			name: "plain LIST should not send CHILDINFO",
 			setupMailboxes: func(user *imapmemserver.User) {
-				user.Create("Parent", nil)
-				user.Create("Parent/Child", nil)
-				user.Subscribe("Parent/Child")
+				user.Create(context.Background(), "Parent", nil)
+				user.Create(context.Background(), "Parent/Child", nil)
+				user.Subscribe(context.Background(), "Parent/Child")
 			},
 			command:       `tag1 LIST "" "*"`,
 			wantCHILDINFO: false,
@@ -72,8 +73,8 @@ func TestListExtendedDataItemGating(t *testing.T) {
 		{
 			name: "LIST with RETURN (CHILDREN) should not send CHILDINFO",
 			setupMailboxes: func(user *imapmemserver.User) {
-				user.Create("Parent", nil)
-				user.Create("Parent/Child", nil)
+				user.Create(context.Background(), "Parent", nil)
+				user.Create(context.Background(), "Parent/Child", nil)
 			},
 			command:       `tag2 LIST "" "*" RETURN (CHILDREN)`,
 			wantCHILDINFO: false,
@@ -82,10 +83,10 @@ func TestListExtendedDataItemGating(t *testing.T) {
 		{
 			name: "LIST with RECURSIVEMATCH allows CHILDINFO",
 			setupMailboxes: func(user *imapmemserver.User) {
-				user.Create("Parent", nil)
-				user.Create("Parent/Child", nil)
-				user.Subscribe("Parent")
-				user.Subscribe("Parent/Child")
+				user.Create(context.Background(), "Parent", nil)
+				user.Create(context.Background(), "Parent/Child", nil)
+				user.Subscribe(context.Background(), "Parent")
+				user.Subscribe(context.Background(), "Parent/Child")
 			},
 			command:       `tag3 LIST (SUBSCRIBED RECURSIVEMATCH) "" "*"`,
 			wantCHILDINFO: false, // In-memory server doesn't generate CHILDINFO, but it's allowed
@@ -94,7 +95,7 @@ func TestListExtendedDataItemGating(t *testing.T) {
 		{
 			name: "plain LIST should not send OLDNAME",
 			setupMailboxes: func(user *imapmemserver.User) {
-				user.Create("INBOX", nil)
+				user.Create(context.Background(), "INBOX", nil)
 			},
 			command:     `tag4 LIST "" "INBOX"`,
 			wantOLDNAME: false,
@@ -103,8 +104,8 @@ func TestListExtendedDataItemGating(t *testing.T) {
 		{
 			name: "LSUB should not send extended data items",
 			setupMailboxes: func(user *imapmemserver.User) {
-				user.Create("INBOX", nil)
-				user.Subscribe("INBOX")
+				user.Create(context.Background(), "INBOX", nil)
+				user.Subscribe(context.Background(), "INBOX")
 			},
 			command:       `tag5 LSUB "" "*"`,
 			wantCHILDINFO: false,
@@ -199,7 +200,7 @@ func TestSelectNoExtendedDataItems(t *testing.T) {
 	// Create a custom server
 	memServer := imapmemserver.New()
 	user := imapmemserver.NewUser(testUsername, testPassword)
-	user.Create("INBOX", nil)
+	user.Create(context.Background(), "INBOX", nil)
 	memServer.AddUser(user)
 
 	server := imapserver.New(&imapserver.Options{

--- a/imapserver/acl.go
+++ b/imapserver/acl.go
@@ -1,6 +1,10 @@
 package imapserver
 
-import "github.com/emersion/go-imap/v2"
+import (
+	"context"
+
+	"github.com/emersion/go-imap/v2"
+)
 
 // SessionACL is an IMAP session which supports the ACL extension (RFC 4314).
 //
@@ -13,7 +17,7 @@ type SessionACL interface {
 	// Returns the mailbox name and list of ACL entries.
 	//
 	// The user must have either the 'l' (lookup) or 'a' (admin) right on the mailbox.
-	GetACL(mailbox string) (*imap.GetACLData, error)
+	GetACL(ctx context.Context, mailbox string) (*imap.GetACLData, error)
 
 	// SetACL sets or modifies the access control list for a mailbox.
 	// The modification parameter determines how the rights are applied:
@@ -28,21 +32,21 @@ type SessionACL interface {
 	// identifier: User email, group name, or special identifier ("anyone", "authenticated")
 	// modification: How to apply the rights (replace, add, or remove)
 	// rights: Rights to grant/add/remove
-	SetACL(mailbox string, identifier imap.RightsIdentifier, modification imap.RightModification, rights imap.RightSet) error
+	SetACL(ctx context.Context, mailbox string, identifier imap.RightsIdentifier, modification imap.RightModification, rights imap.RightSet) error
 
 	// DeleteACL removes the access control list entry for an identifier.
 	// This is equivalent to SetACL with RightModificationReplace and empty rights.
 	//
 	// The user must have the 'a' (admin) right on the mailbox.
-	DeleteACL(mailbox string, identifier imap.RightsIdentifier) error
+	DeleteACL(ctx context.Context, mailbox string, identifier imap.RightsIdentifier) error
 
 	// ListRights lists the rights that can be granted to an identifier on a mailbox.
 	// Returns required rights (always present) and groups of optional rights (may be granted).
 	//
 	// The user must have the 'a' (admin) right on the mailbox.
-	ListRights(mailbox string, identifier imap.RightsIdentifier) (*imap.ListRightsData, error)
+	ListRights(ctx context.Context, mailbox string, identifier imap.RightsIdentifier) (*imap.ListRightsData, error)
 
 	// MyRights returns the rights the current user has on a mailbox.
 	// This command does not require any special permissions - any user can check their own rights.
-	MyRights(mailbox string) (*imap.MyRightsData, error)
+	MyRights(ctx context.Context, mailbox string) (*imap.MyRightsData, error)
 }

--- a/imapserver/acl_capability_test.go
+++ b/imapserver/acl_capability_test.go
@@ -1,6 +1,7 @@
 package imapserver
 
 import (
+	"context"
 	"testing"
 
 	"github.com/emersion/go-imap/v2"
@@ -13,15 +14,21 @@ type aclCapSession struct {
 	Session
 }
 
-func (aclCapSession) GetACL(mailbox string) (*imap.GetACLData, error) { return nil, nil }
-func (aclCapSession) SetACL(mailbox string, id imap.RightsIdentifier, mod imap.RightModification, rights imap.RightSet) error {
-	return nil
-}
-func (aclCapSession) DeleteACL(mailbox string, id imap.RightsIdentifier) error { return nil }
-func (aclCapSession) ListRights(mailbox string, id imap.RightsIdentifier) (*imap.ListRightsData, error) {
+func (aclCapSession) GetACL(ctx context.Context, mailbox string) (*imap.GetACLData, error) {
 	return nil, nil
 }
-func (aclCapSession) MyRights(mailbox string) (*imap.MyRightsData, error) { return nil, nil }
+func (aclCapSession) SetACL(ctx context.Context, mailbox string, id imap.RightsIdentifier, mod imap.RightModification, rights imap.RightSet) error {
+	return nil
+}
+func (aclCapSession) DeleteACL(ctx context.Context, mailbox string, id imap.RightsIdentifier) error {
+	return nil
+}
+func (aclCapSession) ListRights(ctx context.Context, mailbox string, id imap.RightsIdentifier) (*imap.ListRightsData, error) {
+	return nil, nil
+}
+func (aclCapSession) MyRights(ctx context.Context, mailbox string) (*imap.MyRightsData, error) {
+	return nil, nil
+}
 
 func hasCap(caps []imap.Cap, want imap.Cap) bool {
 	for _, c := range caps {

--- a/imapserver/append.go
+++ b/imapserver/append.go
@@ -107,7 +107,7 @@ func (c *Conn) handleAppend(tag string, dec *imapwire.Decoder) error {
 	c.setReadTimeout(literalReadTimeout)
 	defer c.setReadTimeout(cmdReadTimeout)
 
-	data, appendErr := c.session.Append(mailbox, lit, &options)
+	data, appendErr := c.session.Append(c.ctx, mailbox, lit, &options)
 	if _, discardErr := io.Copy(io.Discard, lit); discardErr != nil {
 		// Draining the unread remainder of the literal failed. lit reads only
 		// from the client socket, so this is provably a client-side disconnect

--- a/imapserver/authenticate.go
+++ b/imapserver/authenticate.go
@@ -72,7 +72,7 @@ func (c *Conn) handleAuthenticate(tag string, dec *imapwire.Decoder) error {
 					Text: "SASL identity not supported",
 				}
 			}
-			return c.session.Login(username, password)
+			return c.session.Login(c.ctx, username, password)
 		})
 	}
 
@@ -141,7 +141,7 @@ func (c *Conn) handleUnauthenticate(dec *imapwire.Decoder) error {
 	if !ok {
 		return newClientBugError("UNAUTHENTICATE is not supported")
 	}
-	if err := session.Unauthenticate(); err != nil {
+	if err := session.Unauthenticate(c.ctx); err != nil {
 		return err
 	}
 	c.state = imap.ConnStateNotAuthenticated

--- a/imapserver/capability_session_gating_test.go
+++ b/imapserver/capability_session_gating_test.go
@@ -1,6 +1,7 @@
 package imapserver
 
 import (
+	"context"
 	"testing"
 
 	"github.com/emersion/go-imap/v2"
@@ -13,11 +14,11 @@ type rev2CapSession struct {
 	Session
 }
 
-func (rev2CapSession) Namespace() (*imap.NamespaceData, error) { return nil, nil }
-func (rev2CapSession) Move(w *MoveWriter, numSet imap.NumSet, dest string) error {
+func (rev2CapSession) Namespace(ctx context.Context) (*imap.NamespaceData, error) { return nil, nil }
+func (rev2CapSession) Move(ctx context.Context, w *MoveWriter, numSet imap.NumSet, dest string) error {
 	return nil
 }
-func (rev2CapSession) Unauthenticate() error { return nil }
+func (rev2CapSession) Unauthenticate(ctx context.Context) error { return nil }
 
 // baseCapSession implements only the base Session interface, modelling a
 // backend that has not (yet) implemented IMAP4rev2 / NAMESPACE / MOVE /

--- a/imapserver/cmd_acl.go
+++ b/imapserver/cmd_acl.go
@@ -23,7 +23,7 @@ func (c *Conn) handleGetACL(dec *imapwire.Decoder) error {
 		return newClientBugError("ACL extension is not supported")
 	}
 
-	data, err := session.GetACL(mailbox)
+	data, err := session.GetACL(c.ctx, mailbox)
 	if err != nil {
 		return err
 	}
@@ -64,7 +64,7 @@ func (c *Conn) handleSetACL(dec *imapwire.Decoder) error {
 	}
 
 	identifier := imap.RightsIdentifier(identifierStr)
-	return session.SetACL(mailbox, identifier, modification, expandVirtualRights(rights))
+	return session.SetACL(c.ctx, mailbox, identifier, modification, expandVirtualRights(rights))
 }
 
 func (c *Conn) handleDeleteACL(dec *imapwire.Decoder) error {
@@ -85,7 +85,7 @@ func (c *Conn) handleDeleteACL(dec *imapwire.Decoder) error {
 	}
 
 	identifier := imap.RightsIdentifier(identifierStr)
-	return session.DeleteACL(mailbox, identifier)
+	return session.DeleteACL(c.ctx, mailbox, identifier)
 }
 
 func (c *Conn) handleListRights(dec *imapwire.Decoder) error {
@@ -106,7 +106,7 @@ func (c *Conn) handleListRights(dec *imapwire.Decoder) error {
 	}
 
 	identifier := imap.RightsIdentifier(identifierStr)
-	data, err := session.ListRights(mailbox, identifier)
+	data, err := session.ListRights(c.ctx, mailbox, identifier)
 	if err != nil {
 		return err
 	}
@@ -129,7 +129,7 @@ func (c *Conn) handleMyRights(dec *imapwire.Decoder) error {
 		return newClientBugError("ACL extension is not supported")
 	}
 
-	data, err := session.MyRights(mailbox)
+	data, err := session.MyRights(c.ctx, mailbox)
 	if err != nil {
 		return err
 	}

--- a/imapserver/conn.go
+++ b/imapserver/conn.go
@@ -2,6 +2,7 @@ package imapserver
 
 import (
 	"bufio"
+	"context"
 	"crypto/tls"
 	"errors"
 	"fmt"
@@ -64,6 +65,13 @@ type Conn struct {
 	bw       *bufio.Writer
 	encMutex sync.Mutex
 
+	// ctx is cancelled when the connection is torn down (client disconnect,
+	// serve goroutine exit, or server shutdown via forceCloseConns). It is the
+	// context passed to blocking Session methods so a backend can abandon
+	// in-flight work when the connection goes away. cancel is idempotent.
+	ctx    context.Context
+	cancel context.CancelFunc
+
 	mutex     sync.Mutex
 	conn      net.Conn
 	enabled   imap.CapSet
@@ -78,11 +86,16 @@ func newConn(c net.Conn, server *Server) *Conn {
 	rw := server.options.wrapReadWriter(c)
 	br := bufio.NewReader(rw)
 	bw := bufio.NewWriter(rw)
+	// The context is created here, before the connection is registered with the
+	// server, so forceCloseConns can always cancel it.
+	ctx, cancel := context.WithCancel(context.Background())
 	return &Conn{
 		conn:    c,
 		server:  server,
 		br:      br,
 		bw:      bw,
+		ctx:     ctx,
+		cancel:  cancel,
 		enabled: make(imap.CapSet),
 	}
 }
@@ -123,7 +136,18 @@ func (c *Conn) EnabledCaps() imap.CapSet {
 	return c.enabled.Copy()
 }
 
+// Context returns the connection's context. It is cancelled when the
+// connection is torn down — by client disconnect, by the serve goroutine
+// exiting, or by server shutdown. Backends may use it to bound blocking work,
+// though blocking Session methods already receive it as their first argument.
+func (c *Conn) Context() context.Context {
+	return c.ctx
+}
+
 func (c *Conn) serve() {
+	// Cancel the connection context on any exit so blocking backend work is
+	// released even if the socket close alone doesn't unblock it.
+	defer c.cancel()
 	defer func() {
 		if v := recover(); v != nil {
 			c.server.logger().Printf("panic handling command (remote %v): %v\n%s", c.conn.RemoteAddr(), v, debug.Stack())
@@ -433,7 +457,7 @@ func (c *Conn) handleDelete(dec *imapwire.Decoder) error {
 	if err := c.checkState(imap.ConnStateAuthenticated); err != nil {
 		return err
 	}
-	return c.session.Delete(name)
+	return c.session.Delete(c.ctx, name)
 }
 
 func (c *Conn) handleRename(dec *imapwire.Decoder) error {
@@ -445,7 +469,7 @@ func (c *Conn) handleRename(dec *imapwire.Decoder) error {
 		return err
 	}
 	var options imap.RenameOptions
-	return c.session.Rename(&RenameWriter{conn: c}, oldName, newName, &options)
+	return c.session.Rename(c.ctx, &RenameWriter{conn: c}, oldName, newName, &options)
 }
 
 // RenameWriter writes the unsolicited responses that MAY accompany a successful
@@ -476,7 +500,7 @@ func (c *Conn) handleSubscribe(dec *imapwire.Decoder) error {
 	if err := c.checkState(imap.ConnStateAuthenticated); err != nil {
 		return err
 	}
-	return c.session.Subscribe(name)
+	return c.session.Subscribe(c.ctx, name)
 }
 
 func (c *Conn) handleUnsubscribe(dec *imapwire.Decoder) error {
@@ -487,7 +511,7 @@ func (c *Conn) handleUnsubscribe(dec *imapwire.Decoder) error {
 	if err := c.checkState(imap.ConnStateAuthenticated); err != nil {
 		return err
 	}
-	return c.session.Unsubscribe(name)
+	return c.session.Unsubscribe(c.ctx, name)
 }
 
 func (c *Conn) checkBufferedLiteral(size int64, nonSync bool) error {
@@ -591,7 +615,7 @@ func (c *Conn) poll(cmd string) error {
 	}
 
 	w := &UpdateWriter{conn: c, allowExpunge: allowExpunge}
-	return c.session.Poll(w, allowExpunge)
+	return c.session.Poll(c.ctx, w, allowExpunge)
 }
 
 // useQuotedUTF8 reports whether IMAP strings and mailbox names should be

--- a/imapserver/conn_context_test.go
+++ b/imapserver/conn_context_test.go
@@ -1,0 +1,36 @@
+package imapserver
+
+import (
+	"context"
+	"net"
+	"testing"
+
+	"github.com/emersion/go-imap/v2"
+)
+
+// TestConnContextCancelledByForceClose verifies the M4 plumbing: a connection's
+// context is live once created and is cancelled when the server force-closes it
+// (as Server.Close/Shutdown do), independently of the serve goroutine. This is
+// what lets a backend blocked in a Session method be released on shutdown.
+func TestConnContextCancelledByForceClose(t *testing.T) {
+	srv := New(&Options{Caps: imap.CapSet{imap.CapIMAP4rev2: {}}})
+
+	c1, c2 := net.Pipe()
+	defer c1.Close()
+	defer c2.Close()
+
+	conn := newConn(c2, srv)
+	srv.mutex.Lock()
+	srv.conns[conn] = struct{}{}
+	srv.mutex.Unlock()
+
+	if err := conn.Context().Err(); err != nil {
+		t.Fatalf("connection context cancelled prematurely: %v", err)
+	}
+
+	srv.forceCloseConns()
+
+	if err := conn.Context().Err(); err != context.Canceled {
+		t.Fatalf("connection context after forceCloseConns = %v, want context.Canceled", err)
+	}
+}

--- a/imapserver/copy.go
+++ b/imapserver/copy.go
@@ -13,7 +13,7 @@ func (c *Conn) handleCopy(tag string, dec *imapwire.Decoder, numKind NumKind) er
 	if err := c.checkState(imap.ConnStateSelected); err != nil {
 		return err
 	}
-	data, err := c.session.Copy(numSet, dest)
+	data, err := c.session.Copy(c.ctx, numSet, dest)
 	if err != nil {
 		return err
 	}

--- a/imapserver/create.go
+++ b/imapserver/create.go
@@ -41,5 +41,5 @@ func (c *Conn) handleCreate(dec *imapwire.Decoder) error {
 	if err := c.checkState(imap.ConnStateAuthenticated); err != nil {
 		return err
 	}
-	return c.session.Create(name, &options)
+	return c.session.Create(c.ctx, name, &options)
 }

--- a/imapserver/esearch.go
+++ b/imapserver/esearch.go
@@ -1,6 +1,7 @@
 package imapserver
 
 import (
+	"context"
 	"fmt"
 	"strings"
 
@@ -21,7 +22,7 @@ type SessionMultiSearch interface {
 	// enumerate the user's mailboxes) and MUST populate SearchData.Mailbox and
 	// SearchData.UIDValidity on every result (RFC 7377 §2.1). Because message
 	// numbers are meaningless for unselected mailboxes, results are always UIDs.
-	MultiSearch(source *imap.SearchSource, criteria *imap.SearchCriteria, options *imap.SearchOptions) ([]*imap.SearchData, error)
+	MultiSearch(ctx context.Context, source *imap.SearchSource, criteria *imap.SearchCriteria, options *imap.SearchOptions) ([]*imap.SearchData, error)
 }
 
 // handleESearch implements the RFC 7377 ESEARCH command:
@@ -140,7 +141,7 @@ func (c *Conn) handleESearch(tag string, dec *imapwire.Decoder) error {
 		}
 	}
 
-	results, err := sessionMultiSearch.MultiSearch(&source, &criteria, &options)
+	results, err := sessionMultiSearch.MultiSearch(c.ctx, &source, &criteria, &options)
 	if err != nil {
 		return err
 	}

--- a/imapserver/expunge.go
+++ b/imapserver/expunge.go
@@ -25,7 +25,7 @@ func (c *Conn) expunge(uids *imap.UIDSet) error {
 		return err
 	}
 	w := &ExpungeWriter{conn: c}
-	return c.session.Expunge(w, uids)
+	return c.session.Expunge(c.ctx, w, uids)
 }
 
 func (c *Conn) writeExpunge(seqNum uint32) error {

--- a/imapserver/fetch.go
+++ b/imapserver/fetch.go
@@ -185,7 +185,7 @@ func (c *Conn) handleFetch(dec *imapwire.Decoder, numKind NumKind) error {
 	}
 
 	w := &FetchWriter{conn: c, options: writerOptions}
-	if err := c.session.Fetch(w, numSet, &options); err != nil {
+	if err := c.session.Fetch(c.ctx, w, numSet, &options); err != nil {
 		return err
 	}
 	return nil

--- a/imapserver/idle.go
+++ b/imapserver/idle.go
@@ -49,7 +49,7 @@ func (c *Conn) handleIdle(dec *imapwire.Decoder) error {
 			}
 		}()
 		w := &UpdateWriter{conn: c, allowExpunge: true}
-		done <- c.session.Idle(w, stop)
+		done <- c.session.Idle(c.ctx, w, stop)
 	}()
 
 	c.setReadTimeout(idleReadTimeout)
@@ -63,11 +63,14 @@ func (c *Conn) handleIdle(dec *imapwire.Decoder) error {
 		return newClientBugError("Syntax error: expected DONE to end IDLE command")
 	}
 
-	// Wait for backend to return, with timeout to prevent goroutine leak
+	// Wait for backend to return, with timeout to prevent goroutine leak.
+	// Stop the timer on the normal path so it doesn't linger until it fires.
+	timer := time.NewTimer(30 * time.Second)
+	defer timer.Stop()
 	select {
 	case err := <-done:
 		return err
-	case <-time.After(30 * time.Second):
+	case <-timer.C:
 		c.server.logger().Printf("IDLE backend did not return within 30s after stop; goroutine leaked")
 		return fmt.Errorf("imapserver: IDLE backend did not respond to stop")
 	}

--- a/imapserver/imapmemserver/mailbox.go
+++ b/imapserver/imapmemserver/mailbox.go
@@ -3,6 +3,7 @@ package imapmemserver
 import (
 	"bufio"
 	"bytes"
+	"context"
 	"sort"
 	"strings"
 	"sync"
@@ -263,7 +264,7 @@ func (mbox *Mailbox) flagsLocked() []imap.Flag {
 	return l
 }
 
-func (mbox *Mailbox) Expunge(w *imapserver.ExpungeWriter, uids *imap.UIDSet) error {
+func (mbox *Mailbox) Expunge(ctx context.Context, w *imapserver.ExpungeWriter, uids *imap.UIDSet) error {
 	expunged := make(map[*message]struct{})
 	mbox.mutex.Lock()
 	for _, msg := range mbox.l {
@@ -373,7 +374,7 @@ func (mbox *MailboxView) selectData(options *imap.SelectOptions) (*imap.SelectDa
 	return data, nil
 }
 
-func (mbox *MailboxView) Fetch(w *imapserver.FetchWriter, numSet imap.NumSet, options *imap.FetchOptions) error {
+func (mbox *MailboxView) Fetch(ctx context.Context, w *imapserver.FetchWriter, numSet imap.NumSet, options *imap.FetchOptions) error {
 	markSeen := false
 	for _, bs := range options.BodySection {
 		if !bs.Peek {
@@ -403,7 +404,7 @@ func (mbox *MailboxView) Fetch(w *imapserver.FetchWriter, numSet imap.NumSet, op
 	return err
 }
 
-func (mbox *MailboxView) Search(numKind imapserver.NumKind, criteria *imap.SearchCriteria, options *imap.SearchOptions) (*imap.SearchData, error) {
+func (mbox *MailboxView) Search(ctx context.Context, numKind imapserver.NumKind, criteria *imap.SearchCriteria, options *imap.SearchOptions) (*imap.SearchData, error) {
 	mbox.mutex.Lock()
 	defer mbox.mutex.Unlock()
 
@@ -459,7 +460,7 @@ func (mbox *MailboxView) Search(numKind imapserver.NumKind, criteria *imap.Searc
 	return &data, nil
 }
 
-func (mbox *MailboxView) Sort(kind imapserver.NumKind, sortCriteria []imap.SortCriterion, charset string, searchCriteria *imap.SearchCriteria, options *imap.SortOptions) (*imap.SortData, error) {
+func (mbox *MailboxView) Sort(ctx context.Context, kind imapserver.NumKind, sortCriteria []imap.SortCriterion, charset string, searchCriteria *imap.SearchCriteria, options *imap.SortOptions) (*imap.SortData, error) {
 	mbox.mutex.Lock()
 	defer mbox.mutex.Unlock()
 
@@ -666,7 +667,7 @@ func writeStoreFetchResponse(w *imapserver.FetchWriter, tracker *imapserver.Sess
 	return respWriter.Close()
 }
 
-func (mbox *MailboxView) Store(w *imapserver.FetchWriter, numSet imap.NumSet, flags *imap.StoreFlags, options *imap.StoreOptions) error {
+func (mbox *MailboxView) Store(ctx context.Context, w *imapserver.FetchWriter, numSet imap.NumSet, flags *imap.StoreFlags, options *imap.StoreOptions) error {
 	var modified []modifiedMessageData
 	mbox.forEach(numSet, func(seqNum uint32, msg *message) {
 		if options != nil && options.UnchangedSince > 0 && msg.modSeq > options.UnchangedSince {
@@ -698,11 +699,11 @@ func (mbox *MailboxView) Store(w *imapserver.FetchWriter, numSet imap.NumSet, fl
 	return nil
 }
 
-func (mbox *MailboxView) Poll(w *imapserver.UpdateWriter, allowExpunge bool) error {
+func (mbox *MailboxView) Poll(ctx context.Context, w *imapserver.UpdateWriter, allowExpunge bool) error {
 	return mbox.tracker.Poll(w, allowExpunge)
 }
 
-func (mbox *MailboxView) Idle(w *imapserver.UpdateWriter, stop <-chan struct{}) error {
+func (mbox *MailboxView) Idle(ctx context.Context, w *imapserver.UpdateWriter, stop <-chan struct{}) error {
 	return mbox.tracker.Idle(w, stop)
 }
 

--- a/imapserver/imapmemserver/server.go
+++ b/imapserver/imapmemserver/server.go
@@ -2,6 +2,7 @@
 package imapmemserver
 
 import (
+	"context"
 	"sync"
 
 	"github.com/emersion/go-imap/v2/imapserver"
@@ -48,12 +49,12 @@ type serverSession struct {
 
 var _ imapserver.Session = (*serverSession)(nil)
 
-func (sess *serverSession) Login(username, password string) error {
+func (sess *serverSession) Login(ctx context.Context, username, password string) error {
 	u := sess.server.user(username)
 	if u == nil {
 		return imapserver.ErrAuthFailed
 	}
-	if err := u.Login(username, password); err != nil {
+	if err := u.Login(ctx, username, password); err != nil {
 		return err
 	}
 	sess.UserSession = NewUserSession(u)

--- a/imapserver/imapmemserver/session.go
+++ b/imapserver/imapmemserver/session.go
@@ -1,6 +1,7 @@
 package imapmemserver
 
 import (
+	"context"
 	"sort"
 	"strings"
 
@@ -39,7 +40,7 @@ func (sess *UserSession) Close() error {
 	return nil
 }
 
-func (sess *UserSession) Select(name string, options *imap.SelectOptions) (*imap.SelectData, error) {
+func (sess *UserSession) Select(ctx context.Context, name string, options *imap.SelectOptions) (*imap.SelectData, error) {
 	mbox, err := sess.user.mailbox(name)
 	if err != nil {
 		return nil, err
@@ -51,13 +52,13 @@ func (sess *UserSession) Select(name string, options *imap.SelectOptions) (*imap
 	return sess.mailbox.selectData(options)
 }
 
-func (sess *UserSession) Unselect() error {
+func (sess *UserSession) Unselect(ctx context.Context) error {
 	sess.mailbox.Close()
 	sess.mailbox = nil
 	return nil
 }
 
-func (sess *UserSession) Copy(numSet imap.NumSet, destName string) (*imap.CopyData, error) {
+func (sess *UserSession) Copy(ctx context.Context, numSet imap.NumSet, destName string) (*imap.CopyData, error) {
 	dest, err := sess.user.mailbox(destName)
 	if err != nil {
 		return nil, &imap.Error{
@@ -86,7 +87,7 @@ func (sess *UserSession) Copy(numSet imap.NumSet, destName string) (*imap.CopyDa
 	}, nil
 }
 
-func (sess *UserSession) Move(w *imapserver.MoveWriter, numSet imap.NumSet, destName string) error {
+func (sess *UserSession) Move(ctx context.Context, w *imapserver.MoveWriter, numSet imap.NumSet, destName string) error {
 	dest, err := sess.user.mailbox(destName)
 	if err != nil {
 		return &imap.Error{
@@ -132,25 +133,25 @@ func (sess *UserSession) Move(w *imapserver.MoveWriter, numSet imap.NumSet, dest
 	return nil
 }
 
-func (sess *UserSession) Poll(w *imapserver.UpdateWriter, allowExpunge bool) error {
+func (sess *UserSession) Poll(ctx context.Context, w *imapserver.UpdateWriter, allowExpunge bool) error {
 	if sess.mailbox == nil {
 		return nil
 	}
-	return sess.mailbox.Poll(w, allowExpunge)
+	return sess.mailbox.Poll(ctx, w, allowExpunge)
 }
 
-func (sess *UserSession) Idle(w *imapserver.UpdateWriter, stop <-chan struct{}) error {
+func (sess *UserSession) Idle(ctx context.Context, w *imapserver.UpdateWriter, stop <-chan struct{}) error {
 	if sess.mailbox == nil {
 		return nil // TODO
 	}
-	return sess.mailbox.Idle(w, stop)
+	return sess.mailbox.Idle(ctx, w, stop)
 }
 
-func (sess *UserSession) Sort(kind imapserver.NumKind, sortCriteria []imap.SortCriterion, charset string, searchCriteria *imap.SearchCriteria, options *imap.SortOptions) (*imap.SortData, error) {
-	return sess.mailbox.Sort(kind, sortCriteria, charset, searchCriteria, options)
+func (sess *UserSession) Sort(ctx context.Context, kind imapserver.NumKind, sortCriteria []imap.SortCriterion, charset string, searchCriteria *imap.SearchCriteria, options *imap.SortOptions) (*imap.SortData, error) {
+	return sess.mailbox.Sort(ctx, kind, sortCriteria, charset, searchCriteria, options)
 }
 
-func (sess *UserSession) Thread(numKind imapserver.NumKind, algorithm imap.ThreadAlgorithm, charset string, criteria *imap.SearchCriteria) ([]imap.ThreadData, error) {
+func (sess *UserSession) Thread(ctx context.Context, numKind imapserver.NumKind, algorithm imap.ThreadAlgorithm, charset string, criteria *imap.SearchCriteria) ([]imap.ThreadData, error) {
 	if sess.mailbox == nil {
 		return nil, &imap.Error{
 			Type: imap.StatusResponseTypeNo,
@@ -171,7 +172,7 @@ func (sess *UserSession) Thread(numKind imapserver.NumKind, algorithm imap.Threa
 	}, nil
 }
 
-func (sess *UserSession) MultiSearch(source *imap.SearchSource, criteria *imap.SearchCriteria, options *imap.SearchOptions) ([]*imap.SearchData, error) {
+func (sess *UserSession) MultiSearch(ctx context.Context, source *imap.SearchSource, criteria *imap.SearchCriteria, options *imap.SearchOptions) ([]*imap.SearchData, error) {
 	var results []*imap.SearchData
 	for _, mboxName := range sess.resolveSearchSource(source) {
 		mbox, err := sess.user.mailbox(mboxName)
@@ -182,7 +183,7 @@ func (sess *UserSession) MultiSearch(source *imap.SearchSource, criteria *imap.S
 		view := mbox.NewView()
 
 		// RFC 7377: ESEARCH always reports UIDs, never message numbers.
-		data, err := view.Search(imapserver.NumKindUID, criteria, options)
+		data, err := view.Search(ctx, imapserver.NumKindUID, criteria, options)
 		view.Close()
 		if err != nil {
 			return nil, err
@@ -265,7 +266,7 @@ func (sess *UserSession) resolveSearchSource(source *imap.SearchSource) []string
 	return names
 }
 
-func (sess *UserSession) GetMetadata(mailboxName string, entries []string, options *imap.GetMetadataOptions) (*imap.GetMetadataData, error) {
+func (sess *UserSession) GetMetadata(ctx context.Context, mailboxName string, entries []string, options *imap.GetMetadataOptions) (*imap.GetMetadataData, error) {
 	sess.user.mutex.Lock()
 	defer sess.user.mutex.Unlock()
 
@@ -315,7 +316,7 @@ func (sess *UserSession) GetMetadata(mailboxName string, entries []string, optio
 	}, nil
 }
 
-func (sess *UserSession) SetMetadata(mailboxName string, entries map[string]*[]byte) error {
+func (sess *UserSession) SetMetadata(ctx context.Context, mailboxName string, entries map[string]*[]byte) error {
 	sess.user.mutex.Lock()
 	defer sess.user.mutex.Unlock()
 
@@ -394,7 +395,7 @@ func matchesWithDepth(entryName, requestedEntry string, options *imap.GetMetadat
 }
 
 // GetACL retrieves the access control list for a mailbox
-func (sess *UserSession) GetACL(name string) (*imap.GetACLData, error) {
+func (sess *UserSession) GetACL(ctx context.Context, name string) (*imap.GetACLData, error) {
 	mbox, err := sess.user.mailbox(name)
 	if err != nil {
 		return nil, err
@@ -428,7 +429,7 @@ func (sess *UserSession) GetACL(name string) (*imap.GetACLData, error) {
 }
 
 // SetACL sets or modifies the access control list for a mailbox
-func (sess *UserSession) SetACL(name string, identifier imap.RightsIdentifier, modification imap.RightModification, rights imap.RightSet) error {
+func (sess *UserSession) SetACL(ctx context.Context, name string, identifier imap.RightsIdentifier, modification imap.RightModification, rights imap.RightSet) error {
 	mbox, err := sess.user.mailbox(name)
 	if err != nil {
 		return err
@@ -477,12 +478,12 @@ func (sess *UserSession) SetACL(name string, identifier imap.RightsIdentifier, m
 }
 
 // DeleteACL removes the access control list entry for an identifier
-func (sess *UserSession) DeleteACL(name string, identifier imap.RightsIdentifier) error {
-	return sess.SetACL(name, identifier, imap.RightModificationReplace, nil)
+func (sess *UserSession) DeleteACL(ctx context.Context, name string, identifier imap.RightsIdentifier) error {
+	return sess.SetACL(ctx, name, identifier, imap.RightModificationReplace, nil)
 }
 
 // ListRights lists the rights that can be granted to an identifier on a mailbox
-func (sess *UserSession) ListRights(name string, identifier imap.RightsIdentifier) (*imap.ListRightsData, error) {
+func (sess *UserSession) ListRights(ctx context.Context, name string, identifier imap.RightsIdentifier) (*imap.ListRightsData, error) {
 	_, err := sess.user.mailbox(name)
 	if err != nil {
 		return nil, err
@@ -498,7 +499,7 @@ func (sess *UserSession) ListRights(name string, identifier imap.RightsIdentifie
 }
 
 // MyRights returns the rights the current user has on a mailbox
-func (sess *UserSession) MyRights(name string) (*imap.MyRightsData, error) {
+func (sess *UserSession) MyRights(ctx context.Context, name string) (*imap.MyRightsData, error) {
 	mbox, err := sess.user.mailbox(name)
 	if err != nil {
 		return nil, err

--- a/imapserver/imapmemserver/user.go
+++ b/imapserver/imapmemserver/user.go
@@ -1,6 +1,7 @@
 package imapmemserver
 
 import (
+	"context"
 	"crypto/subtle"
 	"sort"
 	"strings"
@@ -30,7 +31,7 @@ func NewUser(username, password string) *User {
 	}
 }
 
-func (u *User) Login(username, password string) error {
+func (u *User) Login(ctx context.Context, username, password string) error {
 	if username != u.username {
 		return imapserver.ErrAuthFailed
 	}
@@ -58,7 +59,7 @@ func (u *User) mailbox(name string) (*Mailbox, error) {
 	return u.mailboxLocked(name)
 }
 
-func (u *User) Status(name string, options *imap.StatusOptions) (*imap.StatusData, error) {
+func (u *User) Status(ctx context.Context, name string, options *imap.StatusOptions) (*imap.StatusData, error) {
 	mbox, err := u.mailbox(name)
 	if err != nil {
 		return nil, err
@@ -66,7 +67,7 @@ func (u *User) Status(name string, options *imap.StatusOptions) (*imap.StatusDat
 	return mbox.StatusData(options), nil
 }
 
-func (u *User) List(w *imapserver.ListWriter, ref string, patterns []string, options *imap.ListOptions) error {
+func (u *User) List(ctx context.Context, w *imapserver.ListWriter, ref string, patterns []string, options *imap.ListOptions) error {
 	u.mutex.Lock()
 	defer u.mutex.Unlock()
 
@@ -115,7 +116,7 @@ func (u *User) List(w *imapserver.ListWriter, ref string, patterns []string, opt
 	return nil
 }
 
-func (u *User) Append(mailbox string, r imap.LiteralReader, options *imap.AppendOptions) (*imap.AppendData, error) {
+func (u *User) Append(ctx context.Context, mailbox string, r imap.LiteralReader, options *imap.AppendOptions) (*imap.AppendData, error) {
 	mbox, err := u.mailbox(mailbox)
 	if err != nil {
 		return nil, &imap.Error{
@@ -127,7 +128,7 @@ func (u *User) Append(mailbox string, r imap.LiteralReader, options *imap.Append
 	return mbox.appendLiteral(r, options)
 }
 
-func (u *User) Create(name string, options *imap.CreateOptions) error {
+func (u *User) Create(ctx context.Context, name string, options *imap.CreateOptions) error {
 	u.mutex.Lock()
 	defer u.mutex.Unlock()
 
@@ -153,7 +154,7 @@ func (u *User) Create(name string, options *imap.CreateOptions) error {
 	return nil
 }
 
-func (u *User) Delete(name string) error {
+func (u *User) Delete(ctx context.Context, name string) error {
 	u.mutex.Lock()
 	defer u.mutex.Unlock()
 
@@ -165,7 +166,7 @@ func (u *User) Delete(name string) error {
 	return nil
 }
 
-func (u *User) Rename(w *imapserver.RenameWriter, oldName, newName string, options *imap.RenameOptions) error {
+func (u *User) Rename(ctx context.Context, w *imapserver.RenameWriter, oldName, newName string, options *imap.RenameOptions) error {
 	u.mutex.Lock()
 
 	newName = strings.TrimRight(newName, string(mailboxDelim))
@@ -198,7 +199,7 @@ func (u *User) Rename(w *imapserver.RenameWriter, oldName, newName string, optio
 	})
 }
 
-func (u *User) Subscribe(name string) error {
+func (u *User) Subscribe(ctx context.Context, name string) error {
 	mbox, err := u.mailbox(name)
 	if err != nil {
 		return err
@@ -207,7 +208,7 @@ func (u *User) Subscribe(name string) error {
 	return nil
 }
 
-func (u *User) Unsubscribe(name string) error {
+func (u *User) Unsubscribe(ctx context.Context, name string) error {
 	mbox, err := u.mailbox(name)
 	if err != nil {
 		return err
@@ -216,7 +217,7 @@ func (u *User) Unsubscribe(name string) error {
 	return nil
 }
 
-func (u *User) Namespace() (*imap.NamespaceData, error) {
+func (u *User) Namespace(ctx context.Context) (*imap.NamespaceData, error) {
 	return &imap.NamespaceData{
 		Personal: []imap.NamespaceDescriptor{{Delim: mailboxDelim}},
 	}, nil

--- a/imapserver/list.go
+++ b/imapserver/list.go
@@ -23,7 +23,7 @@ func (c *Conn) handleList(dec *imapwire.Decoder) error {
 		conn:    c,
 		options: options,
 	}
-	return c.session.List(w, ref, pattern, options)
+	return c.session.List(c.ctx, w, ref, pattern, options)
 }
 
 func (c *Conn) handleLSub(dec *imapwire.Decoder) error {
@@ -55,7 +55,7 @@ func (c *Conn) handleLSub(dec *imapwire.Decoder) error {
 		conn: c,
 		lsub: true,
 	}
-	return c.session.List(w, ref, []string{pattern}, options)
+	return c.session.List(c.ctx, w, ref, []string{pattern}, options)
 }
 
 // isExtendedListOptions returns true if the client used LIST-EXTENDED syntax,
@@ -377,7 +377,7 @@ func (w *ListWriter) WriteList(data *imap.ListData) error {
 	}
 	if w.options.ReturnMetadata != nil {
 		if sessionMeta, ok := w.conn.session.(SessionMetadata); ok {
-			metaData, err := sessionMeta.GetMetadata(data.Mailbox, w.options.ReturnMetadata, nil)
+			metaData, err := sessionMeta.GetMetadata(w.conn.ctx, data.Mailbox, w.options.ReturnMetadata, nil)
 			if err == nil && metaData != nil {
 				// Write metadata response even if entries is empty (per RFC 5524)
 				// Empty map means metadata was queried but no entries matched

--- a/imapserver/login.go
+++ b/imapserver/login.go
@@ -20,7 +20,7 @@ func (c *Conn) handleLogin(tag string, dec *imapwire.Decoder) error {
 			Text: "TLS is required to authenticate",
 		}
 	}
-	if err := c.session.Login(username, password); err != nil {
+	if err := c.session.Login(c.ctx, username, password); err != nil {
 		return err
 	}
 	c.state = imap.ConnStateAuthenticated

--- a/imapserver/lsub_test.go
+++ b/imapserver/lsub_test.go
@@ -3,6 +3,7 @@ package imapserver_test
 import (
 	"bufio"
 	"bytes"
+	"context"
 	"net"
 	"regexp"
 	"strings"
@@ -24,7 +25,7 @@ type lsubSession struct {
 	gotRecursiveMatch bool
 }
 
-func (s *lsubSession) List(w *imapserver.ListWriter, ref string, patterns []string, options *imap.ListOptions) error {
+func (s *lsubSession) List(ctx context.Context, w *imapserver.ListWriter, ref string, patterns []string, options *imap.ListOptions) error {
 	s.gotSubscribed = options.SelectSubscribed
 	s.gotRecursiveMatch = options.SelectRecursiveMatch
 

--- a/imapserver/metadata.go
+++ b/imapserver/metadata.go
@@ -98,7 +98,7 @@ func (c *Conn) handleGetMetadata(tag string, dec *imapwire.Decoder) error {
 		opts = nil
 	}
 
-	data, err := session.GetMetadata(mailbox, entries, opts)
+	data, err := session.GetMetadata(c.ctx, mailbox, entries, opts)
 	if err != nil {
 		return fmt.Errorf("GETMETADATA for mailbox %q: %w", mailbox, err)
 	}
@@ -171,7 +171,7 @@ func (c *Conn) handleSetMetadata(dec *imapwire.Decoder) error {
 		return newClientBugError("SETMETADATA is not supported")
 	}
 
-	if err := session.SetMetadata(mailbox, entries); err != nil {
+	if err := session.SetMetadata(c.ctx, mailbox, entries); err != nil {
 		return fmt.Errorf("SETMETADATA for mailbox %q: %w", mailbox, err)
 	}
 

--- a/imapserver/metadata_test.go
+++ b/imapserver/metadata_test.go
@@ -2,6 +2,7 @@ package imapserver
 
 import (
 	"bufio"
+	"context"
 	"strings"
 	"testing"
 
@@ -239,7 +240,7 @@ type mockMetadataSession struct {
 	lastOptions       *imap.GetMetadataOptions
 }
 
-func (s *mockMetadataSession) GetMetadata(mailbox string, entries []string, options *imap.GetMetadataOptions) (*imap.GetMetadataData, error) {
+func (s *mockMetadataSession) GetMetadata(ctx context.Context, mailbox string, entries []string, options *imap.GetMetadataOptions) (*imap.GetMetadataData, error) {
 	s.getMetadataCalled = true
 	s.lastMailbox = mailbox
 	s.lastEntries = entries
@@ -252,7 +253,7 @@ func (s *mockMetadataSession) GetMetadata(mailbox string, entries []string, opti
 	}, nil
 }
 
-func (s *mockMetadataSession) SetMetadata(mailbox string, entries map[string]*[]byte) error {
+func (s *mockMetadataSession) SetMetadata(ctx context.Context, mailbox string, entries map[string]*[]byte) error {
 	return nil
 }
 

--- a/imapserver/move.go
+++ b/imapserver/move.go
@@ -18,7 +18,7 @@ func (c *Conn) handleMove(dec *imapwire.Decoder, numKind NumKind) error {
 		return newClientBugError("MOVE is not supported")
 	}
 	w := &MoveWriter{conn: c}
-	return session.Move(w, numSet, dest)
+	return session.Move(c.ctx, w, numSet, dest)
 }
 
 // MoveWriter writes responses for the MOVE command.

--- a/imapserver/namespace.go
+++ b/imapserver/namespace.go
@@ -19,7 +19,7 @@ func (c *Conn) handleNamespace(dec *imapwire.Decoder) error {
 		return newClientBugError("NAMESPACE is not supported")
 	}
 
-	data, err := session.Namespace()
+	data, err := session.Namespace(c.ctx)
 	if err != nil {
 		return err
 	}

--- a/imapserver/search.go
+++ b/imapserver/search.go
@@ -82,7 +82,7 @@ func (c *Conn) handleSearch(tag string, dec *imapwire.Decoder, numKind NumKind) 
 		options.ReturnAll = true
 	}
 
-	data, err := c.session.Search(numKind, &criteria, &options)
+	data, err := c.session.Search(c.ctx, numKind, &criteria, &options)
 	if err != nil {
 		return err
 	}

--- a/imapserver/select.go
+++ b/imapserver/select.go
@@ -103,7 +103,7 @@ func (c *Conn) handleSelect(tag string, dec *imapwire.Decoder, readOnly bool) er
 	}
 
 	if c.state == imap.ConnStateSelected {
-		if err := c.session.Unselect(); err != nil {
+		if err := c.session.Unselect(c.ctx); err != nil {
 			return err
 		}
 		c.state = imap.ConnStateAuthenticated
@@ -117,7 +117,7 @@ func (c *Conn) handleSelect(tag string, dec *imapwire.Decoder, readOnly bool) er
 		}
 	}
 
-	data, err := c.session.Select(mailbox, &options)
+	data, err := c.session.Select(c.ctx, mailbox, &options)
 	if err != nil {
 		return err
 	}
@@ -208,7 +208,7 @@ func (c *Conn) handleUnselect(dec *imapwire.Decoder, expunge bool) error {
 
 	if expunge {
 		w := &ExpungeWriter{conn: c}
-		if err := c.session.Expunge(w, nil); err != nil {
+		if err := c.session.Expunge(c.ctx, w, nil); err != nil {
 			// RFC 4314 §4: for CLOSE, if the server cannot expunge because the user
 			// lacks the "e" right, it MUST ignore the expunge request, close the
 			// mailbox, and return the tagged OK response. Other errors still fail.
@@ -219,7 +219,7 @@ func (c *Conn) handleUnselect(dec *imapwire.Decoder, expunge bool) error {
 		}
 	}
 
-	if err := c.session.Unselect(); err != nil {
+	if err := c.session.Unselect(c.ctx); err != nil {
 		return err
 	}
 

--- a/imapserver/server.go
+++ b/imapserver/server.go
@@ -281,6 +281,9 @@ func (s *Server) Shutdown(ctx context.Context) error {
 func (s *Server) forceCloseConns() {
 	s.mutex.Lock()
 	for c := range s.conns {
+		// Cancel first so a backend blocked on ctx is released even if closing
+		// the socket alone wouldn't unblock it.
+		c.cancel()
 		c.mutex.Lock()
 		c.conn.Close()
 		c.mutex.Unlock()

--- a/imapserver/session.go
+++ b/imapserver/session.go
@@ -1,6 +1,7 @@
 package imapserver
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/emersion/go-imap/v2"
@@ -48,33 +49,39 @@ func (kind NumKind) wire() imapwire.NumKind {
 }
 
 // Session is an IMAP session.
+//
+// The context passed to blocking methods is cancelled when the connection is
+// torn down (client disconnect or server shutdown). Backends should propagate
+// it into blocking work (database queries, object-storage reads, …) so that
+// in-flight operations are abandoned when the client goes away. It is the same
+// context returned by Conn.Context.
 type Session interface {
 	Close() error
 
 	// Not authenticated state
-	Login(username, password string) error
+	Login(ctx context.Context, username, password string) error
 
 	// Authenticated state
-	Select(mailbox string, options *imap.SelectOptions) (*imap.SelectData, error)
-	Create(mailbox string, options *imap.CreateOptions) error
-	Delete(mailbox string) error
-	Rename(w *RenameWriter, mailbox, newName string, options *imap.RenameOptions) error
-	Subscribe(mailbox string) error
-	Unsubscribe(mailbox string) error
-	List(w *ListWriter, ref string, patterns []string, options *imap.ListOptions) error
-	Status(mailbox string, options *imap.StatusOptions) (*imap.StatusData, error)
-	Append(mailbox string, r imap.LiteralReader, options *imap.AppendOptions) (*imap.AppendData, error)
-	Poll(w *UpdateWriter, allowExpunge bool) error
-	Idle(w *UpdateWriter, stop <-chan struct{}) error
+	Select(ctx context.Context, mailbox string, options *imap.SelectOptions) (*imap.SelectData, error)
+	Create(ctx context.Context, mailbox string, options *imap.CreateOptions) error
+	Delete(ctx context.Context, mailbox string) error
+	Rename(ctx context.Context, w *RenameWriter, mailbox, newName string, options *imap.RenameOptions) error
+	Subscribe(ctx context.Context, mailbox string) error
+	Unsubscribe(ctx context.Context, mailbox string) error
+	List(ctx context.Context, w *ListWriter, ref string, patterns []string, options *imap.ListOptions) error
+	Status(ctx context.Context, mailbox string, options *imap.StatusOptions) (*imap.StatusData, error)
+	Append(ctx context.Context, mailbox string, r imap.LiteralReader, options *imap.AppendOptions) (*imap.AppendData, error)
+	Poll(ctx context.Context, w *UpdateWriter, allowExpunge bool) error
+	Idle(ctx context.Context, w *UpdateWriter, stop <-chan struct{}) error
 
 	// Selected state
-	Unselect() error
-	Expunge(w *ExpungeWriter, uids *imap.UIDSet) error
-	Search(kind NumKind, criteria *imap.SearchCriteria, options *imap.SearchOptions) (*imap.SearchData, error)
-	Sort(kind NumKind, sortCriteria []imap.SortCriterion, charset string, searchCriteria *imap.SearchCriteria, options *imap.SortOptions) (*imap.SortData, error)
-	Fetch(w *FetchWriter, numSet imap.NumSet, options *imap.FetchOptions) error
-	Store(w *FetchWriter, numSet imap.NumSet, flags *imap.StoreFlags, options *imap.StoreOptions) error
-	Copy(numSet imap.NumSet, dest string) (*imap.CopyData, error)
+	Unselect(ctx context.Context) error
+	Expunge(ctx context.Context, w *ExpungeWriter, uids *imap.UIDSet) error
+	Search(ctx context.Context, kind NumKind, criteria *imap.SearchCriteria, options *imap.SearchOptions) (*imap.SearchData, error)
+	Sort(ctx context.Context, kind NumKind, sortCriteria []imap.SortCriterion, charset string, searchCriteria *imap.SearchCriteria, options *imap.SortOptions) (*imap.SortData, error)
+	Fetch(ctx context.Context, w *FetchWriter, numSet imap.NumSet, options *imap.FetchOptions) error
+	Store(ctx context.Context, w *FetchWriter, numSet imap.NumSet, flags *imap.StoreFlags, options *imap.StoreOptions) error
+	Copy(ctx context.Context, numSet imap.NumSet, dest string) (*imap.CopyData, error)
 }
 
 // SessionNamespace is an IMAP session which supports NAMESPACE.
@@ -82,7 +89,7 @@ type SessionNamespace interface {
 	Session
 
 	// Authenticated state
-	Namespace() (*imap.NamespaceData, error)
+	Namespace(ctx context.Context) (*imap.NamespaceData, error)
 }
 
 // SessionMove is an IMAP session which supports MOVE.
@@ -90,7 +97,7 @@ type SessionMove interface {
 	Session
 
 	// Selected state
-	Move(w *MoveWriter, numSet imap.NumSet, dest string) error
+	Move(ctx context.Context, w *MoveWriter, numSet imap.NumSet, dest string) error
 }
 
 // SessionIMAP4rev2 is an IMAP session which supports IMAP4rev2.
@@ -113,7 +120,7 @@ type SessionUnauthenticate interface {
 	Session
 
 	// Authenticated state
-	Unauthenticate() error
+	Unauthenticate(ctx context.Context) error
 }
 
 // SessionAppendLimit is an IMAP session which has the same APPEND limit for
@@ -161,10 +168,10 @@ type SessionMetadata interface {
 	// GetMetadata retrieves server or mailbox annotations.
 	// If mailbox is empty string "", retrieve server annotations.
 	// entries contains the list of entry names to retrieve.
-	GetMetadata(mailbox string, entries []string, options *imap.GetMetadataOptions) (*imap.GetMetadataData, error)
+	GetMetadata(ctx context.Context, mailbox string, entries []string, options *imap.GetMetadataOptions) (*imap.GetMetadataData, error)
 
 	// SetMetadata sets or removes server or mailbox annotations.
 	// If mailbox is empty string "", set server annotations.
 	// To remove an entry, set its value to nil.
-	SetMetadata(mailbox string, entries map[string]*[]byte) error
+	SetMetadata(ctx context.Context, mailbox string, entries map[string]*[]byte) error
 }

--- a/imapserver/session_context_test.go
+++ b/imapserver/session_context_test.go
@@ -1,0 +1,93 @@
+package imapserver_test
+
+import (
+	"context"
+	"net"
+	"testing"
+	"time"
+
+	"github.com/emersion/go-imap/v2"
+	"github.com/emersion/go-imap/v2/imapclient"
+	"github.com/emersion/go-imap/v2/imapserver"
+	"github.com/emersion/go-imap/v2/imapserver/imapmemserver"
+)
+
+// ctxProbeSession embeds a real in-memory session (so every Session method and
+// optional interface is implemented) but overrides Select to block until its
+// context is cancelled, recording the resulting error.
+type ctxProbeSession struct {
+	*imapmemserver.UserSession
+	selectStarted chan struct{}
+	selectCtxErr  chan error
+}
+
+func (s *ctxProbeSession) Select(ctx context.Context, mailbox string, options *imap.SelectOptions) (*imap.SelectData, error) {
+	close(s.selectStarted)
+	<-ctx.Done()
+	s.selectCtxErr <- ctx.Err()
+	return nil, ctx.Err()
+}
+
+// TestSessionContextCancelledOnServerClose is an end-to-end check that the
+// context handed to a blocking Session method is cancelled when the server is
+// shut down while the method is in flight.
+func TestSessionContextCancelledOnServerClose(t *testing.T) {
+	user := imapmemserver.NewUser("user", "pass")
+	if err := user.Create(context.Background(), "INBOX", nil); err != nil {
+		t.Fatalf("Create() = %v", err)
+	}
+
+	probe := &ctxProbeSession{
+		UserSession:   imapmemserver.NewUserSession(user),
+		selectStarted: make(chan struct{}),
+		selectCtxErr:  make(chan error, 1),
+	}
+
+	server := imapserver.New(&imapserver.Options{
+		NewSession: func(*imapserver.Conn) (imapserver.Session, *imapserver.GreetingData, error) {
+			return probe, nil, nil
+		},
+		InsecureAuth: true,
+		Caps:         imap.CapSet{imap.CapIMAP4rev1: {}, imap.CapIMAP4rev2: {}},
+	})
+
+	ln, err := net.Listen("tcp", "localhost:0")
+	if err != nil {
+		t.Fatalf("net.Listen() = %v", err)
+	}
+	go server.Serve(ln)
+	defer server.Close()
+
+	conn, err := net.Dial("tcp", ln.Addr().String())
+	if err != nil {
+		t.Fatalf("net.Dial() = %v", err)
+	}
+	client := imapclient.New(conn, nil)
+	defer client.Close()
+
+	if err := client.Login("user", "pass").Wait(); err != nil {
+		t.Fatalf("Login().Wait() = %v", err)
+	}
+
+	// Select blocks in the backend; run it off the test goroutine.
+	go client.Select("INBOX", nil).Wait()
+
+	select {
+	case <-probe.selectStarted:
+	case <-time.After(5 * time.Second):
+		t.Fatal("Select never reached the backend")
+	}
+
+	// The backend is blocked inside Select. Shutting the server down must cancel
+	// the context it was given.
+	go server.Close()
+
+	select {
+	case err := <-probe.selectCtxErr:
+		if err != context.Canceled {
+			t.Fatalf("backend Select context error = %v, want context.Canceled", err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("backend context was not cancelled on server shutdown")
+	}
+}

--- a/imapserver/sort.go
+++ b/imapserver/sort.go
@@ -130,7 +130,7 @@ func (c *Conn) handleSort(tag string, dec *imapwire.Decoder, numKind NumKind) er
 	}
 
 	// Call the session's Sort method
-	data, err := c.session.Sort(numKind, sortCriteria, charset, &searchCriteria, &options)
+	data, err := c.session.Sort(c.ctx, numKind, sortCriteria, charset, &searchCriteria, &options)
 	if err != nil {
 		return err
 	}

--- a/imapserver/status.go
+++ b/imapserver/status.go
@@ -47,7 +47,7 @@ func (c *Conn) handleStatus(dec *imapwire.Decoder) error {
 		return err
 	}
 
-	data, err := c.session.Status(mailbox, &options)
+	data, err := c.session.Status(c.ctx, mailbox, &options)
 	if err != nil {
 		return err
 	}

--- a/imapserver/store.go
+++ b/imapserver/store.go
@@ -101,7 +101,7 @@ func (c *Conn) handleStore(dec *imapwire.Decoder, numKind NumKind) error {
 	}
 
 	w := &FetchWriter{conn: c}
-	return c.session.Store(w, numSet, &imap.StoreFlags{
+	return c.session.Store(c.ctx, w, numSet, &imap.StoreFlags{
 		Op:     op,
 		Silent: silent,
 		Flags:  flags,

--- a/imapserver/thread.go
+++ b/imapserver/thread.go
@@ -1,6 +1,7 @@
 package imapserver
 
 import (
+	"context"
 	"fmt"
 	"strings"
 
@@ -10,7 +11,7 @@ import (
 
 // SessionThread is implemented by sessions that support RFC 5256 THREAD.
 type SessionThread interface {
-	Thread(numKind NumKind, algorithm imap.ThreadAlgorithm, charset string, criteria *imap.SearchCriteria) ([]imap.ThreadData, error)
+	Thread(ctx context.Context, numKind NumKind, algorithm imap.ThreadAlgorithm, charset string, criteria *imap.SearchCriteria) ([]imap.ThreadData, error)
 }
 
 func (c *Conn) handleThread(dec *imapwire.Decoder, numKind NumKind) error {
@@ -76,7 +77,7 @@ func (c *Conn) handleThread(dec *imapwire.Decoder, numKind NumKind) error {
 		}
 	}
 
-	data, err := sessionThread.Thread(numKind, algorithm, charset, &criteria)
+	data, err := sessionThread.Thread(c.ctx, numKind, algorithm, charset, &criteria)
 	if err != nil {
 		return err
 	}

--- a/imapserver/utf8_negotiation_test.go
+++ b/imapserver/utf8_negotiation_test.go
@@ -3,6 +3,7 @@ package imapserver_test
 import (
 	"bufio"
 	"bytes"
+	"context"
 	"net"
 	"strings"
 	"testing"
@@ -31,7 +32,7 @@ func TestUTF8MailboxNameNegotiation(t *testing.T) {
 	utf7Bytes := []byte(mailboxModUTF7) // pure ASCII
 
 	memUser := imapmemserver.NewUser(username, password)
-	if err := memUser.Create(mailboxName, nil); err != nil {
+	if err := memUser.Create(context.Background(), mailboxName, nil); err != nil {
 		t.Fatalf("Create(%q): %v", mailboxName, err)
 	}
 	memServer := imapmemserver.New()


### PR DESCRIPTION
Blocking Session backend methods previously had no way to learn that the connection had gone away, so in-flight work (DB queries, object-storage reads) kept running after client disconnect or during server shutdown. This adds a per-connection context.Context, cancelled when the connection is torn down, and passes it as the first argument to every I/O-bound Session method.

Mechanism:
- Conn gains a context created in newConn (before the conn is registered so forceCloseConns can always reach it) and cancelled both on serve() exit and in forceCloseConns (so Server.Close/Shutdown release backends blocked in a handler, from a separate goroutine). Exposed as Conn.Context().
- ctx is added to the I/O-bound methods of Session and every optional sub-interface (Namespace, Move, Unauthenticate, Metadata, ACL, MultiSearch, Thread). Pure accessors (AppendLimit, GetCapabilities, AuthenticateMechanisms, AdditionalCapabilities, ID) and Close keep their signatures.
- All command handlers pass c.ctx; the in-memory backend and its callers are migrated.

Also fixes an IDLE timer leak: the 30s post-DONE guard used time.After, which lingered until it fired; it now uses time.NewTimer with defer Stop().

BREAKING CHANGE: Session and its sub-interfaces now take context.Context as the first argument on blocking methods. Backend implementations must be updated.

Tests: TestConnContextCancelledByForceClose (plumbing) and TestSessionContextCancelledOnServerClose (end-to-end: a backend blocked in Select is released when the server shuts down). Full suite green under -race.