### PR TITLE
imapclient: parse a multipart body that carries no children

### DIFF
--- a/imapclient/bodystructure_childless_test.go
+++ b/imapclient/bodystructure_childless_test.go
@@ -1,0 +1,147 @@
+package imapclient
+
+import (
+	"bufio"
+	"strings"
+	"testing"
+
+	"github.com/emersion/go-imap/v2"
+	"github.com/emersion/go-imap/v2/internal/imapwire"
+)
+
+// TestReadBodyStructureChildlessMultipart is a regression test for a multipart
+// body carrying no child parts.
+//
+// RFC 9051 body-type-mpart is "1*body SP media-subtype [SP body-ext-mpart]", so
+// at least one child is required and a server emitting none is malformed. Some
+// do anyway, for an alternative part that ended up empty:
+//
+//	("ALTERNATIVE" ("BOUNDARY" "...") NIL NIL)
+//
+// A body starting with a string was always read as body-type-1part, so the
+// media subtype was looked for where the parameter list sits, and the whole
+// FETCH response failed with
+//
+//	in body-type-mpart: in body-type-1part: imapwire: expected string, got "("
+//
+// One empty part costs the entire response, including BODY[] of every message
+// in it, and in the report the sibling part was a 1.4 MB PDF attachment.
+//
+// Upstream report: emersion/go-imap#701 by Fizzadar.
+func TestReadBodyStructureChildlessMultipart(t *testing.T) {
+	// Verbatim from the upstream report.
+	const data = `(("ALTERNATIVE" ("BOUNDARY" "e7e3f78cb2203c4e50561d13c480670d46c0bb5ccba09400aae9c221fc41") NIL NIL)("APPLICATION" "PDF" NIL NIL NIL "BASE64" 1476806 NIL ("ATTACHMENT" ("FILENAME" "investing-101.pdf")) NIL) "MIXED" ("BOUNDARY" "7b1fa0fc24c33f620e26ce902dcf2ecbcc7ba56cd9e042624b2ee60b9d56") NIL NIL)`
+
+	dec := imapwire.NewDecoder(bufio.NewReader(strings.NewReader(data)), imapwire.ConnSideClient)
+	bs, err := readBody(dec, &Options{})
+	if err != nil {
+		t.Fatalf("readBody() = %v", err)
+	}
+
+	mp, ok := bs.(*imap.BodyStructureMultiPart)
+	if !ok {
+		t.Fatalf("readBody() = %T, want *imap.BodyStructureMultiPart", bs)
+	}
+	if mp.Subtype != "MIXED" {
+		t.Errorf("Subtype = %q, want %q", mp.Subtype, "MIXED")
+	}
+	if len(mp.Children) != 2 {
+		t.Fatalf("len(Children) = %v, want 2", len(mp.Children))
+	}
+
+	// The empty alternative comes back as a multipart with no children.
+	alt, ok := mp.Children[0].(*imap.BodyStructureMultiPart)
+	if !ok {
+		t.Fatalf("Children[0] = %T, want *imap.BodyStructureMultiPart", mp.Children[0])
+	}
+	if alt.Subtype != "ALTERNATIVE" {
+		t.Errorf("Children[0].Subtype = %q, want %q", alt.Subtype, "ALTERNATIVE")
+	}
+	if len(alt.Children) != 0 {
+		t.Errorf("len(Children[0].Children) = %v, want 0", len(alt.Children))
+	}
+	if alt.Extended == nil || alt.Extended.Params["boundary"] == "" {
+		t.Errorf("Children[0].Extended = %#v, want the boundary parameter", alt.Extended)
+	}
+
+	// What actually matters: the sibling part after it is still read correctly.
+	pdf, ok := mp.Children[1].(*imap.BodyStructureSinglePart)
+	if !ok {
+		t.Fatalf("Children[1] = %T, want *imap.BodyStructureSinglePart", mp.Children[1])
+	}
+	if pdf.Subtype != "PDF" {
+		t.Errorf("Children[1].Subtype = %q, want %q", pdf.Subtype, "PDF")
+	}
+	if pdf.Size != 1476806 {
+		t.Errorf("Children[1].Size = %v, want 1476806", pdf.Size)
+	}
+	if pdf.Extended == nil || pdf.Extended.Disposition == nil {
+		t.Fatalf("Children[1].Extended.Disposition = nil, want the attachment disposition")
+	}
+	if got := pdf.Extended.Disposition.Params["filename"]; got != "investing-101.pdf" {
+		t.Errorf("Children[1] filename = %q, want %q", got, "investing-101.pdf")
+	}
+}
+
+// TestReadBodyStructureChildlessMultipartBare covers the same shape with no
+// extension data at all, where there is nothing after the subtype.
+func TestReadBodyStructureChildlessMultipartBare(t *testing.T) {
+	const data = `(("ALTERNATIVE")("TEXT" "PLAIN" NIL NIL NIL "7BIT" 10 1) "MIXED")`
+
+	dec := imapwire.NewDecoder(bufio.NewReader(strings.NewReader(data)), imapwire.ConnSideClient)
+	bs, err := readBody(dec, &Options{})
+	if err != nil {
+		t.Fatalf("readBody() = %v", err)
+	}
+
+	mp := bs.(*imap.BodyStructureMultiPart)
+	if len(mp.Children) != 2 {
+		t.Fatalf("len(Children) = %v, want 2", len(mp.Children))
+	}
+	alt, ok := mp.Children[0].(*imap.BodyStructureMultiPart)
+	if !ok {
+		t.Fatalf("Children[0] = %T, want *imap.BodyStructureMultiPart", mp.Children[0])
+	}
+	if alt.Subtype != "ALTERNATIVE" || len(alt.Children) != 0 {
+		t.Errorf("Children[0] = %+v, want an empty ALTERNATIVE", alt)
+	}
+	if txt := mp.Children[1].(*imap.BodyStructureSinglePart); txt.Subtype != "PLAIN" {
+		t.Errorf("Children[1].Subtype = %q, want %q", txt.Subtype, "PLAIN")
+	}
+}
+
+// TestReadBodyStructureSinglePartUnaffected pins conformant single parts: the
+// media type and subtype must keep being read as such, not mistaken for a
+// childless multipart.
+func TestReadBodyStructureSinglePartUnaffected(t *testing.T) {
+	for _, tc := range []struct {
+		name         string
+		data         string
+		typ, subtype string
+		size         uint32
+	}{
+		{
+			name: "text/plain", data: `("TEXT" "PLAIN" ("CHARSET" "US-ASCII") NIL NIL "7BIT" 1152 23)`,
+			typ: "TEXT", subtype: "PLAIN", size: 1152,
+		},
+		{
+			name: "application/pdf with disposition", data: `("APPLICATION" "PDF" NIL NIL NIL "BASE64" 1476806 NIL ("ATTACHMENT" ("FILENAME" "x.pdf")) NIL)`,
+			typ: "APPLICATION", subtype: "PDF", size: 1476806,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			dec := imapwire.NewDecoder(bufio.NewReader(strings.NewReader(tc.data)), imapwire.ConnSideClient)
+			bs, err := readBody(dec, &Options{})
+			if err != nil {
+				t.Fatalf("readBody() = %v", err)
+			}
+			sp, ok := bs.(*imap.BodyStructureSinglePart)
+			if !ok {
+				t.Fatalf("readBody() = %T, want *imap.BodyStructureSinglePart", bs)
+			}
+			if sp.Type != tc.typ || sp.Subtype != tc.subtype || sp.Size != tc.size {
+				t.Errorf("got %v/%v size %v, want %v/%v size %v", sp.Type, sp.Subtype, sp.Size, tc.typ, tc.subtype, tc.size)
+			}
+		})
+	}
+}

