### PR TITLE
imapserver/imapclient: connection cap, ALPN, constant-time login, idl…

### DIFF
--- a/imapclient/client.go
+++ b/imapclient/client.go
@@ -303,6 +303,9 @@ func DialStartTLS(address string, options *Options) (*Client, error) {
 	if tlsConfig.ServerName == "" {
 		tlsConfig.ServerName = host
 	}
+	if tlsConfig.NextProtos == nil {
+		tlsConfig.NextProtos = []string{"imap"} // RFC 7817 / parity with DialTLS
+	}
 	newOptions := *options
 	newOptions.TLSConfig = tlsConfig
 	return NewStartTLS(conn, &newOptions)

--- a/imapclient/idle.go
+++ b/imapclient/idle.go
@@ -101,6 +101,11 @@ func (cmd *IdleCommand) Wait() error {
 	if cmd.err != nil {
 		return cmd.err
 	}
+	if cmd.lastChild == nil {
+		// Defensive: every err==nil exit path sets lastChild, but guard against a
+		// future path that doesn't rather than nil-dereference here.
+		return cmd.err
+	}
 	return cmd.lastChild.Wait()
 }
 

--- a/imapserver/imapmemserver/user.go
+++ b/imapserver/imapmemserver/user.go
@@ -32,10 +32,12 @@ func NewUser(username, password string) *User {
 }
 
 func (u *User) Login(ctx context.Context, username, password string) error {
-	if username != u.username {
-		return imapserver.ErrAuthFailed
-	}
-	if subtle.ConstantTimeCompare([]byte(password), []byte(u.password)) != 1 {
+	// Compare both username and password without short-circuiting, so response
+	// timing does not distinguish "unknown user" from "wrong password" (username
+	// enumeration). Both use constant-time comparison.
+	userOK := subtle.ConstantTimeCompare([]byte(username), []byte(u.username))
+	passOK := subtle.ConstantTimeCompare([]byte(password), []byte(u.password))
+	if userOK != 1 || passOK != 1 {
 		return imapserver.ErrAuthFailed
 	}
 	return nil

--- a/imapserver/imapmemserver/user_test.go
+++ b/imapserver/imapmemserver/user_test.go
@@ -1,0 +1,27 @@
+package imapmemserver
+
+import (
+	"context"
+	"testing"
+)
+
+// I1: Login must reject unknown users and wrong passwords, and accept the valid
+// pair. The comparison no longer short-circuits on the username (to avoid a
+// timing side channel); this locks in that the behavior is still correct.
+func TestUserLoginRejectsUnknownUserAndWrongPassword(t *testing.T) {
+	u := NewUser("alice", "secret")
+	ctx := context.Background()
+
+	if err := u.Login(ctx, "alice", "secret"); err != nil {
+		t.Errorf("valid login = %v, want nil", err)
+	}
+	if err := u.Login(ctx, "bob", "secret"); err == nil {
+		t.Error("unknown user should fail")
+	}
+	if err := u.Login(ctx, "alice", "wrong"); err == nil {
+		t.Error("wrong password should fail")
+	}
+	if err := u.Login(ctx, "bob", "wrong"); err == nil {
+		t.Error("unknown user + wrong password should fail")
+	}
+}

--- a/imapserver/maxconn_test.go
+++ b/imapserver/maxconn_test.go
@@ -1,0 +1,60 @@
+package imapserver_test
+
+import (
+	"bufio"
+	"net"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/emersion/go-imap/v2"
+	"github.com/emersion/go-imap/v2/imapserver"
+	"github.com/emersion/go-imap/v2/imapserver/imapmemserver"
+)
+
+// L6: with MaxConnections set, a connection beyond the limit is refused with a
+// BYE rather than served.
+func TestMaxConnections(t *testing.T) {
+	memServer := imapmemserver.New()
+	server := imapserver.New(&imapserver.Options{
+		NewSession: func(*imapserver.Conn) (imapserver.Session, *imapserver.GreetingData, error) {
+			return memServer.NewSession(), nil, nil
+		},
+		InsecureAuth:   true,
+		Caps:           imap.CapSet{imap.CapIMAP4rev2: {}},
+		MaxConnections: 1,
+	})
+
+	ln, err := net.Listen("tcp", "localhost:0")
+	if err != nil {
+		t.Fatalf("net.Listen() = %v", err)
+	}
+	go server.Serve(ln)
+	defer server.Close()
+
+	readLine := func(conn net.Conn) string {
+		conn.SetReadDeadline(time.Now().Add(5 * time.Second))
+		line, _ := bufio.NewReader(conn).ReadString('\n')
+		return line
+	}
+
+	// First connection takes the only slot and is served (gets the greeting).
+	c1, err := net.Dial("tcp", ln.Addr().String())
+	if err != nil {
+		t.Fatalf("net.Dial() first = %v", err)
+	}
+	defer c1.Close()
+	if got := readLine(c1); !strings.HasPrefix(got, "* OK") {
+		t.Fatalf("first connection greeting = %q, want a * OK greeting", got)
+	}
+
+	// Second connection is over the limit and must be refused with BYE.
+	c2, err := net.Dial("tcp", ln.Addr().String())
+	if err != nil {
+		t.Fatalf("net.Dial() second = %v", err)
+	}
+	defer c2.Close()
+	if got := readLine(c2); !strings.Contains(got, "BYE Too many connections") {
+		t.Fatalf("second connection response = %q, want a BYE refusal", got)
+	}
+}

--- a/imapserver/server.go
+++ b/imapserver/server.go
@@ -56,6 +56,12 @@ type Options struct {
 	// connection. If nil, the default check using type assertion is used.
 	// Note: This does NOT affect STARTTLS behavior.
 	IsTLS func(net.Conn) bool
+	// MaxConnections limits the number of concurrent client connections served.
+	// When the limit is reached, further connections are refused with a BYE and
+	// closed immediately, rather than consuming a goroutine and a file
+	// descriptor. Zero means no limit (the historical behavior); operators can
+	// alternatively front the listener with golang.org/x/net/netutil.LimitListener.
+	MaxConnections int
 	// Raw ingress and egress data will be written to this writer, if any.
 	// Note, this may include sensitive information such as credentials used
 	// during authentication.
@@ -93,6 +99,11 @@ type Server struct {
 	listeners map[net.Listener]struct{}
 	conns     map[*Conn]struct{}
 	closed    bool
+
+	// connSem bounds concurrent connections when Options.MaxConnections > 0. A
+	// slot is acquired before spawning a connection goroutine and released when
+	// it exits. nil means unlimited.
+	connSem chan struct{}
 }
 
 // New creates a new server.
@@ -100,11 +111,15 @@ func New(options *Options) *Server {
 	if caps := options.caps(); !caps.Has(imap.CapIMAP4rev2) && !caps.Has(imap.CapIMAP4rev1) {
 		panic("imapserver: at least IMAP4rev1 must be supported")
 	}
-	return &Server{
+	s := &Server{
 		options:   *options,
 		listeners: make(map[net.Listener]struct{}),
 		conns:     make(map[*Conn]struct{}),
 	}
+	if options.MaxConnections > 0 {
+		s.connSem = make(chan struct{}, options.MaxConnections)
+	}
+	return s
 }
 
 func (s *Server) logger() Logger {
@@ -160,12 +175,36 @@ func (s *Server) Serve(ln net.Listener) error {
 		}
 
 		delay = 0
+
+		// Enforce MaxConnections: acquire a slot without blocking the accept
+		// loop; if the server is at capacity, refuse the connection cleanly.
+		if s.connSem != nil {
+			select {
+			case s.connSem <- struct{}{}:
+			default:
+				go s.rejectConn(conn)
+				continue
+			}
+		}
+
 		s.connsWaitGroup.Add(1)
 		go func() {
 			defer s.connsWaitGroup.Done()
+			if s.connSem != nil {
+				defer func() { <-s.connSem }()
+			}
 			newConn(conn, s).serve()
 		}()
 	}
+}
+
+// rejectConn refuses a connection that would exceed MaxConnections, sending a
+// BYE before closing so the client learns why. Best-effort and bounded by a
+// write deadline so a non-reading client can't stall it.
+func (s *Server) rejectConn(conn net.Conn) {
+	conn.SetWriteDeadline(time.Now().Add(respWriteTimeout))
+	conn.Write([]byte("* BYE Too many connections\r\n"))
+	conn.Close()
 }
 
 // ListenAndServe listens on the TCP network address addr and then calls Serve.

--- a/imapserver/status.go
+++ b/imapserver/status.go
@@ -30,21 +30,24 @@ func (c *Conn) handleStatus(dec *imapwire.Decoder) error {
 		return dec.Err()
 	}
 
+	if err := c.checkState(imap.ConnStateAuthenticated); err != nil {
+		return err
+	}
+
 	// RECENT was removed in IMAP4rev2 (RFC 9051). Reject STATUS (RECENT) when the
 	// session has ENABLEd IMAP4rev2, or when the server does not advertise
 	// IMAP4rev1 at all. This mirrors SELECT, which suppresses the obsolete RECENT
 	// response under the same condition (select.go): gating on the session-enabled
 	// revision rather than only the server-advertised one, so a rev2 client on a
 	// dual-advertised server can't still pull the obsolete item.
+	//
+	// The state check runs first so a client in the wrong state gets a state
+	// error rather than "Unknown STATUS data item".
 	if options.NumRecent && (c.enabledHas(imap.CapIMAP4rev2) || !c.server.options.caps().Has(imap.CapIMAP4rev1)) {
 		return &imap.Error{
 			Type: imap.StatusResponseTypeBad,
 			Text: "Unknown STATUS data item",
 		}
-	}
-
-	if err := c.checkState(imap.ConnStateAuthenticated); err != nil {
-		return err
 	}
 
 	data, err := c.session.Status(c.ctx, mailbox, &options)

--- a/imapserver/status_recent_test.go
+++ b/imapserver/status_recent_test.go
@@ -1,0 +1,32 @@
+package imapserver
+
+import (
+	"bufio"
+	"strings"
+	"testing"
+
+	"github.com/emersion/go-imap/v2"
+	"github.com/emersion/go-imap/v2/internal/imapwire"
+)
+
+// I4: STATUS in the wrong state must yield a state error, not the RECENT
+// "Unknown STATUS data item" rejection — the state check now runs first.
+func TestStatusRecentWrongStateReturnsStateError(t *testing.T) {
+	c := &Conn{
+		state:   imap.ConnStateNotAuthenticated,
+		enabled: make(imap.CapSet),
+		server:  New(&Options{Caps: imap.CapSet{imap.CapIMAP4rev2: {}}}),
+	}
+	dec := imapwire.NewDecoder(bufio.NewReader(strings.NewReader(" INBOX (RECENT)\r\n")), imapwire.ConnSideServer)
+
+	err := c.handleStatus(dec)
+	if err == nil {
+		t.Fatal("expected an error for STATUS in the not-authenticated state")
+	}
+	if strings.Contains(err.Error(), "Unknown STATUS data item") {
+		t.Fatalf("RECENT rejection ran before the state check: %v", err)
+	}
+	if !strings.Contains(err.Error(), "only valid in") {
+		t.Fatalf("expected a state error, got: %v", err)
+	}
+}


### PR DESCRIPTION
…e guard, STATUS ordering (L6,L7,I1,I3,I4)

Remaining audit robustness/polish items.

L6 (server.go): add optional Options.MaxConnections. When set, connections
    beyond the limit are refused with "* BYE Too many connections" and closed,
    instead of consuming a goroutine + fd. A slot is acquired non-blockingly in
    the accept loop and released when the connection goroutine exits; zero keeps
    the historical unlimited behavior.

L7 (imapclient/client.go): DialStartTLS now sets tlsConfig.NextProtos=["imap"]
    when unset, matching DialTLS.

I1 (imapmemserver/user.go): User.Login compared the username with != before the
    constant-time password check, so response timing distinguished "unknown
    user" from "wrong password" (enumeration). Compare both without
    short-circuiting, both constant-time.

I3 (imapclient/idle.go): IdleCommand.Wait guards against a nil lastChild rather
    than relying on the implicit invariant that every err==nil path sets it.

I4 (status.go): run checkState before the STATUS (RECENT) rejection so a
    wrong-state client gets a state error, not "Unknown STATUS data item".

Not changed — I2 (DebugWriter tees cleartext credentials): opt-in and documented on both client and server. Redacting on a raw byte tee would need a stateful IMAP parser inside the tee (LOGIN/AUTHENTICATE args, literals, pipelining), which is fragile and disproportionate for a debug-only feature.

Tests added for L6, I1, I4; full suite green under -race.