### PR TITLE
imapclient: recover from stray quotes in BODYSTRUCTURE strings

### DIFF
--- a/imapclient/bodystructure_quotes_test.go
+++ b/imapclient/bodystructure_quotes_test.go
@@ -1,0 +1,135 @@
+package imapclient
+
+import (
+	"bufio"
+	"strings"
+	"testing"
+
+	"github.com/emersion/go-imap/v2"
+	"github.com/emersion/go-imap/v2/internal/imapwire"
+)
+
+// TestReadBodyStructureStrayQuotes is a regression test for one malformed field
+// failing an entire FETCH response.
+//
+// 163.com writes an empty body-fld-desc as "" "" -- four quote bytes, which is
+// not a valid quoted string. Quoted stopped at the second quote and left the
+// other two on the wire, so every following field decoded against the wrong
+// offsets and the response died with
+//
+//	in body-type-mpart: in body-type-1part: imapwire: expected SP, got "\""
+//
+// The description is cosmetic, but the failure took down the whole response,
+// including BODY[] of every message in it.
+//
+// Upstream report: emersion/go-imap#659, fix proposed in emersion/go-imap#679
+// by xiaoquanidea.
+func TestReadBodyStructureStrayQuotes(t *testing.T) {
+	// Verbatim from the upstream report.
+	const data = `(("text" "html" ("charset" "UTF-8") NIL NIL "quoted-printable" 1224 16)("application" "octet-stream" ("name" "2154973550.pdf") NIL """" "base64" 65322) "MIXED")`
+
+	dec := imapwire.NewDecoder(bufio.NewReader(strings.NewReader(data)), imapwire.ConnSideClient)
+	bs, err := readBody(dec, &Options{})
+	if err != nil {
+		t.Fatalf("readBody() = %v", err)
+	}
+
+	mp, ok := bs.(*imap.BodyStructureMultiPart)
+	if !ok {
+		t.Fatalf("readBody() = %T, want *imap.BodyStructureMultiPart", bs)
+	}
+	if mp.Subtype != "MIXED" {
+		t.Errorf("Subtype = %q, want %q", mp.Subtype, "MIXED")
+	}
+	if len(mp.Children) != 2 {
+		t.Fatalf("len(Children) = %v, want 2", len(mp.Children))
+	}
+
+	// The part carrying the malformed description must still decode, and the
+	// fields after it must not be shifted.
+	pdf, ok := mp.Children[1].(*imap.BodyStructureSinglePart)
+	if !ok {
+		t.Fatalf("Children[1] = %T, want *imap.BodyStructureSinglePart", mp.Children[1])
+	}
+	if pdf.Description != "" {
+		t.Errorf("Description = %q, want empty", pdf.Description)
+	}
+	if pdf.Encoding != "base64" {
+		t.Errorf("Encoding = %q, want %q", pdf.Encoding, "base64")
+	}
+	if pdf.Size != 65322 {
+		t.Errorf("Size = %v, want 65322", pdf.Size)
+	}
+	if got := pdf.Params["name"]; got != "2154973550.pdf" {
+		t.Errorf("Params[name] = %q, want %q", got, "2154973550.pdf")
+	}
+}
+
+// TestReadBodyStructureStrayQuotesInParam covers the same malformation in a
+// body-fld-param value, and the trailing-')' position that a fixed two-byte
+// lookahead would miss.
+func TestReadBodyStructureStrayQuotesInParam(t *testing.T) {
+	const data = `("application" "octet-stream" ("name" """") NIL NIL "base64" 42)`
+
+	dec := imapwire.NewDecoder(bufio.NewReader(strings.NewReader(data)), imapwire.ConnSideClient)
+	bs, err := readBody(dec, &Options{})
+	if err != nil {
+		t.Fatalf("readBody() = %v", err)
+	}
+
+	sp, ok := bs.(*imap.BodyStructureSinglePart)
+	if !ok {
+		t.Fatalf("readBody() = %T, want *imap.BodyStructureSinglePart", bs)
+	}
+	if got, ok := sp.Params["name"]; !ok || got != "" {
+		t.Errorf("Params[name] = %q (present=%v), want empty and present", got, ok)
+	}
+	if sp.Encoding != "base64" {
+		t.Errorf("Encoding = %q, want %q", sp.Encoding, "base64")
+	}
+	if sp.Size != 42 {
+		t.Errorf("Size = %v, want 42", sp.Size)
+	}
+}
+
+// TestReadBodyStructureQuotingUnaffected pins conformant input: the recovery
+// must never fire on a well-formed response. An escaped quote inside a
+// description, and a genuinely empty description, must both survive verbatim.
+func TestReadBodyStructureQuotingUnaffected(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		data string
+		want string
+	}{
+		{
+			name: "escaped quote in description",
+			data: `("text" "plain" NIL NIL "say \"hi\"" "7bit" 10 1)`,
+			want: `say "hi"`,
+		},
+		{
+			name: "empty description",
+			data: `("text" "plain" NIL NIL "" "7bit" 10 1)`,
+			want: "",
+		},
+		{
+			name: "ordinary description",
+			data: `("text" "plain" NIL NIL "Compiler diff" "7bit" 10 1)`,
+			want: "Compiler diff",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			dec := imapwire.NewDecoder(bufio.NewReader(strings.NewReader(tc.data)), imapwire.ConnSideClient)
+			bs, err := readBody(dec, &Options{})
+			if err != nil {
+				t.Fatalf("readBody() = %v", err)
+			}
+			sp := bs.(*imap.BodyStructureSinglePart)
+			if sp.Description != tc.want {
+				t.Errorf("Description = %q, want %q", sp.Description, tc.want)
+			}
+			if sp.Encoding != "7bit" || sp.Size != 10 {
+				t.Errorf("Encoding = %q, Size = %v; want 7bit, 10 (fields shifted)", sp.Encoding, sp.Size)
+			}
+		})
+	}
+}

