### PR TITLE
imapclient: don't assume message/global carries body-type-msg fields

### DIFF
--- a/imapclient/bodystructure_test.go
+++ b/imapclient/bodystructure_test.go
@@ -1,0 +1,169 @@
+package imapclient
+
+import (
+	"bufio"
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/emersion/go-imap/v2"
+	"github.com/emersion/go-imap/v2/internal/imapwire"
+)
+
+// message/global (RFC 6532) is a single-part body type. RFC 9051 lists it
+// alongside message/rfc822 in body-type-msg, so an IMAP4rev2 server follows the
+// basic fields with an envelope, a nested body structure and a line count. An
+// IMAP4rev1 server has no such rule -- RFC 3501 body-type-msg names only
+// message/rfc822 -- so it emits message/global as a plain body-type-basic and
+// goes straight to the extension data. Dovecot does the latter.
+//
+// The parser must therefore decide by what actually follows, not by the
+// subtype: an envelope is a parenthesized list, so a '(' means body-type-msg
+// and anything else (NIL, a string, end of list) means body-type-basic.
+//
+// Upstream report: emersion/go-imap#741, fix proposed in emersion/go-imap#704
+// by andybalholm. The Dovecot capture below is from that PR.
+var bodyStructureCases = []struct {
+	name   string
+	data   string
+	parsed imap.BodyStructure
+}{
+	{
+		// The regression: an IMAP4rev1 server omits envelope/body/lines and
+		// goes straight to body-ext-1part. Parsing used to fail here with
+		// "in envelope: expected '(', got \"N\"" because the SP before the
+		// md5 field was taken as the start of an envelope.
+		name: "message/global without body-type-msg fields (IMAP4rev1)",
+		data: `("message" "global" ("name" "Untitled attachment 00019.dat") NIL NIL "7bit" 6726 NIL ("attachment" ("filename" "Untitled attachment 00019.dat")) NIL NIL)`,
+		parsed: &imap.BodyStructureSinglePart{
+			Type:     "message",
+			Subtype:  "global",
+			Params:   map[string]string{"name": "Untitled attachment 00019.dat"},
+			Encoding: "7bit",
+			Size:     6726,
+			Extended: &imap.BodyStructureSinglePartExt{
+				Disposition: &imap.BodyStructureDisposition{
+					Value:  "attachment",
+					Params: map[string]string{"filename": "Untitled attachment 00019.dat"},
+				},
+			},
+		},
+	},
+	{
+		// An IMAP4rev2 server does send the body-type-msg fields for
+		// message/global. This must keep working after the fix.
+		name: "message/global with body-type-msg fields (IMAP4rev2)",
+		data: `("message" "global" ("name" "fwd.eml") NIL NIL "7bit" 6726 (NIL "Fwd" NIL NIL NIL NIL NIL NIL NIL NIL) ("text" "plain" NIL NIL NIL "7bit" 100 4) 123 NIL NIL NIL NIL)`,
+		parsed: &imap.BodyStructureSinglePart{
+			Type:     "message",
+			Subtype:  "global",
+			Params:   map[string]string{"name": "fwd.eml"},
+			Encoding: "7bit",
+			Size:     6726,
+			MessageRFC822: &imap.BodyStructureMessageRFC822{
+				Envelope: &imap.Envelope{Subject: "Fwd"},
+				BodyStructure: &imap.BodyStructureSinglePart{
+					Type:     "text",
+					Subtype:  "plain",
+					Encoding: "7bit",
+					Size:     100,
+					Text:     &imap.BodyStructureText{NumLines: 4},
+				},
+				NumLines: 123,
+			},
+			Extended: &imap.BodyStructureSinglePartExt{},
+		},
+	},
+	{
+		// message/rfc822 is body-type-msg in both revisions, so its
+		// envelope is still mandatory and is not probed for.
+		name: "message/rfc822 (unchanged)",
+		data: `("message" "rfc822" NIL NIL NIL "7bit" 6726 (NIL "Fwd" NIL NIL NIL NIL NIL NIL NIL NIL) ("text" "plain" NIL NIL NIL "7bit" 100 4) 123)`,
+		parsed: &imap.BodyStructureSinglePart{
+			Type:     "message",
+			Subtype:  "rfc822",
+			Encoding: "7bit",
+			Size:     6726,
+			MessageRFC822: &imap.BodyStructureMessageRFC822{
+				Envelope: &imap.Envelope{Subject: "Fwd"},
+				BodyStructure: &imap.BodyStructureSinglePart{
+					Type:     "text",
+					Subtype:  "plain",
+					Encoding: "7bit",
+					Size:     100,
+					Text:     &imap.BodyStructureText{NumLines: 4},
+				},
+				NumLines: 123,
+			},
+		},
+	},
+	{
+		name: "text/plain (unchanged)",
+		data: `("text" "html" ("charset" "utf-8") NIL NIL "quoted-printable" 5606 133 NIL NIL NIL NIL)`,
+		parsed: &imap.BodyStructureSinglePart{
+			Type:     "text",
+			Subtype:  "html",
+			Params:   map[string]string{"charset": "utf-8"},
+			Encoding: "quoted-printable",
+			Size:     5606,
+			Text:     &imap.BodyStructureText{NumLines: 133},
+			Extended: &imap.BodyStructureSinglePartExt{},
+		},
+	},
+}
+
+func TestReadBodyStructure(t *testing.T) {
+	for _, tc := range bodyStructureCases {
+		t.Run(tc.name, func(t *testing.T) {
+			dec := imapwire.NewDecoder(bufio.NewReader(strings.NewReader(tc.data)), imapwire.ConnSideClient)
+			bs, err := readBody(dec, &Options{})
+			if err != nil {
+				t.Fatalf("readBody() = %v", err)
+			}
+			if !reflect.DeepEqual(bs, tc.parsed) {
+				t.Fatalf("readBody() =\n\t%#v\nwant\n\t%#v", bs, tc.parsed)
+			}
+		})
+	}
+}
+
+// TestReadBodyStructureDovecotMultipart is the full multipart capture the
+// upstream report was filed against: a message/global attachment nested in a
+// mixed/related/alternative tree.
+func TestReadBodyStructureDovecotMultipart(t *testing.T) {
+	const data = `(("text" "plain" ("charset" "UTF-8") NIL NIL "quoted-printable" 576 31 NIL NIL NIL NIL)("message" "global" ("name" "Untitled attachment 00019.dat") NIL NIL "7bit" 6726 NIL ("attachment" ("filename" "Untitled attachment 00019.dat")) NIL NIL) "mixed" ("boundary" "----=_NextPart_000_0061") NIL ("en-us") NIL)`
+
+	dec := imapwire.NewDecoder(bufio.NewReader(strings.NewReader(data)), imapwire.ConnSideClient)
+	bs, err := readBody(dec, &Options{})
+	if err != nil {
+		t.Fatalf("readBody() = %v", err)
+	}
+
+	mp, ok := bs.(*imap.BodyStructureMultiPart)
+	if !ok {
+		t.Fatalf("readBody() = %T, want *imap.BodyStructureMultiPart", bs)
+	}
+	if len(mp.Children) != 2 {
+		t.Fatalf("len(Children) = %v, want 2", len(mp.Children))
+	}
+
+	global, ok := mp.Children[1].(*imap.BodyStructureSinglePart)
+	if !ok {
+		t.Fatalf("Children[1] = %T, want *imap.BodyStructureSinglePart", mp.Children[1])
+	}
+	if global.Subtype != "global" {
+		t.Errorf("Children[1].Subtype = %q, want %q", global.Subtype, "global")
+	}
+	if global.MessageRFC822 != nil {
+		t.Errorf("Children[1].MessageRFC822 = %#v, want nil", global.MessageRFC822)
+	}
+	if global.Extended == nil || global.Extended.Disposition == nil {
+		t.Fatalf("Children[1].Extended.Disposition = nil, want the attachment disposition")
+	}
+	if got := global.Extended.Disposition.Value; got != "attachment" {
+		t.Errorf("Children[1] disposition = %q, want %q", got, "attachment")
+	}
+	if got := mp.Extended.Language; !reflect.DeepEqual(got, []string{"en-us"}) {
+		t.Errorf("Language = %q, want [en-us]", got)
+	}
+}

