### PR TITLE
imapserver: fix search recursion, enabled-map race, condStore reset, …

### DIFF
--- a/imapserver/audit_l_fixes_test.go
+++ b/imapserver/audit_l_fixes_test.go
@@ -1,0 +1,115 @@
+package imapserver
+
+import (
+	"bufio"
+	"context"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/emersion/go-imap/v2"
+	"github.com/emersion/go-imap/v2/internal/imapwire"
+)
+
+// L1: deeply nested NOT/OR SEARCH keys must be rejected with a clean error
+// rather than recursing unbounded (they bypass the decoder's maxListDepth).
+func TestSearchKeyNestingBounded(t *testing.T) {
+	input := strings.Repeat("NOT ", maxSearchKeyDepth+50) + "ALL\r\n"
+	dec := imapwire.NewDecoder(bufio.NewReader(strings.NewReader(input)), imapwire.ConnSideServer)
+
+	var criteria imap.SearchCriteria
+	err := readSearchKey(&Conn{}, &criteria, dec)
+	if err == nil {
+		t.Fatal("expected an error for over-deep SEARCH key nesting, got nil")
+	}
+	if !strings.Contains(err.Error(), "too deep") {
+		t.Fatalf("error = %v, want a nesting-too-deep client bug error", err)
+	}
+}
+
+// A legitimately shallow nesting must still parse fine.
+func TestSearchKeyShallowNestingOK(t *testing.T) {
+	input := "OR NOT ALL (SEEN)\r\n"
+	dec := imapwire.NewDecoder(bufio.NewReader(strings.NewReader(input)), imapwire.ConnSideServer)
+
+	var criteria imap.SearchCriteria
+	if err := readSearchKey(&Conn{}, &criteria, dec); err != nil {
+		t.Fatalf("readSearchKey() on a shallow query = %v", err)
+	}
+}
+
+type unauthProbeSession struct {
+	Session
+}
+
+func (unauthProbeSession) Unauthenticate(ctx context.Context) error { return nil }
+
+// L4: UNAUTHENTICATE must reset the CONDSTORE-enabled flag (RFC 8437), not just
+// the enabled cap set, so a re-authenticated client isn't sent MODSEQ items.
+func TestUnauthenticateResetsCondStore(t *testing.T) {
+	c := &Conn{
+		state:   imap.ConnStateAuthenticated,
+		enabled: make(imap.CapSet),
+		session: unauthProbeSession{},
+	}
+	c.markCondStoreEnabled()
+	if !c.CondStoreEnabled() {
+		t.Fatal("precondition: CondStoreEnabled() should be true after markCondStoreEnabled")
+	}
+
+	dec := imapwire.NewDecoder(bufio.NewReader(strings.NewReader("\r\n")), imapwire.ConnSideServer)
+	if err := c.handleUnauthenticate(dec); err != nil {
+		t.Fatalf("handleUnauthenticate() = %v", err)
+	}
+
+	if c.CondStoreEnabled() {
+		t.Error("CondStoreEnabled() still true after UNAUTHENTICATE")
+	}
+	if c.state != imap.ConnStateNotAuthenticated {
+		t.Errorf("state = %v, want NotAuthenticated", c.state)
+	}
+}
+
+// L5: MailboxTracker invariant violations must return an error, not panic
+// (backends call these from arbitrary goroutines with no recover).
+func TestMailboxTrackerQueueReturnsErrorNotPanic(t *testing.T) {
+	tr := NewMailboxTracker(5)
+
+	if err := tr.QueueExpunge(0, 0); err == nil {
+		t.Error("QueueExpunge(0) should return an error")
+	}
+	if err := tr.QueueExpunge(10, 0); err == nil {
+		t.Error("QueueExpunge out of range should return an error")
+	}
+	if err := tr.QueueNumMessages(3); err == nil {
+		t.Error("QueueNumMessages decreasing the count should return an error")
+	}
+	// A valid update still succeeds.
+	if err := tr.QueueNumMessages(7); err != nil {
+		t.Errorf("QueueNumMessages(7) on a 5-message mailbox = %v, want nil", err)
+	}
+}
+
+// L2: enabledHas must be safe to call concurrently with ENABLE writing the
+// c.enabled map. Meaningful under -race.
+func TestEnabledHasConcurrentSafe(t *testing.T) {
+	c := &Conn{enabled: make(imap.CapSet)}
+
+	var wg sync.WaitGroup
+	wg.Add(2)
+	go func() {
+		defer wg.Done()
+		for i := 0; i < 2000; i++ {
+			c.mutex.Lock()
+			c.enabled[imap.CapIMAP4rev2] = struct{}{}
+			c.mutex.Unlock()
+		}
+	}()
+	go func() {
+		defer wg.Done()
+		for i := 0; i < 2000; i++ {
+			_ = c.enabledHas(imap.CapIMAP4rev2)
+		}
+	}()
+	wg.Wait()
+}

