### PR TITLE
imapclient: send a zero-length SASL continuation as an empty line

### DIFF
--- a/imapclient/authenticate.go
+++ b/imapclient/authenticate.go
@@ -1,6 +1,7 @@
 package imapclient
 
 import (
+	"encoding/base64"
 	"fmt"
 
 	"github.com/emersion/go-sasl"
@@ -76,7 +77,13 @@ type authenticateCommand struct {
 }
 
 func (c *Client) writeSASLResp(resp []byte) error {
-	respStr := internal.EncodeSASL(resp)
+	// A continuation response is plain base64, so a zero-length response is an
+	// empty line. The "=" zero-length marker of RFC 4959 Section 3 is valid only
+	// in the initial-response slot of the AUTHENTICATE command line: here it is
+	// not valid base64, and strict servers (e.g. Dovecot) reject it. Multi-step
+	// mechanisms hit this — SASL GSSAPI (RFC 4752) acknowledges the server's
+	// AP-REP with an empty token.
+	respStr := base64.StdEncoding.EncodeToString(resp)
 	if _, err := c.bw.WriteString(respStr + "\r\n"); err != nil {
 		return err
 	}

--- a/imapclient/authenticate_test.go
+++ b/imapclient/authenticate_test.go
@@ -1,11 +1,19 @@
 package imapclient_test
 
 import (
+	"bufio"
+	"encoding/base64"
+	"fmt"
+	"io"
+	"net"
+	"strings"
 	"testing"
+	"time"
 
 	"github.com/emersion/go-sasl"
 
 	"github.com/emersion/go-imap/v2"
+	"github.com/emersion/go-imap/v2/imapclient"
 )
 
 func TestClient_Authenticate(t *testing.T) {
@@ -20,5 +28,99 @@ func TestClient_Authenticate(t *testing.T) {
 
 	if state := client.State(); state != imap.ConnStateAuthenticated {
 		t.Errorf("State() = %v, want %v", state, imap.ConnStateAuthenticated)
+	}
+}
+
+const emptyRespMech = "X-TEST-EMPTY"
+
+// emptyRespSASLClient is a two-step mechanism whose response to the server's
+// challenge is zero-length, like the mutual-authentication step of SASL GSSAPI
+// (RFC 4752 Section 3.1), where the client acknowledges the server's AP-REP
+// with an empty token.
+type emptyRespSASLClient struct{}
+
+func (*emptyRespSASLClient) Start() (mech string, ir []byte, err error) {
+	return emptyRespMech, nil, nil
+}
+
+func (*emptyRespSASLClient) Next(challenge []byte) ([]byte, error) {
+	return []byte{}, nil
+}
+
+// TestClient_Authenticate_EmptyContinuationResponse is a regression test for a
+// zero-length SASL continuation response being sent as "=".
+//
+// RFC 4959 Section 3 defines "=" as the zero-length *initial response* marker,
+// valid only in the "AUTHENTICATE <mech> <initial-response>" command line. A
+// continuation response is plain base64 (RFC 3501 Section 9, base64), where a
+// zero-length value is an empty line. Servers that validate base64 strictly
+// (Dovecot: "Invalid base64 data in continued response") reject "=" and fail
+// the authentication.
+//
+// Upstream report: emersion/go-imap#760, fix proposed in emersion/go-imap#761.
+func TestClient_Authenticate_EmptyContinuationResponse(t *testing.T) {
+	clientConn, serverConn := net.Pipe()
+	defer clientConn.Close()
+
+	respCh := make(chan string, 1)
+	errCh := make(chan error, 1)
+	go func() {
+		defer serverConn.Close()
+
+		br := bufio.NewReader(serverConn)
+		if _, err := io.WriteString(serverConn, "* OK [CAPABILITY IMAP4rev2 AUTH="+emptyRespMech+"] ready\r\n"); err != nil {
+			errCh <- fmt.Errorf("write greeting: %v", err)
+			return
+		}
+
+		line, err := br.ReadString('\n')
+		if err != nil {
+			errCh <- fmt.Errorf("read AUTHENTICATE: %v", err)
+			return
+		}
+		fields := strings.Fields(line)
+		if len(fields) == 0 {
+			errCh <- fmt.Errorf("empty command line")
+			return
+		}
+		tag := fields[0]
+
+		// Challenge the client. Its response to this challenge is zero-length.
+		challenge := base64.StdEncoding.EncodeToString([]byte("challenge"))
+		if _, err := io.WriteString(serverConn, "+ "+challenge+"\r\n"); err != nil {
+			errCh <- fmt.Errorf("write continuation request: %v", err)
+			return
+		}
+
+		resp, err := br.ReadString('\n')
+		if err != nil {
+			errCh <- fmt.Errorf("read SASL response: %v", err)
+			return
+		}
+		respCh <- strings.TrimSuffix(strings.TrimSuffix(resp, "\n"), "\r")
+
+		io.WriteString(serverConn, tag+" OK "+emptyRespMech+" authentication successful\r\n")
+		io.Copy(io.Discard, br)
+	}()
+
+	client := imapclient.New(clientConn, nil)
+	defer client.Close()
+
+	if err := client.Authenticate(&emptyRespSASLClient{}); err != nil {
+		t.Fatalf("Authenticate() = %v", err)
+	}
+
+	select {
+	case err := <-errCh:
+		t.Fatalf("test server: %v", err)
+	case got := <-respCh:
+		if got == "=" {
+			t.Fatalf(`zero-length continuation response sent as "="; RFC 4959 reserves "=" for the initial-response slot, so this must be an empty line`)
+		}
+		if got != "" {
+			t.Fatalf("continuation response = %q, want an empty line", got)
+		}
+	case <-time.After(10 * time.Second):
+		t.Fatal("timed out waiting for the SASL continuation response")
 	}
 }


### PR DESCRIPTION
Adopted from upstream **[emersion/go-imap#761](https://github.com/emersion/go-imap/pull/761)** by [@hstern](https://github.com/hstern), which fixes upstream issue [#760](https://github.com/emersion/go-imap/issues/760). The regression test is ours.

## The bug (verified present on `sora`)

`imapclient.writeSASLResp` encoded the continuation response with `internal.EncodeSASL`, which maps a zero-length input to `"="`:

```go
func EncodeSASL(b []byte) string {
	if len(b) == 0 {
		return "="
	}
	return base64.StdEncoding.EncodeToString(b)
}
```

RFC 4959 §3 defines `=` as the zero-length **initial response** marker, and only for the `AUTHENTICATE <mech> <initial-response>` command line. A *continuation* response is plain base64 (RFC 3501 §9 `base64`), where a zero-length value is simply an empty line — `=` is not valid base64 there. Servers that validate strictly reject it; Dovecot answers `Invalid base64 data in continued response` and fails the authentication.

Only multi-step mechanisms whose client emits a zero-length token are affected. SASL GSSAPI (RFC 4752 §3.1) does exactly that when acknowledging the server's AP-REP. Single-round mechanisms (PLAIN, OAUTHBEARER) never reach this path, which is why our existing `TestClient_Authenticate` did not catch it.

## Red/green test

`TestClient_Authenticate_EmptyContinuationResponse` drives `Authenticate` against a `net.Pipe` fake server with a two-step mechanism whose `Next` returns `[]byte{}`, and asserts on the exact bytes the client puts on the wire.

Before the fix:

```
--- FAIL: TestClient_Authenticate_EmptyContinuationResponse (0.00s)
    authenticate_test.go:118: zero-length continuation response sent as "="; RFC 4959
        reserves "=" for the initial-response slot, so this must be an empty line
```

After: passes. Full `go test ./...` is green.

## Review notes — what I deliberately did *not* adopt

- `internal.EncodeSASL` is left unchanged. Its `=` rule is correct for the initial-response slot and is still used there by `Authenticate`; the bug was the caller, not the helper.
- **Server side, out of scope.** `imapserver/authenticate.go:92-94` has a mirror-image asymmetry — a `nil` challenge emits `+ `, but a non-nil zero-length challenge emits `+ =`. I checked and did not change it: an empty continuation request is already overloaded in the client direction (`imapclient/authenticate.go:44` reads an empty challenge as "server wants my initial response"), so collapsing `[]byte{}` to `+ ` would change how our own client interprets the exchange. Unlike the client direction, `+ =` at least parses as `resp-text`. Worth a separate look, not a drive-by change in a client fix.
- Our server's *receive* path already handles this correctly: `decodeSASL("")` returns an empty slice, so an empty continuation line from a peer is accepted.