### PR TITLE
imapserver: resolve "*" in a sequence set against the client's view

### DIFF
--- a/imapserver/imapmemserver/mailbox.go
+++ b/imapserver/imapmemserver/mailbox.go
@@ -813,7 +813,10 @@ func (mbox *MailboxView) staticNumSet(numSet imap.NumSet) imap.NumSet {
 
 	switch numSet := numSet.(type) {
 	case imap.SeqSet:
-		max := uint32(len(mbox.l))
+		// "*" is the largest sequence number the client can name, which is a
+		// property of its view: pending appends are not addressable yet, and
+		// pending expunges still are.
+		max := mbox.tracker.EncodeNumMessages()
 		for i := range numSet {
 			r := &numSet[i]
 			staticNumRange(&r.Start, &r.Stop, max)

--- a/imapserver/seqset_star_test.go
+++ b/imapserver/seqset_star_test.go
@@ -1,0 +1,195 @@
+package imapserver_test
+
+import (
+	"bufio"
+	"context"
+	"net"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/emersion/go-imap/v2"
+	"github.com/emersion/go-imap/v2/imapserver"
+	"github.com/emersion/go-imap/v2/imapserver/imapmemserver"
+)
+
+const starTestMessage = "From: <a@example.org>\r\nSubject: hi\r\n\r\nbody\r\n"
+
+type rawConn struct {
+	t  *testing.T
+	c  net.Conn
+	br *bufio.Reader
+}
+
+func (rc *rawConn) send(s string) {
+	rc.t.Helper()
+	if _, err := rc.c.Write([]byte(s + "\r\n")); err != nil {
+		rc.t.Fatalf("write %q: %v", s, err)
+	}
+}
+
+// readUntilTag returns every line up to and including the tagged completion.
+func (rc *rawConn) readUntilTag(tag string) []string {
+	rc.t.Helper()
+	var lines []string
+	for {
+		line, err := rc.br.ReadString('\n')
+		if err != nil {
+			rc.t.Fatalf("read (waiting for %v): %v", tag, err)
+		}
+		line = strings.TrimRight(line, "\r\n")
+		lines = append(lines, line)
+		if strings.HasPrefix(line, tag+" ") {
+			return lines
+		}
+	}
+}
+
+func (rc *rawConn) appendMessage(tag, mailbox string) {
+	rc.t.Helper()
+	rc.send(tag + " APPEND " + mailbox + " {" + strconv.Itoa(len(starTestMessage)) + "}")
+	line, err := rc.br.ReadString('\n')
+	if err != nil {
+		rc.t.Fatalf("read continuation request: %v", err)
+	}
+	if !strings.HasPrefix(line, "+") {
+		rc.t.Fatalf("APPEND: got %q, want a continuation request", line)
+	}
+	if _, err := rc.c.Write([]byte(starTestMessage + "\r\n")); err != nil {
+		rc.t.Fatalf("write literal: %v", err)
+	}
+	resp := rc.readUntilTag(tag)
+	if !strings.Contains(resp[len(resp)-1], "OK") {
+		rc.t.Fatalf("APPEND = %q, want OK", resp[len(resp)-1])
+	}
+}
+
+// TestSeqSetStarUsesClientView is a regression test for '*' in a sequence set
+// resolving against the server's message count instead of the client's.
+//
+// Expunges are held back from a session until it can safely receive them, so a
+// session's view can legitimately contain MORE messages than the mailbox does.
+// Resolving '*' against the server-side count then produces a range that is too
+// short, and messages the client can still address are silently skipped:
+// STORE 1:* quietly does nothing to them and reports OK.
+//
+// The reverse direction -- a message appended but not yet announced -- is
+// already handled, because forEachLocked drops any message whose
+// SessionTracker.EncodeSeqNum is 0. That guard cannot help here: these messages
+// have perfectly good client sequence numbers, they just sit above the
+// truncated range.
+//
+// RFC 9051 Section 2.3.1.2: '*' is "the largest number in use", a property of
+// the client's view of the mailbox.
+//
+// Upstream: emersion/go-imap#586 by emersion.
+func TestSeqSetStarUsesClientView(t *testing.T) {
+	const (
+		username = "user"
+		password = "pass"
+	)
+
+	memUser := imapmemserver.NewUser(username, password)
+	if err := memUser.Create(context.Background(), "INBOX", nil); err != nil {
+		t.Fatalf("Create(INBOX): %v", err)
+	}
+	memServer := imapmemserver.New()
+	memServer.AddUser(memUser)
+
+	srv := imapserver.New(&imapserver.Options{
+		NewSession: func(*imapserver.Conn) (imapserver.Session, *imapserver.GreetingData, error) {
+			return memServer.NewSession(), nil, nil
+		},
+		Caps:         imap.CapSet{imap.CapIMAP4rev1: {}, imap.CapIMAP4rev2: {}},
+		InsecureAuth: true,
+	})
+	defer srv.Close()
+
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("Listen: %v", err)
+	}
+	defer ln.Close()
+	go srv.Serve(ln)
+
+	dial := func() *rawConn {
+		t.Helper()
+		conn, err := net.Dial("tcp", ln.Addr().String())
+		if err != nil {
+			t.Fatalf("Dial: %v", err)
+		}
+		t.Cleanup(func() { conn.Close() })
+		if err := conn.SetDeadline(time.Now().Add(10 * time.Second)); err != nil {
+			t.Fatalf("SetDeadline: %v", err)
+		}
+		rc := &rawConn{t: t, c: conn, br: bufio.NewReader(conn)}
+		if _, err := rc.br.ReadString('\n'); err != nil { // greeting
+			t.Fatalf("read greeting: %v", err)
+		}
+		rc.send("x LOGIN " + username + " " + password)
+		rc.readUntilTag("x")
+		return rc
+	}
+
+	a, b := dial(), dial()
+
+	// Three messages, and A selects so its view is exactly those three.
+	b.appendMessage("b1", "INBOX")
+	b.appendMessage("b2", "INBOX")
+	b.appendMessage("b3", "INBOX")
+	a.send("a1 SELECT INBOX")
+	a.readUntilTag("a1")
+
+	// B removes the first one. A is not told: an expunge is withheld from a
+	// session until it runs a command that can carry it, so A's view still has
+	// three messages while the mailbox has two.
+	b.send("b4 SELECT INBOX")
+	b.readUntilTag("b4")
+	b.send("b5 STORE 1 +FLAGS (\\Deleted)")
+	b.readUntilTag("b5")
+	b.send("b6 EXPUNGE")
+	b.readUntilTag("b6")
+
+	// A names '*' without having polled in between. In A's numbering the two
+	// surviving messages are 2 and 3, so both must be flagged.
+	a.send("a2 STORE 1:* +FLAGS (\\Seen)")
+	resp := a.readUntilTag("a2")
+
+	got := map[string]bool{}
+	for _, line := range resp {
+		for _, seqNum := range []string{"2", "3"} {
+			if strings.HasPrefix(line, "* "+seqNum+" FETCH") && containsSeen(line) {
+				got[seqNum] = true
+			}
+		}
+	}
+	for _, seqNum := range []string{"2", "3"} {
+		if !got[seqNum] {
+			t.Errorf("STORE 1:* did not touch message %v, which is inside the client's 1:* range:\n\t%s", seqNum, strings.Join(resp, "\n\t"))
+		}
+	}
+
+	// Confirm against the mailbox rather than trusting the untagged responses:
+	// after A catches up, both surviving messages must carry \Seen.
+	a.send("a3 NOOP")
+	a.readUntilTag("a3")
+
+	a.send("a4 FETCH 1:* (FLAGS)")
+	flags := a.readUntilTag("a4")
+	var seen int
+	for _, line := range flags {
+		if strings.HasPrefix(line, "* ") && strings.Contains(line, "FETCH") && containsSeen(line) {
+			seen++
+		}
+	}
+	if seen != 2 {
+		t.Errorf("%v of 2 surviving messages carry \\Seen:\n\t%s", seen, strings.Join(flags, "\n\t"))
+	}
+}
+
+// containsSeen reports whether a FETCH line carries the \Seen flag. Flag names
+// are case-insensitive and this server lowercases them on the wire.
+func containsSeen(line string) bool {
+	return strings.Contains(strings.ToLower(line), "\\seen")
+}

--- a/imapserver/tracker.go
+++ b/imapserver/tracker.go
@@ -359,3 +359,32 @@ func (t *SessionTracker) EncodeSeqNum(seqNum uint32) uint32 {
 	}
 	return seqNum
 }
+
+// EncodeNumMessages converts the number of messages in the mailbox from the
+// server view to the client view.
+//
+// This is the value "*" refers to in a sequence set: the largest sequence
+// number the client can currently name. It differs from the server's count in
+// both directions -- a message that has been appended but not yet announced is
+// not addressable, and a message whose expunge has not been dispatched yet
+// still is.
+func (t *SessionTracker) EncodeNumMessages() uint32 {
+	t.mutex.Lock()
+	defer t.mutex.Unlock()
+
+	// Undo each pending update, newest first, to recover the count as of the
+	// last one the client actually saw.
+	n := t.mailbox.numMessages
+	for i := len(t.queue) - 1; i >= 0; i-- {
+		update := &t.queue[i]
+		if update.numMessages != 0 {
+			// prevNumMessages is the count before this update, so an update
+			// that announced more than one new message is undone correctly.
+			n = update.prevNumMessages
+		}
+		if update.expunge != 0 {
+			n++
+		}
+	}
+	return n
+}

--- a/imapserver/tracker_test.go
+++ b/imapserver/tracker_test.go
@@ -182,3 +182,83 @@ func TestSessionTracker(t *testing.T) {
 		})
 	}
 }