--- a/imapserver/authenticate.go
+++ b/imapserver/authenticate.go
@@ -147,6 +147,10 @@ func (c *Conn) handleUnauthenticate(dec *imapwire.Decoder) error {
 	c.state = imap.ConnStateNotAuthenticated
 	c.mutex.Lock()
 	c.enabled = make(imap.CapSet)
+	// Reset CONDSTORE-enabled state too (RFC 8437): the connection returns to
+	// not-authenticated as if freshly connected, so a re-authenticated client
+	// that never re-enables CONDSTORE must not receive MODSEQ data items.
+	c.condStore = false
 	c.mutex.Unlock()
 	return nil
 }

--- a/imapserver/cond_caps.go
+++ b/imapserver/cond_caps.go
@@ -23,7 +23,7 @@ func (c *Conn) supportsCondStore() bool {
 		sessionCaps := capSession.GetCapabilities()
 		return sessionCaps.Has(imap.CapCondStore) || sessionCaps.Has(imap.CapIMAP4rev2)
 	}
-	return c.enabled.Has(imap.CapIMAP4rev2) || c.availableCapsSet().Has(imap.CapCondStore) || c.availableCapsSet().Has(imap.CapIMAP4rev2)
+	return c.enabledHas(imap.CapIMAP4rev2) || c.availableCapsSet().Has(imap.CapCondStore) || c.availableCapsSet().Has(imap.CapIMAP4rev2)
 }
 
 // markCondStoreEnabled records that the client has issued a CONDSTORE-enabling

--- a/imapserver/conn.go
+++ b/imapserver/conn.go
@@ -136,6 +136,16 @@ func (c *Conn) EnabledCaps() imap.CapSet {
 	return c.enabled.Copy()
 }
 
+// enabledHas reports whether cap has been ENABLEd on this connection. It takes
+// c.mutex so it is safe to call from UpdateWriter/tracker callbacks that a
+// backend may invoke from its own goroutine, concurrently with ENABLE writing
+// c.enabled on the command goroutine (c.enabled is a plain map).
+func (c *Conn) enabledHas(cap imap.Cap) bool {
+	c.mutex.Lock()
+	defer c.mutex.Unlock()
+	return c.enabled.Has(cap)
+}
+
 // Context returns the connection's context. It is cancelled when the
 // connection is torn down — by client disconnect, by the serve goroutine
 // exiting, or by server shutdown. Backends may use it to bound blocking work,