--- a/imapclient/fetch.go
+++ b/imapclient/fetch.go
@@ -1084,7 +1084,14 @@ func readBodyType1part(dec *imapwire.Decoder, typ string, options *Options) (*im
 		return &bs, nil
 	}
 
-	if strings.EqualFold(bs.Type, "message") && (strings.EqualFold(bs.Subtype, "rfc822") || strings.EqualFold(bs.Subtype, "global")) {
+	// message/rfc822 is body-type-msg in both revisions, so the envelope, the
+	// nested body structure and the line count always follow. message/global
+	// (RFC 6532) is body-type-msg only in RFC 9051: an IMAP4rev1 server emits
+	// it as a body-type-basic and goes straight to the extension data. Decide
+	// by what actually follows -- an envelope is a parenthesized list, so a '('
+	// means the fields are there and anything else means they are not.
+	// See https://github.com/emersion/go-imap/issues/741
+	if strings.EqualFold(bs.Type, "message") && (strings.EqualFold(bs.Subtype, "rfc822") || strings.EqualFold(bs.Subtype, "global") && dec.NextByteIs('(')) {
 		var msg imap.BodyStructureMessageRFC822
 
 		msg.Envelope, err = readEnvelope(dec, options)

--- a/internal/imapwire/decoder.go
+++ b/internal/imapwire/decoder.go
@@ -136,6 +136,19 @@ func (dec *Decoder) acceptByte(want byte) bool {
 	return true
 }
 
+// NextByteIs reports whether the next byte is want, without consuming it.
+//
+// It is a lookahead for grammars where the production depends on what follows
+// rather than on what has already been read. On a read error it returns false
+// and sets the decoder error, like any other accept.
+func (dec *Decoder) NextByteIs(want byte) bool {
+	if !dec.acceptByte(want) {
+		return false
+	}
+	dec.mustUnreadByte()
+	return true
+}
+
 // EOF returns true if end-of-file is reached.
 func (dec *Decoder) EOF() bool {
 	_, err := dec.r.ReadByte()


### PR DESCRIPTION
Adopted from upstream **[emersion/go-imap#704](https://github.com/emersion/go-imap/pull/704)** by [@andybalholm](https://github.com/andybalholm), which fixes upstream issue [#741](https://github.com/emersion/go-imap/issues/741). The Dovecot capture in the tests comes from that PR; the surrounding cases are ours.

## The bug (verified present on `sora`)

`message/global` (RFC 6532) is listed in `body-type-msg` by **RFC 9051** but not by **RFC 3501**, whose `body-type-msg` names only `message/rfc822`. So an IMAP4rev2 server follows the basic fields with envelope + nested body structure + line count, while an IMAP4rev1 server emits `message/global` as a plain `body-type-basic` and goes straight to the extension data. Dovecot does the latter.

`readBodyType1part` keyed off the subtype alone, so it read the SP after the size as the start of an envelope. Against an IMAP4rev1 server, every `FETCH BODYSTRUCTURE` carrying a `message/global` part failed — and since this is a decode error on the response, it takes down the whole FETCH, not just that part.

## Red/green test

`imapclient/bodystructure_test.go` drives `readBody` directly. Before the fix:

```
--- FAIL: TestReadBodyStructure/message/global_without_body-type-msg_fields_(IMAP4rev1)
        readBody() = in body-type-1part: imapwire: expected '(', got "N"
--- FAIL: TestReadBodyStructureDovecotMultipart
        readBody() = in body-type-mpart: in body-type-1part: imapwire: expected '(', got "N"
```

After: all pass, full `go test ./...` green. The table also pins the three cases that must **not** change — IMAP4rev2 `message/global` *with* the fields, `message/rfc822`, and `text/*` — and those three passed before the fix too, so they are genuine regression guards rather than tests written to the new behaviour.

## Review notes

- The fix probes for `(`: an envelope is a parenthesized list, so `(` means the `body-type-msg` fields are present and anything else (`NIL`, a string, end of list) means they are not. `message/rfc822` is deliberately *not* probed — it is `body-type-msg` in both revisions, so a missing envelope there is a genuine protocol error and should keep erroring.
- Go's `&&` binds tighter than `||`, so the condition reads as `message && (rfc822 || (global && NextByteIs('(')))`. Confirmed by the IMAP4rev2 and rfc822 test cases.
- `Decoder.NextByteIs` is new. Worth noting for our hardened decoder specifically: it is **accounting-neutral against `MaxSize`** — `acceptByte` increments `readBytes` and `mustUnreadByte` decrements it, so the lookahead does not consume budget. On a read error it returns false with the decoder error set, and the caller then falls through to `readBodyExt1part`, which fails on the same sticky error.