### PR TITLE
imapwire: treat a short literal as an error, not a clean EOF

### DIFF
--- a/imapserver/append_truncated_test.go
+++ b/imapserver/append_truncated_test.go
@@ -1,0 +1,143 @@
+package imapserver_test
+
+import (
+	"bufio"
+	"context"
+	"net"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/emersion/go-imap/v2"
+	"github.com/emersion/go-imap/v2/imapserver"
+	"github.com/emersion/go-imap/v2/imapserver/imapmemserver"
+)
+
+// TestAppendTruncatedLiteralIsRejected is the server-side half of the truncated
+// literal regression.
+//
+// A client announces APPEND {N} and then disappears after fewer than N bytes.
+// The literal reader used to report the underlying io.EOF verbatim, so the
+// backend's io.Copy returned successfully and the short payload was stored as a
+// complete message. The client never saw a tagged OK -- the connection was gone
+// -- so from its point of view the APPEND failed, while the mailbox had gained
+// a silently truncated copy.
+//
+// Upstream report: emersion/go-imap#650, fix proposed in emersion/go-imap#676
+// by vzeroupper.
+func TestAppendTruncatedLiteralIsRejected(t *testing.T) {
+	const (
+		username = "user"
+		password = "pass"
+		// Announced size is deliberately larger than what we send.
+		announcedSize = 200
+	)
+	partial := "From: <a@example.org>\r\nSubject: truncated\r\n\r\nhalf a mes"
+
+	memUser := imapmemserver.NewUser(username, password)
+	if err := memUser.Create(context.Background(), "INBOX", nil); err != nil {
+		t.Fatalf("Create(INBOX): %v", err)
+	}
+	memServer := imapmemserver.New()
+	memServer.AddUser(memUser)
+
+	srv := imapserver.New(&imapserver.Options{
+		NewSession: func(*imapserver.Conn) (imapserver.Session, *imapserver.GreetingData, error) {
+			return memServer.NewSession(), nil, nil
+		},
+		Caps:         imap.CapSet{imap.CapIMAP4rev1: {}, imap.CapIMAP4rev2: {}},
+		InsecureAuth: true,
+	})
+	defer srv.Close()
+
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("Listen: %v", err)
+	}
+	defer ln.Close()
+	go srv.Serve(ln)
+
+	dial := func() (net.Conn, *bufio.Reader) {
+		t.Helper()
+		conn, err := net.Dial("tcp", ln.Addr().String())
+		if err != nil {
+			t.Fatalf("Dial: %v", err)
+		}
+		if err := conn.SetDeadline(time.Now().Add(10 * time.Second)); err != nil {
+			t.Fatalf("SetDeadline: %v", err)
+		}
+		br := bufio.NewReader(conn)
+		if _, err := br.ReadString('\n'); err != nil { // greeting
+			t.Fatalf("read greeting: %v", err)
+		}
+		return conn, br
+	}
+
+	readUntilTag := func(br *bufio.Reader, tag string) string {
+		t.Helper()
+		var sb strings.Builder
+		for {
+			line, err := br.ReadString('\n')
+			if err != nil {
+				t.Fatalf("read: %v", err)
+			}
+			sb.WriteString(line)
+			if strings.HasPrefix(line, tag+" ") {
+				return sb.String()
+			}
+		}
+	}
+
+	// Announce a 200-byte literal, then send a short prefix and hang up.
+	conn, br := dial()
+	if _, err := conn.Write([]byte("a1 LOGIN " + username + " " + password + "\r\n")); err != nil {
+		t.Fatalf("write LOGIN: %v", err)
+	}
+	readUntilTag(br, "a1")
+
+	if _, err := conn.Write([]byte("a2 APPEND INBOX {" + strconv.Itoa(announcedSize) + "}\r\n")); err != nil {
+		t.Fatalf("write APPEND: %v", err)
+	}
+	line, err := br.ReadString('\n')
+	if err != nil {
+		t.Fatalf("read continuation request: %v", err)
+	}
+	if !strings.HasPrefix(line, "+") {
+		t.Fatalf("APPEND: got %q, want a continuation request", line)
+	}
+	if _, err := conn.Write([]byte(partial)); err != nil {
+		t.Fatalf("write partial literal: %v", err)
+	}
+	conn.Close()
+
+	// The server is still processing the half-delivered APPEND. Watch the
+	// mailbox for long enough that it has certainly finished and torn the
+	// connection down, failing as soon as a message shows up rather than
+	// sampling once and racing the server.
+	deadline := time.Now().Add(750 * time.Millisecond)
+	for time.Now().Before(deadline) {
+		if n := mailboxMessageCount(t, memUser); n != 0 {
+			t.Fatalf("INBOX gained %d message(s) from a truncated APPEND: the server stored %d of the %d announced bytes as a complete message", n, len(partial), announcedSize)
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+
+	if n := mailboxMessageCount(t, memUser); n != 0 {
+		t.Fatalf("INBOX has %d message(s) after a truncated APPEND, want 0: the server stored %d of the %d announced bytes as a complete message", n, len(partial), announcedSize)
+	}
+}
+
+// mailboxMessageCount reports how many messages INBOX holds, via a fresh
+// session so it never observes the torn-down connection's state.
+func mailboxMessageCount(t *testing.T, u *imapmemserver.User) int {
+	t.Helper()
+	data, err := u.Status(context.Background(), "INBOX", &imap.StatusOptions{NumMessages: true})
+	if err != nil {
+		t.Fatalf("Status(INBOX): %v", err)
+	}
+	if data.NumMessages == nil {
+		t.Fatalf("Status(INBOX): no NumMessages")
+	}
+	return int(*data.NumMessages)
+}

--- a/internal/imapwire/decoder.go
+++ b/internal/imapwire/decoder.go
@@ -601,11 +601,11 @@ func (dec *Decoder) Literal(ptr *string) bool {
 	const absoluteMaxBufferedLiteral = 4 * 1024 * 1024
 	if dec.CheckBufferedLiteralFunc != nil {
 		if err := dec.CheckBufferedLiteralFunc(lit.Size(), nonSync); err != nil {
-			lit.cancel()
+			lit.cancel(nil)
 			return false
 		}
 	} else if lit.Size() > absoluteMaxBufferedLiteral {
-		lit.cancel()
+		lit.cancel(nil)
 		return dec.returnErr(fmt.Errorf("imapwire: literal of %d bytes exceeds default buffered cap", lit.Size()))
 	}
 	var sb strings.Builder
@@ -643,7 +643,7 @@ func (dec *Decoder) LiteralReader() (lit *LiteralReader, nonSync, ok bool) {
 	lit = &LiteralReader{
 		dec:  dec,
 		size: size,
-		r:    io.LimitReader(dec.r, size),
+		r:    newLimitReader(dec.r, size),
 	}
 	return lit, nonSync, true
 }
@@ -676,14 +676,25 @@ func (lit *LiteralReader) Size() int64 {
 func (lit *LiteralReader) Read(b []byte) (int, error) {
 	n, err := lit.r.Read(b)
 	if err == io.EOF {
-		lit.cancel()
+		lit.cancel(nil)
+	} else if err != nil {
+		// Any other failure -- an i/o timeout being the common one -- breaks
+		// the literal for good. Release it and record the cause, so that later
+		// decodes report the i/o error instead of our own "cannot decode while
+		// a literal is open".
+		lit.cancel(err)
 	}
 	return n, err
 }
 
-func (lit *LiteralReader) cancel() {
+// cancel releases the literal. A non-nil err is recorded as the decoder error,
+// first one wins.
+func (lit *LiteralReader) cancel(err error) {
 	if lit.dec == nil {
 		return
+	}
+	if err != nil {
+		lit.dec.returnErr(err)
 	}
 	lit.dec.literal = false
 	lit.dec = nil

--- a/internal/imapwire/limit_reader.go
+++ b/internal/imapwire/limit_reader.go
@@ -1,0 +1,34 @@
+package imapwire
+
+import "io"
+
+// limitReader reads at most n bytes from an underlying reader.
+//
+// It behaves like io.LimitReader except for a short read: reaching the
+// underlying io.EOF before n bytes have been delivered yields
+// io.ErrUnexpectedEOF. A literal announces its exact size up front, so a peer
+// that stops early has truncated it, and reporting that as a clean io.EOF would
+// hand the caller a short value indistinguishable from a complete one.
+type limitReader struct {
+	r    io.Reader
+	left int64
+}
+
+func newLimitReader(r io.Reader, n int64) *limitReader {
+	return &limitReader{r: r, left: n}
+}
+
+func (lr *limitReader) Read(p []byte) (int, error) {
+	if lr.left <= 0 {
+		return 0, io.EOF
+	}
+	if int64(len(p)) > lr.left {
+		p = p[:lr.left]
+	}
+	n, err := lr.r.Read(p)
+	lr.left -= int64(n)
+	if err == io.EOF && lr.left > 0 {
+		err = io.ErrUnexpectedEOF
+	}
+	return n, err
+}

--- a/internal/imapwire/literal_test.go
+++ b/internal/imapwire/literal_test.go
@@ -1,0 +1,124 @@
+package imapwire
+
+import (
+	"bufio"
+	"errors"
+	"io"
+	"strings"
+	"testing"
+)
+
+// errAfterReader yields data, then fails every subsequent read with err.
+type errAfterReader struct {
+	data string
+	err  error
+	off  int
+}
+
+func (r *errAfterReader) Read(p []byte) (int, error) {
+	if r.off >= len(r.data) {
+		return 0, r.err
+	}
+	n := copy(p, r.data[r.off:])
+	r.off += n
+	return n, nil
+}
+
+// TestLiteralReaderTruncated is a regression test for a short literal being
+// reported as a complete one.
+//
+// A peer announces {N} and then goes away after fewer than N bytes. The literal
+// was wrapped in io.LimitReader, which reports the underlying io.EOF verbatim,
+// so the reader looked like it had delivered a complete value: io.ReadAll
+// returned the short payload with a nil error and the caller had no way to tell
+// it apart from a full read.
+//
+// That is silent data truncation in both directions. A client hands a truncated
+// message body to the application as if it were whole; a server accepts a
+// truncated APPEND literal and stores it as a complete message.
+//
+// Upstream report: emersion/go-imap#650, fix proposed in emersion/go-imap#676
+// by vzeroupper.
+func TestLiteralReaderTruncated(t *testing.T) {
+	dec := NewDecoder(bufio.NewReader(strings.NewReader("{10}\r\nabc")), ConnSideClient)
+
+	lit, _, ok := dec.LiteralReader()
+	if !ok {
+		t.Fatalf("LiteralReader() = %v", dec.Err())
+	}
+	if lit.Size() != 10 {
+		t.Fatalf("Size() = %v, want 10", lit.Size())
+	}
+
+	b, err := io.ReadAll(lit)
+	if !errors.Is(err, io.ErrUnexpectedEOF) {
+		t.Fatalf("io.ReadAll(lit) = %q, %v; want io.ErrUnexpectedEOF (literal truncated at %d of %d bytes)", b, err, len(b), lit.Size())
+	}
+}
+
+// TestLiteralReaderComplete pins the case that must not change: a literal that
+// delivers exactly the announced number of bytes still ends in a clean io.EOF.
+func TestLiteralReaderComplete(t *testing.T) {
+	dec := NewDecoder(bufio.NewReader(strings.NewReader("{3}\r\nabcRest\r\n")), ConnSideClient)
+
+	lit, _, ok := dec.LiteralReader()
+	if !ok {
+		t.Fatalf("LiteralReader() = %v", dec.Err())
+	}
+
+	b, err := io.ReadAll(lit)
+	if err != nil {
+		t.Fatalf("io.ReadAll(lit) = %v, want nil", err)
+	}
+	if string(b) != "abc" {
+		t.Fatalf("io.ReadAll(lit) = %q, want %q", b, "abc")
+	}
+	if dec.Err() != nil {
+		t.Fatalf("Err() = %v, want nil", dec.Err())
+	}
+	// The literal must be released so the decoder can carry on with the
+	// response, and it must not have eaten the bytes that follow it.
+	if dec.literal {
+		t.Error("decoder still has a literal open after a complete read")
+	}
+	var atom string
+	if !dec.Atom(&atom) || atom != "Rest" {
+		t.Errorf("Atom() = %q, %v; want %q", atom, dec.Err(), "Rest")
+	}
+}
+
+// TestLiteralReaderNonEOFError is a regression test for a non-EOF read failure
+// leaving the decoder wedged.
+//
+// LiteralReader.Read released the literal only on io.EOF, so any other failure
+// (an i/o timeout being the common one) left dec.literal set and dec.err unset.
+// Every later decode then failed with "cannot decode while a literal is open" —
+// a message about our own state — instead of the i/o error that actually broke
+// the connection.
+func TestLiteralReaderNonEOFError(t *testing.T) {
+	errBoom := errors.New("boom")
+	dec := NewDecoder(bufio.NewReader(&errAfterReader{data: "{10}\r\nabc", err: errBoom}), ConnSideClient)
+
+	lit, _, ok := dec.LiteralReader()
+	if !ok {
+		t.Fatalf("LiteralReader() = %v", dec.Err())
+	}
+
+	if _, err := io.ReadAll(lit); !errors.Is(err, errBoom) {
+		t.Fatalf("io.ReadAll(lit) = %v, want %v", err, errBoom)
+	}
+
+	if dec.literal {
+		t.Error("decoder still has a literal open after a failed read")
+	}
+	if !errors.Is(dec.Err(), errBoom) {
+		t.Errorf("Err() = %v, want %v", dec.Err(), errBoom)
+	}
+
+	// The wedged decoder reported its own state instead of the real cause.
+	var atom string
+	dec.Atom(&atom)
+	if err := dec.Err(); err != nil && strings.Contains(err.Error(), "cannot decode while a literal is open") {
+		t.Errorf("Err() = %v, want the underlying i/o error", err)
+	}
+}


### PR DESCRIPTION
Adopted from upstream **[emersion/go-imap#676](https://github.com/emersion/go-imap/pull/676)** by [@vzeroupper](https://github.com/vzeroupper), which addresses upstream issue [#650](https://github.com/emersion/go-imap/issues/650). Tests are ours.

## The bug (verified present on `sora`) — server-side data corruption

A literal announces its exact size up front, so a peer that stops early has **truncated** it. `LiteralReader` wrapped the connection in `io.LimitReader`, which reports the underlying `io.EOF` verbatim — so a short literal was indistinguishable from a complete one, and `io.Copy`/`io.ReadAll` returned the partial payload with a **nil error**.

The consequence on the server is worse than the upstream report describes. `handleAppend` hands the literal straight to `Session.Append`, whose `io.Copy` succeeded on the fragment, so **the truncated message was committed to the mailbox**:

```
2026/08/15 02:05:04 handling APPEND command (remote 127.0.0.1:49517): unexpected EOF
--- FAIL: TestAppendTruncatedLiteralIsRejected (0.02s)
    INBOX gained 1 message(s) from a truncated APPEND: the server stored 55 of
    the 200 announced bytes as a complete message
```

Note the connection error *was* logged — but only after the backend had already stored the fragment. And since the client never received the tagged OK (its connection was gone), it has every reason to retry, ending up with both the truncated copy and the real one. Client-side, the same flaw hands a truncated message body to the application as if complete.

Worth noting: the existing `"APPEND failed: connection closed before the message was fully received"` branch in [imapserver/append.go](imapserver/append.go) was already written expecting `io.ErrUnexpectedEOF` from a truncated literal — its comment says so explicitly. It just never actually saw that error. This change makes that code path real.

## Second bug: a wedged decoder after a non-EOF read failure

`LiteralReader.Read` called `cancel` only on `io.EOF`, so an i/o timeout mid-literal left `dec.literal` set and `dec.err` unset. Every later decode then failed with `imapwire: cannot decode while a literal is open` — our own state, not the i/o error that actually broke the connection. `cancel` now takes the cause and records it via `returnErr`, so first-real-error wins.

## Red/green

| Test | Without fix | With fix |
|---|---|---|
| `TestAppendTruncatedLiteralIsRejected` | `INBOX gained 1 message(s)` | pass |
| `TestLiteralReaderTruncated` | `io.ReadAll(lit) = "abc", <nil>` | pass |
| `TestLiteralReaderNonEOFError` | `Err() = imapwire: cannot decode while a literal is open` | pass |
| `TestLiteralReaderComplete` (guard) | pass | pass |

Full `go test ./...` green, and `-race` green on `imapclient`, `imapserver`, `internal/imapwire`.

## Review notes — what I changed vs upstream, and what I left out

- **`limitReader` kept minimal.** Upstream's version also returns `io.EOF` eagerly on the call that delivers the last byte, and takes `int` (a downcast from the `int64` size). Mine is `io.LimitReader` semantics with exactly one difference — an early underlying `io.EOF` becomes `io.ErrUnexpectedEOF` — and stays `int64`. Smaller behavioural delta on a hot path.
- **`cancel` uses `returnErr`, not `dec.err = err`** as upstream does, so it respects the decoder's existing first-error-wins rule.
- **Not adopted: the `done chan error` rework in `handleFetch`.** That part of #676 fixed a client *hang*, which `sora` already fixes at [imapclient/fetch.go:1422](imapclient/fetch.go#L1422) by closing the channel on any error rather than only `io.EOF`. With `cancel` now recording the cause, the decode that follows surfaces the same error anyway, so the rework would be diff without behaviour.
- **Caveat worth stating:** the server-side fix works because the backend propagates the read failure out of `Append` — `imapmemserver` does. A backend that swallows `io.Copy` errors would still commit a fragment. This change gives backends the correct signal, which they previously never received; it can't force them to check it.