@@ -486,7 +496,7 @@ type RenameWriter struct {
 // an unsolicited extended LIST would confuse an IMAP4rev1-only client (this
 // mirrors how RECENT is suppressed for rev2 clients).
 func (w *RenameWriter) WriteOldName(data *imap.ListData) error {
-	if !w.conn.enabled.Has(imap.CapIMAP4rev2) {
+	if !w.conn.enabledHas(imap.CapIMAP4rev2) {
 		return nil
 	}
 	return w.conn.writeListData(data, nil, true)
@@ -775,7 +785,7 @@ func (w *UpdateWriter) WriteNumMessages(n uint32) error {
 
 // WriteNumRecent writes an RECENT response (not used in IMAP4rev2, will be ignored).
 func (w *UpdateWriter) WriteNumRecent(n uint32) error {
-	if w.conn.enabled.Has(imap.CapIMAP4rev2) || !w.conn.server.options.caps().Has(imap.CapIMAP4rev1) {
+	if w.conn.enabledHas(imap.CapIMAP4rev2) || !w.conn.server.options.caps().Has(imap.CapIMAP4rev1) {
 		return nil
 	}
 	return w.conn.writeObsoleteRecent(n)

--- a/imapserver/search.go
+++ b/imapserver/search.go
@@ -234,14 +234,28 @@ func maybeReadSearchKeyAtom(dec *imapwire.Decoder, ptr *string) bool {
 	})
 }
 
+// maxSearchKeyDepth bounds SEARCH-key nesting. The parenthesized-list path is
+// already capped by the decoder's maxListDepth, but NOT/OR recurse directly and
+// would otherwise be bounded only by the 50 KiB command size — a single small
+// command can drive many thousands of NOT/OR levels. Cap it well above any real
+// query.
+const maxSearchKeyDepth = 100
+
 func readSearchKey(c *Conn, criteria *imap.SearchCriteria, dec *imapwire.Decoder) error {
+	return readSearchKeyDepth(c, criteria, dec, 0)
+}
+
+func readSearchKeyDepth(c *Conn, criteria *imap.SearchCriteria, dec *imapwire.Decoder, depth int) error {
+	if depth > maxSearchKeyDepth {
+		return newClientBugError("SEARCH key nesting too deep")
+	}
 	var key string
 	if maybeReadSearchKeyAtom(dec, &key) {
-		return readSearchKeyWithAtom(c, criteria, dec, key)
+		return readSearchKeyWithAtomDepth(c, criteria, dec, key, depth)
 	}
 	return dec.ExpectList(func() error {
 		for {
-			if err := readSearchKey(c, criteria, dec); err != nil {
+			if err := readSearchKeyDepth(c, criteria, dec, depth+1); err != nil {
 				return err
 			}
 			if !dec.SP() {
@@ -253,6 +267,10 @@ func readSearchKey(c *Conn, criteria *imap.SearchCriteria, dec *imapwire.Decoder
 }
 
 func readSearchKeyWithAtom(c *Conn, criteria *imap.SearchCriteria, dec *imapwire.Decoder, key string) error {
+	return readSearchKeyWithAtomDepth(c, criteria, dec, key, 0)
+}
+
+func readSearchKeyWithAtomDepth(c *Conn, criteria *imap.SearchCriteria, dec *imapwire.Decoder, key string, depth int) error {
 	key = strings.ToUpper(key)
 	switch key {
 	case "ALL":
@@ -359,7 +377,7 @@ func readSearchKeyWithAtom(c *Conn, criteria *imap.SearchCriteria, dec *imapwire
 			return dec.Err()
 		}
 		var not imap.SearchCriteria
-		if err := readSearchKey(c, &not, dec); err != nil {
+		if err := readSearchKeyDepth(c, &not, dec, depth+1); err != nil {
 			return err
 		}
 		criteria.Not = append(criteria.Not, not)
@@ -368,13 +386,13 @@ func readSearchKeyWithAtom(c *Conn, criteria *imap.SearchCriteria, dec *imapwire
 			return dec.Err()
 		}
 		var or [2]imap.SearchCriteria
-		if err := readSearchKey(c, &or[0], dec); err != nil {
+		if err := readSearchKeyDepth(c, &or[0], dec, depth+1); err != nil {
 			return err
 		}
 		if !dec.ExpectSP() {
 			return dec.Err()
 		}
-		if err := readSearchKey(c, &or[1], dec); err != nil {
+		if err := readSearchKeyDepth(c, &or[1], dec, depth+1); err != nil {
 			return err
 		}
 		criteria.Or = append(criteria.Or, or)

--- a/imapserver/select.go
+++ b/imapserver/select.go
@@ -36,7 +36,7 @@ func (c *Conn) handleSelect(tag string, dec *imapwire.Decoder, readOnly bool) er
 				}
 			case "QRESYNC":
 				// Per RFC 7162, QRESYNC requires ENABLE QRESYNC
-				if c.enabled.Has(imap.CapQResync) {
+				if c.enabledHas(imap.CapQResync) {
 					if !dec.ExpectSP() {
 						return dec.Err()
 					}
@@ -145,7 +145,7 @@ func (c *Conn) handleSelect(tag string, dec *imapwire.Decoder, readOnly bool) er
 	// "The server MUST send EXISTS and RECENT responses, as documented
 	// in RFC 3501, even when QRESYNC is active."
 	writeExists(enc.Encoder, data.NumMessages)
-	if !c.enabled.Has(imap.CapIMAP4rev2) && c.server.options.caps().Has(imap.CapIMAP4rev1) {
+	if !c.enabledHas(imap.CapIMAP4rev2) && c.server.options.caps().Has(imap.CapIMAP4rev1) {
 		writeObsoleteRecent(enc.Encoder, data.NumRecent)
 		if data.FirstUnseenSeqNum != 0 {
 			writeObsoleteUnseen(enc.Encoder, data.FirstUnseenSeqNum)

--- a/imapserver/sort.go
+++ b/imapserver/sort.go
@@ -136,7 +136,7 @@ func (c *Conn) handleSort(tag string, dec *imapwire.Decoder, numKind NumKind) er
 	}
 
 	// Write SORT/ESORT response
-	if c.enabled.Has(imap.CapIMAP4rev2) || extended {
+	if c.enabledHas(imap.CapIMAP4rev2) || extended {
 		return c.writeESort(tag, data, &options, numKind)
 	} else {
 		return c.writeSort(data.All, numKind)

--- a/imapserver/status.go
+++ b/imapserver/status.go
@@ -36,7 +36,7 @@ func (c *Conn) handleStatus(dec *imapwire.Decoder) error {
 	// response under the same condition (select.go): gating on the session-enabled
 	// revision rather than only the server-advertised one, so a rev2 client on a
 	// dual-advertised server can't still pull the obsolete item.
-	if options.NumRecent && (c.enabled.Has(imap.CapIMAP4rev2) || !c.server.options.caps().Has(imap.CapIMAP4rev1)) {
+	if options.NumRecent && (c.enabledHas(imap.CapIMAP4rev2) || !c.server.options.caps().Has(imap.CapIMAP4rev1)) {
 		return &imap.Error{
 			Type: imap.StatusResponseTypeBad,
 			Text: "Unknown STATUS data item",

--- a/imapserver/tracker.go
+++ b/imapserver/tracker.go
@@ -38,15 +38,20 @@ func (t *MailboxTracker) NewSession() *SessionTracker {
 	return st
 }
 
-func (t *MailboxTracker) queueUpdate(update *trackerUpdate, source *SessionTracker) {
+func (t *MailboxTracker) queueUpdate(update *trackerUpdate, source *SessionTracker) error {
 	t.mutex.Lock()
 	defer t.mutex.Unlock()
 
+	// These are backend invariant violations. Return an error instead of
+	// panicking: MailboxTracker is a shared entry point that backends call from
+	// arbitrary goroutines (not just IDLE, which recovers), so a panic here would
+	// crash whatever goroutine reported the inconsistency — often the whole
+	// process.
 	if update.expunge != 0 && update.expunge > t.numMessages {
-		panic(fmt.Errorf("imapserver: expunge sequence number (%v) out of range (%v messages in mailbox)", update.expunge, t.numMessages))
+		return fmt.Errorf("imapserver: expunge sequence number (%v) out of range (%v messages in mailbox)", update.expunge, t.numMessages)
 	}
 	if update.numMessages != 0 && update.numMessages < t.numMessages {
-		panic(fmt.Errorf("imapserver: cannot decrease mailbox number of messages from %v to %v", t.numMessages, update.numMessages))
+		return fmt.Errorf("imapserver: cannot decrease mailbox number of messages from %v to %v", t.numMessages, update.numMessages)
 	}
 
 	// Capture the current count before applying the update so that
@@ -69,6 +74,7 @@ func (t *MailboxTracker) queueUpdate(update *trackerUpdate, source *SessionTrack
 	case update.numMessages != 0:
 		t.numMessages = update.numMessages
 	}
+	return nil
 }
 
 // QueueExpunge queues a new EXPUNGE update.
@@ -76,25 +82,29 @@ func (t *MailboxTracker) queueUpdate(update *trackerUpdate, source *SessionTrack
 // uid is the UID of the expunged message. It is used to emit a VANISHED response
 // (RFC 7162 §3.2.10) instead of EXPUNGE for QRESYNC-enabled sessions; pass 0 when
 // no UID is available (such sessions then fall back to EXPUNGE).
-func (t *MailboxTracker) QueueExpunge(seqNum uint32, uid imap.UID) {
+//
+// It returns an error (rather than panicking) if seqNum is 0 or out of range, so
+// a backend bug cannot crash the calling goroutine.
+func (t *MailboxTracker) QueueExpunge(seqNum uint32, uid imap.UID) error {
 	if seqNum == 0 {
-		panic("imapserver: invalid expunge message sequence number")
+		return fmt.Errorf("imapserver: invalid expunge message sequence number")
 	}
-	t.queueUpdate(&trackerUpdate{expunge: seqNum, expungeUID: uid}, nil)
+	return t.queueUpdate(&trackerUpdate{expunge: seqNum, expungeUID: uid}, nil)
 }
 
-// QueueNumMessages queues a new EXISTS update.
-func (t *MailboxTracker) QueueNumMessages(n uint32) {
+// QueueNumMessages queues a new EXISTS update. It returns an error if n would
+// decrease the tracked message count.
+func (t *MailboxTracker) QueueNumMessages(n uint32) error {
 	// TODO: merge consecutive NumMessages updates
-	t.queueUpdate(&trackerUpdate{numMessages: n}, nil)
+	return t.queueUpdate(&trackerUpdate{numMessages: n}, nil)
 }
 
 // QueueMailboxFlags queues a new FLAGS update.
-func (t *MailboxTracker) QueueMailboxFlags(flags []imap.Flag) {
+func (t *MailboxTracker) QueueMailboxFlags(flags []imap.Flag) error {
 	if flags == nil {
 		flags = []imap.Flag{}
 	}
-	t.queueUpdate(&trackerUpdate{mailboxFlags: flags}, nil)
+	return t.queueUpdate(&trackerUpdate{mailboxFlags: flags}, nil)
 }
 
 // QueueMessageFlags queues a new FETCH FLAGS update.
@@ -105,8 +115,8 @@ func (t *MailboxTracker) QueueMailboxFlags(flags []imap.Flag) {
 // instead of falling back to a full re-sync. Pass 0 when no modseq is available.
 //
 // If source is not nil, the update won't be dispatched to it.
-func (t *MailboxTracker) QueueMessageFlags(seqNum uint32, uid imap.UID, flags []imap.Flag, modSeq uint64, source *SessionTracker) {
-	t.queueUpdate(&trackerUpdate{fetch: &trackerUpdateFetch{
+func (t *MailboxTracker) QueueMessageFlags(seqNum uint32, uid imap.UID, flags []imap.Flag, modSeq uint64, source *SessionTracker) error {
+	return t.queueUpdate(&trackerUpdate{fetch: &trackerUpdateFetch{
 		seqNum: seqNum,
 		uid:    uid,
 		flags:  flags,
@@ -192,7 +202,7 @@ func (t *SessionTracker) Poll(w *UpdateWriter, allowExpunge bool) error {
 	// VANISHED (by UID) rather than EXPUNGE (by sequence number). Coalesce
 	// consecutive expunges into a single VANISHED set, flushing it before any
 	// other kind of update so response ordering is preserved.
-	qresync := w.conn != nil && w.conn.enabled.Has(imap.CapQResync)
+	qresync := w.conn != nil && w.conn.enabledHas(imap.CapQResync)
 	var vanished imap.UIDSet
 	flushVanished := func() error {
 		if len(vanished) == 0 {


### PR DESCRIPTION
…tracker panics (L1,L2,L4,L5)

Four low-severity robustness fixes from the audit.

L1 (search.go): NOT/OR search keys recursed via readSearchKey directly,
    bypassing the decoder's maxListDepth cap the parenthesized-list path uses. A
    single 50 KiB command could drive many thousands of levels. Thread a depth
    counter through readSearchKey and cap at 100 (well above any real query),
    returning a clean client-bug error past that.

L2 (conn.go, cond_caps.go, select.go, sort.go, status.go): c.enabled (a plain
    map) and c.condStore were read off the UpdateWriter/tracker path without
    c.mutex while ENABLE writes them under the lock — a concurrent map read+write
    (panic) if a backend drives updates from its own goroutine. Add a locked
    enabledHas accessor and route the reads through it (and the existing locked
    CondStoreEnabled/useQuotedUTF8).

L4 (authenticate.go): UNAUTHENTICATE reset c.enabled but not c.condStore, so a
    re-authenticated client could be sent MODSEQ items it never enabled. Reset it
    too (RFC 8437).

L5 (tracker.go): MailboxTracker.Queue* panicked on backend invariant violations
    (out-of-range expunge, count decrease, seqNum 0). These are called from
    arbitrary backend goroutines with no recover, so a backend bug could crash
    the process. Return an error instead. The Queue* signatures gain an error
    return, which is source-compatible for callers that ignore it.

Tests added for each; full suite green under -race.