--- a/imapclient/fetch.go
+++ b/imapclient/fetch.go
@@ -1064,7 +1064,7 @@ func readBodyType1part(dec *imapwire.Decoder, typ string, options *Options) (*im
 	}
 
 	var description string
-	if !dec.ExpectSP() || !dec.ExpectNString(&bs.ID) || !dec.ExpectSP() || !dec.ExpectNString(&description) || !dec.ExpectSP() || !dec.ExpectNString(&bs.Encoding) || !dec.ExpectSP() || !dec.ExpectBodyFldOctets(&bs.Size) {
+	if !dec.ExpectSP() || !dec.ExpectNString(&bs.ID) || !dec.ExpectSP() || !dec.ExpectNStringAllowStrayQuotes(&description) || !dec.ExpectSP() || !dec.ExpectNString(&bs.Encoding) || !dec.ExpectSP() || !dec.ExpectBodyFldOctets(&bs.Size) {
 		return nil, dec.Err()
 	}
 
@@ -1264,7 +1264,7 @@ func readBodyFldParam(dec *imapwire.Decoder, options *Options) (map[string]strin
 	)
 	err := dec.ExpectNList(func() error {
 		var s string
-		if !dec.ExpectString(&s) {
+		if !dec.ExpectStringAllowStrayQuotes(&s) {
 			return dec.Err()
 		}
 

--- a/internal/imapwire/decoder.go
+++ b/internal/imapwire/decoder.go
@@ -393,6 +393,15 @@ func (dec *Decoder) ExpectModSeq(ptr *uint64) bool {
 }
 
 func (dec *Decoder) Quoted(ptr *string) bool {
+	return dec.quoted(ptr, false)
+}
+
+// maxStrayQuotes bounds the recovery in quoted: the malformation seen in the
+// wild is a doubled empty string ("" written as """"), so two is enough, and a
+// bound keeps a hostile peer from making us discard an unbounded run.
+const maxStrayQuotes = 2
+
+func (dec *Decoder) quoted(ptr *string, allowStrayQuotes bool) bool {
 	if !dec.Special('"') {
 		return false
 	}
@@ -416,8 +425,56 @@ func (dec *Decoder) Quoted(ptr *string) bool {
 
 		sb.WriteByte(ch)
 	}
+
+	if allowStrayQuotes {
+		// A conformant peer always follows the closing quote with a delimiter
+		// (SP, '(', ')', ']' or CRLF), so a '"' here means the peer emitted a
+		// malformed token and the rest of the response would decode against the
+		// wrong offsets. Swallowing the stray run costs nothing on conformant
+		// input and keeps one bad field from failing the whole response.
+		//
+		// Peek rather than readByte: hitting the end of the input here is not
+		// an error, and must not set the decoder error.
+		for i := 0; i < maxStrayQuotes; i++ {
+			b, err := dec.r.Peek(1)
+			if err != nil || b[0] != '"' {
+				break
+			}
+			dec.r.Discard(1)
+			dec.readBytes++
+		}
+	}
+
 	*ptr = sb.String()
 	return true
+}
+
+// ExpectNStringAllowStrayQuotes is ExpectNString, tolerating a malformed quoted
+// string that carries stray trailing quotes. Use it only for fields where a
+// non-conformant server has been observed in the wild and the value is not
+// load-bearing.
+func (dec *Decoder) ExpectNStringAllowStrayQuotes(ptr *string) bool {
+	var s string
+	if dec.Atom(&s) {
+		if !dec.Expect(s == "NIL", "nstring") {
+			return false
+		}
+		*ptr = ""
+		return true
+	}
+	if dec.quoted(ptr, true) || dec.Literal(ptr) {
+		return true
+	}
+	return dec.Expect(false, "string")
+}
+
+// ExpectStringAllowStrayQuotes is ExpectString with the same tolerance as
+// ExpectNStringAllowStrayQuotes.
+func (dec *Decoder) ExpectStringAllowStrayQuotes(ptr *string) bool {
+	if dec.quoted(ptr, true) || dec.Literal(ptr) {
+		return true
+	}
+	return dec.Expect(false, "string")
 }
 
 func (dec *Decoder) ExpectAString(ptr *string) bool {


### PR DESCRIPTION
Adopted from upstream **[emersion/go-imap#679](https://github.com/emersion/go-imap/pull/679)** by [@xiaoquanidea](https://github.com/xiaoquanidea), which fixes upstream issue [#659](https://github.com/emersion/go-imap/issues/659). Tests are ours, and the recovery rule differs from upstream's — see below.

## The bug (verified present on `sora`)

163.com writes an empty `body-fld-desc` as four quote bytes (`""""`), which is not a valid quoted string. `Quoted` stopped at the second quote and left the other two on the wire, so every following field decoded against the wrong offsets:

```
in body-type-mpart: in body-type-1part: imapwire: expected SP, got "\""
```

The description itself is cosmetic. The cost was not — **one malformed field failed the entire FETCH response**, taking `BODY[]` of every message in it down with it. Reproduced against the verbatim capture from the upstream report.

## Why this leniency is safe

A conformant peer always follows a closing quote with a delimiter — SP, `(`, `)`, `]`, or CRLF. A `"` in that position is unambiguously a peer bug, so there is no conformant input where the recovery can fire. Three guard cases pin that (escaped quote inside a description, genuinely empty description, ordinary description); they pass **both** before and after the change.

Scope is kept deliberately narrow: only `body-fld-desc` and `body-fld-param` values, the two fields where the malformation has been observed. Everything else keeps parsing strictly.

Two details that matter for our hardened decoder:
- The recovery **peeks** rather than reads, so hitting the end of input does not set the decoder error.
- It is **bounded to two stray quotes**, so a hostile peer cannot make us discard an unbounded run. Discarded bytes are still counted against `MaxSize`.

## Deviation from upstream

Upstream peeks a fixed two bytes and discards only if both are quotes. That misses `""""` at the end of a list — in `("name" """")` the second peeked byte is `)`, so nothing is discarded and the parser stays desynced. Consuming a bounded run one byte at a time handles both positions. `TestReadBodyStructureStrayQuotesInParam` covers exactly that case.

## Red/green

| Test | Without fix | With fix |
|---|---|---|
| `TestReadBodyStructureStrayQuotes` (163.com capture) | `expected SP, got "\""` | pass |
| `TestReadBodyStructureStrayQuotesInParam` | `expected SP, got "\""` | pass |
| `TestReadBodyStructureQuotingUnaffected` (3 guards) | pass | pass |

Full `go test ./...` green, `-race` green.