### PR TITLE
imapclient: send HEADER.FIELDS names as atoms

### DIFF
--- a/imapclient/fetch.go
+++ b/imapclient/fetch.go
@@ -148,7 +148,12 @@ func writeFetchItemBodySection(enc *imapwire.Encoder, item *imap.FetchItemBodySe
 
 		if len(headerList) > 0 {
 			enc.SP().List(len(headerList), func(i int) {
-				enc.String(headerList[i])
+				// header-fld-name is an astring, so a quoted name is legal, but
+				// some servers only handle the atom form: mailo.com answers
+				// BODY[HEADER.FIELDS ("Message-ID")] with an empty body while
+				// answering the unquoted form correctly.
+				// See https://github.com/emersion/go-imap/pull/589
+				enc.AString(headerList[i])
 			})
 		}
 	}

--- a/imapclient/fetch_encode_test.go
+++ b/imapclient/fetch_encode_test.go
@@ -1,0 +1,107 @@
+package imapclient
+
+import (
+	"bufio"
+	"bytes"
+	"testing"
+
+	"github.com/emersion/go-imap/v2"
+	"github.com/emersion/go-imap/v2/internal/imapwire"
+)
+
+func encodeBodySection(item *imap.FetchItemBodySection) string {
+	buf := &bytes.Buffer{}
+	bw := bufio.NewWriter(buf)
+	enc := imapwire.NewEncoder(bw, imapwire.ConnSideClient)
+	writeFetchItemBodySection(enc, item)
+	bw.Flush()
+	return buf.String()
+}
+
+// TestWriteFetchItemBodySectionHeaderFields pins how header field names go out
+// on the wire.
+//
+// header-fld-name is an astring, so both "Message-ID" and Message-ID are legal,
+// but the atom form is what every widely deployed client sends and therefore
+// the better-tested path through a server's parser. mailo.com answers
+// BODY[HEADER.FIELDS ("Message-ID")] with an empty body while answering the
+// unquoted form correctly.
+//
+// Upstream: emersion/go-imap#589 by rakoo.
+func TestWriteFetchItemBodySectionHeaderFields(t *testing.T) {
+	tests := []struct {
+		name string
+		item *imap.FetchItemBodySection
+		want string
+	}{
+		{
+			name: "header fields as atoms",
+			item: &imap.FetchItemBodySection{Specifier: imap.PartSpecifierHeader, HeaderFields: []string{"Message-ID", "Subject"}},
+			want: "BODY[HEADER.FIELDS (Message-ID Subject)]",
+		},
+		{
+			name: "header fields not",
+			item: &imap.FetchItemBodySection{Specifier: imap.PartSpecifierHeader, HeaderFieldsNot: []string{"Received"}},
+			want: "BODY[HEADER.FIELDS.NOT (Received)]",
+		},
+		{
+			name: "peek",
+			item: &imap.FetchItemBodySection{Peek: true, Specifier: imap.PartSpecifierHeader, HeaderFields: []string{"From"}},
+			want: "BODY.PEEK[HEADER.FIELDS (From)]",
+		},
+		{
+			// Not a valid atom, so it must keep the quoted form rather than
+			// being written bare and corrupting the command.
+			name: "name needing quotes falls back to a string",
+			item: &imap.FetchItemBodySection{Specifier: imap.PartSpecifierHeader, HeaderFields: []string{"X Weird"}},
+			want: `BODY[HEADER.FIELDS ("X Weird")]`,
+		},
+		{
+			name: "name with a parenthesis falls back to a string",
+			item: &imap.FetchItemBodySection{Specifier: imap.PartSpecifierHeader, HeaderFields: []string{"X-(a)"}},
+			want: `BODY[HEADER.FIELDS ("X-(a)")]`,
+		},
+		{
+			name: "whole message unaffected",
+			item: &imap.FetchItemBodySection{},
+			want: "BODY[]",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := encodeBodySection(tc.item); got != tc.want {
+				t.Errorf("writeFetchItemBodySection() = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestEncoderAString(t *testing.T) {
+	tests := []struct {
+		in   string
+		want string
+	}{
+		{"Message-ID", "Message-ID"},
+		{"Subject", "Subject"},
+		{"X-Custom_Header.1", "X-Custom_Header.1"},
+		{"", `""`},
+		{"has space", `"has space"`},
+		{`has"quote`, `"has\"quote"`},
+		{"has(paren", `"has(paren"`},
+		{"has]bracket", `"has]bracket"`},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.in, func(t *testing.T) {
+			buf := &bytes.Buffer{}
+			bw := bufio.NewWriter(buf)
+			enc := imapwire.NewEncoder(bw, imapwire.ConnSideClient)
+			enc.AString(tc.in)
+			bw.Flush()
+			if got := buf.String(); got != tc.want {
+				t.Errorf("AString(%q) = %v, want %v", tc.in, got, tc.want)
+			}
+		})
+	}
+}

--- a/imapclient/fetch_headerfields_test.go
+++ b/imapclient/fetch_headerfields_test.go
@@ -1,0 +1,91 @@
+package imapclient_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/emersion/go-imap/v2"
+)
+
+// TestFetchHeaderFieldsRoundTrip exercises BODY[HEADER.FIELDS (...)] end to end
+// against our own server, so the unquoted header names the client now emits are
+// proven to parse on the receiving side and to select the right headers.
+//
+// There was no end-to-end coverage of HEADER.FIELDS before, which is why the
+// encoding could be changed without anything noticing.
+func TestFetchHeaderFieldsRoundTrip(t *testing.T) {
+	client, server := newClientServerPair(t, imap.ConnStateSelected)
+	defer client.Close()
+	defer server.Close()
+
+	seqSet := imap.SeqSetNum(1)
+	fetchOptions := &imap.FetchOptions{
+		BodySection: []*imap.FetchItemBodySection{{
+			Specifier:    imap.PartSpecifierHeader,
+			HeaderFields: []string{"Message-Id", "Content-Type"},
+		}},
+	}
+
+	messages, err := client.Fetch(seqSet, fetchOptions).Collect()
+	if err != nil {
+		t.Fatalf("Fetch().Collect() = %v", err)
+	}
+	if len(messages) != 1 {
+		t.Fatalf("len(messages) = %v, want 1", len(messages))
+	}
+
+	var body string
+	for _, buf := range messages[0].BodySection {
+		body = string(buf.Bytes)
+	}
+	if body == "" {
+		t.Fatal("no body section returned for HEADER.FIELDS")
+	}
+
+	// The requested headers must be there...
+	for _, want := range []string{"Message-Id:", "Content-Type:"} {
+		if !strings.Contains(body, want) {
+			t.Errorf("body section %q does not contain %q", body, want)
+		}
+	}
+	// ...and the unrequested ones must not, which is what proves the field
+	// list was actually parsed rather than ignored.
+	for _, notWant := range []string{"MIME-Version:", "Content-Transfer-Encoding:"} {
+		if strings.Contains(body, notWant) {
+			t.Errorf("body section %q contains unrequested header %q", body, notWant)
+		}
+	}
+}
+
+// TestFetchHeaderFieldsNotRoundTrip is the HEADER.FIELDS.NOT counterpart.
+func TestFetchHeaderFieldsNotRoundTrip(t *testing.T) {
+	client, server := newClientServerPair(t, imap.ConnStateSelected)
+	defer client.Close()
+	defer server.Close()
+
+	fetchOptions := &imap.FetchOptions{
+		BodySection: []*imap.FetchItemBodySection{{
+			Specifier:       imap.PartSpecifierHeader,
+			HeaderFieldsNot: []string{"Message-Id"},
+		}},
+	}
+
+	messages, err := client.Fetch(imap.SeqSetNum(1), fetchOptions).Collect()
+	if err != nil {
+		t.Fatalf("Fetch().Collect() = %v", err)
+	}
+	if len(messages) != 1 {
+		t.Fatalf("len(messages) = %v, want 1", len(messages))
+	}
+
+	var body string
+	for _, buf := range messages[0].BodySection {
+		body = string(buf.Bytes)
+	}
+	if strings.Contains(body, "Message-Id:") {
+		t.Errorf("body section %q contains the excluded header Message-Id", body)
+	}
+	if !strings.Contains(body, "Content-Type:") {
+		t.Errorf("body section %q does not contain Content-Type:", body)
+	}
+}

--- a/internal/imapwire/encoder.go
+++ b/internal/imapwire/encoder.go
@@ -107,6 +107,34 @@ func (enc *Encoder) String(s string) *Encoder {
 	return enc.Quoted(s)
 }
 
+// AString writes an astring, preferring the bare atom form when the value
+// allows it.
+//
+// Both forms are valid, but the atom form is what every widely deployed client
+// emits, so it is the better-tested path through a server's parser. Values that
+// are not valid atoms fall back to String.
+func (enc *Encoder) AString(s string) *Encoder {
+	if isAtom(s) {
+		return enc.Atom(s)
+	}
+	return enc.String(s)
+}
+
+// isAtom reports whether s can be written as a bare atom. ']' is excluded --
+// astring-char admits it but atom-char does not, so such values take the
+// quoted path.
+func isAtom(s string) bool {
+	if s == "" {
+		return false
+	}
+	for i := 0; i < len(s); i++ {
+		if !IsAtomChar(s[i]) {
+			return false
+		}
+	}
+	return true
+}
+
 func (enc *Encoder) validQuoted(s string) bool {
 	if len(s) > 4096 {
 		return false


### PR DESCRIPTION
Adopted from upstream **[emersion/go-imap#589](https://github.com/emersion/go-imap/pull/589)** by [@rakoo](https://github.com/rakoo). Tests are ours, and the encoding is gated differently — see below.

## This one is interop, not a bug

Calling it out up front since the loop's rule is red/green for bugs: the previous output was **RFC-conformant**. `header-fld-name` is an `astring`, so `"Message-ID"` and `Message-ID` are both legal. The atom form is simply what every widely deployed client emits, which makes it the better-tested path through a server's parser. mailo.com answers `BODY[HEADER.FIELDS ("Message-ID")]` with an empty body while answering the unquoted form correctly.

Before → after:

```
BODY[HEADER.FIELDS ("Message-ID" "Subject")]     →  BODY[HEADER.FIELDS (Message-ID Subject)]
BODY[HEADER.FIELDS.NOT ("Received")]             →  BODY[HEADER.FIELDS.NOT (Received)]
BODY.PEEK[HEADER.FIELDS ("From")]                →  BODY.PEEK[HEADER.FIELDS (From)]
```

## Deviation from upstream

Upstream writes `enc.Atom(...)` unconditionally. That emits a **syntactically invalid command** for any header name that is not a valid atom — `HeaderFields: []string{"X Weird"}` would go out as `BODY[HEADER.FIELDS (X Weird)]`, i.e. two fields.

This PR adds `Encoder.AString`, which writes the atom form when the value is a valid atom and falls back to `String` otherwise. `]` is treated as needing the quoted form too, since `astring-char` admits it but `atom-char` does not. `TestEncoderAString` pins all of that.

## Testing

Since there is no red/green pair for an interop change, it comes with an **end-to-end round trip** instead. HEADER.FIELDS had **no end-to-end coverage at all** before this — which is precisely why the wire encoding could be changed without anything noticing.

`TestFetchHeaderFieldsRoundTrip` / `TestFetchHeaderFieldsNotRoundTrip` drive a real FETCH against our own server and assert both that the requested headers come back **and that the unrequested ones do not** — the negative half is what proves the field list was actually parsed rather than ignored. This also confirms our server accepts the new unquoted form.

Full `go test ./...` green, `-race` green on `imapclient` and `imapserver`.