+
+// TestSessionTrackerEncodeNumMessages covers the value "*" resolves to in a
+// sequence set. The mailbox starts with 42 messages, all of them already known
+// to the client, and each case then queues updates the client has not seen.
+func TestSessionTrackerEncodeNumMessages(t *testing.T) {
+	tests := []struct {
+		name    string
+		pending []trackerUpdate
+		want    uint32
+	}{
+		{
+			name: "no pending updates",
+			want: 42,
+		},
+		{
+			// The client cannot name a message it has not been told about.
+			name:    "one pending append",
+			pending: []trackerUpdate{{numMessages: 43}},
+			want:    42,
+		},
+		{
+			// A single update announcing three messages at once must be undone
+			// as three, not as one. Deriving the count by decrementing per
+			// update gets this wrong.
+			name:    "one pending append of three messages",
+			pending: []trackerUpdate{{numMessages: 45}},
+			want:    42,
+		},
+		{
+			name:    "several pending appends",
+			pending: []trackerUpdate{{numMessages: 43}, {numMessages: 46}},
+			want:    42,
+		},
+		{
+			// The expunge has not been dispatched, so from the client's point
+			// of view the message is still there and still addressable.
+			name:    "one pending expunge",
+			pending: []trackerUpdate{{expunge: 1}},
+			want:    42,
+		},
+		{
+			name:    "two pending expunges",
+			pending: []trackerUpdate{{expunge: 1}, {expunge: 1}},
+			want:    42,
+		},
+		{
+			name:    "append then expunge",
+			pending: []trackerUpdate{{numMessages: 43}, {expunge: 1}},
+			want:    42,
+		},
+		{
+			name:    "expunge then append",
+			pending: []trackerUpdate{{expunge: 1}, {numMessages: 42}},
+			want:    42,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			mboxTracker := imapserver.NewMailboxTracker(42)
+			sessTracker := mboxTracker.NewSession()
+			for _, update := range tc.pending {
+				switch {
+				case update.expunge != 0:
+					if err := mboxTracker.QueueExpunge(update.expunge, 0); err != nil {
+						t.Fatalf("QueueExpunge(%v): %v", update.expunge, err)
+					}
+				case update.numMessages != 0:
+					if err := mboxTracker.QueueNumMessages(update.numMessages); err != nil {
+						t.Fatalf("QueueNumMessages(%v): %v", update.numMessages, err)
+					}
+				}
+			}
+
+			if got := sessTracker.EncodeNumMessages(); got != tc.want {
+				t.Errorf("EncodeNumMessages() = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Adopted from upstream **[emersion/go-imap#586](https://github.com/emersion/go-imap/pull/586)** by [@emersion](https://github.com/emersion). Tests are ours, and the count is derived differently — see below.

## The bug (verified present on `sora`)

`MailboxView.staticNumSet` resolved `*` to `uint32(len(mbox.l))` — the **server's** message count. Sequence numbers are a property of the *client's* view, and the two diverge: expunges are withheld from a session until it runs a command that can carry them, so a session's view can legitimately hold **more** messages than the mailbox does.

When it does, `*` comes out too low and the range is truncated. With one pending expunge and two surviving messages, `STORE 1:*` touched only the first — and still reported OK:

```
--- FAIL: TestSeqSetStarUsesClientView (0.00s)
    STORE 1:* did not touch message 3, which is inside the client's 1:* range:
        * 2 FETCH (UID 2 FLAGS (\seen))
        * 1 FETCH (UID 1 FLAGS (\deleted))
        a2 OK STORE completed
    1 of 2 surviving messages carry \Seen:
        * 1 FETCH (UID 2 FLAGS (\seen))
        * 2 FETCH (UID 3 FLAGS ())
```

A silent partial STORE reported as success is the bad part — nothing in the response tells the client a message was left alone.

### Correction to an earlier read of this

My first attempt at a red test used the *append* direction (a message added but not yet announced) and **passed on unfixed code**. That direction is already safe: such a message has no client sequence number, and `forEachLocked` drops anything whose `EncodeSeqNum` is 0 ([mailbox.go:790](imapserver/imapmemserver/mailbox.go#L790)). That guard cannot help in the expunge direction, because those messages have perfectly good sequence numbers — they just sit above the truncated range. The committed test exercises the expunge direction.

## Deviation from upstream

Upstream derives the count by decrementing once per queued update, and ships a `// TODO: this doesn't handle increments > 1` for the resulting error. Our `trackerUpdate` already records `prevNumMessages` for `EncodeSeqNum`, so undoing an update to exactly the count that preceded it is both simpler and correct for a batch append.

Verified rather than assumed — swapping in upstream's logic fails our unit test:

```
--- FAIL: TestSessionTrackerEncodeNumMessages/one_pending_append_of_three_messages
    EncodeNumMessages() = 44, want 42
--- FAIL: TestSessionTrackerEncodeNumMessages/several_pending_appends
    EncodeNumMessages() = 44, want 42
```

No TODO is needed on this version.

## Scope

The **UIDSet case is deliberately unchanged**. RFC 9051 §6.4.8 defines `*` in a UID range as the largest UID in the mailbox — "a UID range of 559:* always includes the UID of the last message in the mailbox" — which is the server-side view it already uses.

## Testing

- `TestSeqSetStarUsesClientView` — end-to-end over two connections, red before / green after. It asserts against the mailbox afterwards rather than trusting the untagged responses, and also asserts the message that *should* be flagged **is**, so it cannot pass by the STORE doing nothing.
- `TestSessionTrackerEncodeNumMessages` — 8 cases over `EncodeNumMessages` directly: pending appends (including a batch), pending expunges, and both interleavings.

Full `go test ./...` green, `-race` green on `imapserver`, `imapmemserver`, `imapclient`.