--- a/imapclient/fetch.go
+++ b/imapclient/fetch.go
@@ -1028,8 +1028,26 @@ func readBody(dec *imapwire.Decoder, options *Options) (imap.BodyStructure, erro
 		err       error
 	)
 	if dec.String(&mediaType) {
-		token = "body-type-1part"
-		bs, err = readBodyType1part(dec, mediaType, options)
+		// A body opening with a string is body-type-1part, whose media type is
+		// followed by a media subtype -- also a string.
+		//
+		// Except when it is a multipart that lost all of its children. RFC 9051
+		// requires at least one ("1*body SP media-subtype [SP body-ext-mpart]"),
+		// but servers do emit an empty alternative as ("ALTERNATIVE" (params)
+		// ...), where the leading string is the subtype and what follows is the
+		// extension data. Tell them apart by whether a string comes next: it
+		// always does in a conformant 1part, and never in this shape.
+		// See https://github.com/emersion/go-imap/issues/701
+		hasSP := dec.SP()
+
+		var subtype string
+		if hasSP && dec.String(&subtype) {
+			token = "body-type-1part"
+			bs, err = readBodyType1part(dec, mediaType, subtype, options)
+		} else {
+			token = "body-type-mpart"
+			bs, err = readChildlessBodyTypeMpart(dec, mediaType, hasSP, options)
+		}
 	} else {
 		token = "body-type-mpart"
 		bs, err = readBodyTypeMpart(dec, options)
@@ -1051,10 +1069,13 @@ func readBody(dec *imapwire.Decoder, options *Options) (imap.BodyStructure, erro
 	return bs, nil
 }
 
-func readBodyType1part(dec *imapwire.Decoder, typ string, options *Options) (*imap.BodyStructureSinglePart, error) {
-	bs := imap.BodyStructureSinglePart{Type: typ}
+// readBodyType1part reads a body-type-1part whose media type and subtype have
+// already been consumed by readBody, which needs them to tell a single part
+// from a childless multipart.
+func readBodyType1part(dec *imapwire.Decoder, typ, subtype string, options *Options) (*imap.BodyStructureSinglePart, error) {
+	bs := imap.BodyStructureSinglePart{Type: typ, Subtype: subtype}
 
-	if !dec.ExpectSP() || !dec.ExpectString(&bs.Subtype) || !dec.ExpectSP() {
+	if !dec.ExpectSP() {
 		return nil, dec.Err()
 	}
 	var err error
@@ -1167,6 +1188,24 @@ func readBodyExt1part(dec *imapwire.Decoder, options *Options) (*imap.BodyStruct
 	}
 
 	return &ext, nil
+}
+
+// readChildlessBodyTypeMpart reads the malformed multipart described in
+// readBody: no child bodies, the media subtype already consumed, and optional
+// body-ext-mpart left to read.
+func readChildlessBodyTypeMpart(dec *imapwire.Decoder, subtype string, hasSP bool, options *Options) (*imap.BodyStructureMultiPart, error) {
+	bs := imap.BodyStructureMultiPart{Subtype: subtype}
+	if !hasSP {
+		// Nothing follows the subtype at all, e.g. ("ALTERNATIVE").
+		return &bs, nil
+	}
+
+	var err error
+	bs.Extended, err = readBodyExtMpart(dec, options)
+	if err != nil {
+		return nil, fmt.Errorf("in body-ext-mpart: %w", err)
+	}
+	return &bs, nil
 }
 
 func readBodyTypeMpart(dec *imapwire.Decoder, options *Options) (*imap.BodyStructureMultiPart, error) {


### PR DESCRIPTION
Fixes upstream issue **[emersion/go-imap#701](https://github.com/emersion/go-imap/issues/701)**, reported by [@Fizzadar](https://github.com/Fizzadar). No upstream fix exists — the reporter said they might attempt one. Fix and tests are ours.

## The bug (verified present on `sora`)

RFC 9051 defines `body-type-mpart` as `1*body SP media-subtype [SP body-ext-mpart]` — at least one child — so a server emitting none is malformed. They do it anyway, for an alternative part that ended up empty:

```
("ALTERNATIVE" ("BOUNDARY" "e7e3f78...") NIL NIL)
```

`readBody` treated any body opening with a string as `body-type-1part`, so it looked for the media subtype where the parameter list sits:

```
--- FAIL: TestReadBodyStructureChildlessMultipart
    readBody() = in body-type-mpart: in body-type-1part: imapwire: expected string, got "("
--- FAIL: TestReadBodyStructureChildlessMultipartBare
    readBody() = in body-type-mpart: in body-type-1part: imapwire: expected SP, got ")"
```

(The second reproduces the error in the report's title.) One empty part costs the **entire FETCH response**, `BODY[]` of every message in it included — in the report the sibling part was a 1.4 MB PDF attachment.

## Why the detection is unambiguous

Tell the two shapes apart by whether a **string comes next**:

- conformant `body-type-1part` — always has one, since `media-subtype` is a `string`
- this shape — never does; what follows the subtype is a parenthesized parameter list, `NIL`, or the end of the body

So conformant input cannot reach the new branch, and the tolerance costs nothing. `TestReadBodyStructureSinglePartUnaffected` pins that, passing **both** before and after.

The lookahead is `dec.String`, which consumes nothing and sets no decoder error when it does not match — so no new decoder primitive is needed, and this branch does **not** depend on #29. `readBodyType1part` now takes the subtype `readBody` already read.

## Red/green

| Test | Without fix | With fix |
|---|---|---|
| `TestReadBodyStructureChildlessMultipart` (verbatim report capture) | `expected string, got "("` | pass |
| `TestReadBodyStructureChildlessMultipartBare` (`("ALTERNATIVE")`) | `expected SP, got ")"` | pass |
| `TestReadBodyStructureSinglePartUnaffected` (2 guards) | pass | pass |

The empty alternative comes back as a `BodyStructureMultiPart` with `Children` empty and its boundary parameter intact, and — the point of the fix — the sibling part after it parses correctly, disposition and filename included.

Full `go test ./...` green, `-race` green.

## Related issue triage

**#678** (`expected '(', got "N"`) needs nothing further: the capture in its comments (`("text" "html" ("charset" "utf-8") NIL NIL "quoted-printable" 5606 133 NIL NIL NIL NIL)`) already parses on `sora` today, and the error in its log is the `message/global` case fixed by #29.