### PR TITLE
imapclient: skip a response code we cannot parse instead of failing

### DIFF
--- a/imapclient/client.go
+++ b/imapclient/client.go
@@ -749,6 +749,9 @@ func (c *Client) readResponseTagged(tag, typ string) (startTLS *startTLSCommand,
 	hasSP := c.dec.SP()
 
 	var code string
+	// See the matching comment in readResponseData: a code we cannot parse is
+	// skipped like one we do not recognise, rather than failing the connection.
+	var malformedCode bool
 	if hasSP && c.dec.Special('[') { // resp-text-code
 		if !c.dec.ExpectAtom(&code) {
 			return nil, fmt.Errorf("in resp-text-code: %w", c.dec.Err())
@@ -781,13 +784,14 @@ func (c *Client) readResponseTagged(tag, typ string) (startTLS *startTLSCommand,
 		case "APPENDUID":
 			var (
 				uidValidity uint32
-				uid         imap.UID
+				uidNum      uint32
 			)
-			if !c.dec.ExpectSP() || !c.dec.ExpectNumber(&uidValidity) || !c.dec.ExpectSP() || !c.dec.ExpectUID(&uid) {
-				return nil, fmt.Errorf("in resp-code-apnd: %w", c.dec.Err())
+			if !c.dec.SP() || !c.dec.Number(&uidValidity) || !c.dec.SP() || !c.dec.Number(&uidNum) {
+				malformedCode = true
+				break
 			}
 			if cmd, ok := cmd.(*AppendCommand); ok {
-				cmd.data.UID = uid
+				cmd.data.UID = imap.UID(uidNum)
 				cmd.data.UIDValidity = uidValidity
 			}
 		case "COPYUID":
@@ -833,6 +837,10 @@ func (c *Client) readResponseTagged(tag, typ string) (startTLS *startTLSCommand,
 			if c.dec.SP() {
 				c.dec.DiscardUntilByte(']')
 			}
+		}
+		if malformedCode {
+			c.dec.DiscardUntilByte(']')
+			code = ""
 		}
 		if !c.dec.ExpectSpecial(']') {
 			return nil, fmt.Errorf("in resp-text: %w", c.dec.Err())
@@ -898,6 +906,16 @@ func (c *Client) readResponseData(typ string) error {
 		hasSP := c.dec.SP()
 
 		var code string
+		// malformedCode is set when a code we recognise carries an argument we
+		// cannot parse. Rather than failing the connection over advisory
+		// metadata, we skip the code exactly as we skip an unknown one: RFC 9051
+		// Section 7.1 already requires clients to ignore codes they do not
+		// recognise, and a code that will not parse is no more usable than one
+		// we have never heard of. Servers do get this wrong -- dynadot sends a
+		// millisecond timestamp as UIDVALIDITY, which does not fit the 32 bits
+		// RFC 9051 gives it, and that alone made the server unusable.
+		// See https://github.com/emersion/go-imap/issues/612
+		var malformedCode bool
 		if hasSP && c.dec.Special('[') { // resp-text-code
 			if !c.dec.ExpectAtom(&code) {
 				return fmt.Errorf("in resp-text-code: %w", c.dec.Err())
@@ -931,17 +949,19 @@ func (c *Client) readResponseData(typ string) error {
 					handler(&UnilateralDataMailbox{PermanentFlags: flags})
 				}
 			case "UIDNEXT":
-				var uidNext imap.UID
-				if !c.dec.ExpectSP() || !c.dec.ExpectUID(&uidNext) {
-					return c.dec.Err()
+				var num uint32
+				if !c.dec.SP() || !c.dec.Number(&num) {
+					malformedCode = true
+					break
 				}
 				if cmd := findPendingCmdByType[*SelectCommand](c); cmd != nil {
-					cmd.data.UIDNext = uidNext
+					cmd.data.UIDNext = imap.UID(num)
 				}
 			case "UIDVALIDITY":
 				var uidValidity uint32
-				if !c.dec.ExpectSP() || !c.dec.ExpectNumber(&uidValidity) {
-					return c.dec.Err()
+				if !c.dec.SP() || !c.dec.Number(&uidValidity) {
+					malformedCode = true
+					break
 				}
 				if cmd := findPendingCmdByType[*SelectCommand](c); cmd != nil {
 					cmd.data.UIDValidity = uidValidity
@@ -961,8 +981,9 @@ func (c *Client) readResponseData(typ string) error {
 				}
 			case "HIGHESTMODSEQ":
 				var modSeq uint64
-				if !c.dec.ExpectSP() || !c.dec.ExpectModSeq(&modSeq) {
-					return c.dec.Err()
+				if !c.dec.SP() || !c.dec.ModSeq(&modSeq) {
+					malformedCode = true
+					break
 				}
 				if cmd := findPendingCmdByType[*SelectCommand](c); cmd != nil {
 					cmd.data.HighestModSeq = modSeq
@@ -977,6 +998,12 @@ func (c *Client) readResponseData(typ string) error {
 				if c.dec.SP() {
 					c.dec.DiscardUntilByte(']')
 				}
+			}
+			if malformedCode {
+				// Drop whatever is left of the code and forget its name, so it
+				// is reported the same as any code we do not act on.
+				c.dec.DiscardUntilByte(']')
+				code = ""
 			}
 			if !c.dec.ExpectSpecial(']') {
 				return fmt.Errorf("in resp-text: %w", c.dec.Err())

--- a/imapclient/resp_code_tolerance_test.go
+++ b/imapclient/resp_code_tolerance_test.go
@@ -1,0 +1,260 @@
+package imapclient_test
+
+import (
+	"bufio"
+	"io"
+	"net"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/emersion/go-imap/v2/imapclient"
+)
+
+// newCodeServer starts a server that answers every command with respLines
+// followed by a tagged OK, and returns a connected client.
+func newCodeServer(t *testing.T, respLines string) *imapclient.Client {
+	t.Helper()
+
+	clientConn, serverConn := net.Pipe()
+	t.Cleanup(func() { clientConn.Close() })
+
+	go func() {
+		defer serverConn.Close()
+		br := bufio.NewReader(serverConn)
+		io.WriteString(serverConn, "* OK [CAPABILITY IMAP4rev2] ready\r\n")
+		for {
+			line, err := br.ReadString('\n')
+			if err != nil {
+				return
+			}
+			fields := strings.Fields(line)
+			if len(fields) == 0 {
+				continue
+			}
+			io.WriteString(serverConn, respLines)
+			io.WriteString(serverConn, fields[0]+" OK completed\r\n")
+		}
+	}()
+
+	client := imapclient.New(clientConn, nil)
+	t.Cleanup(func() { client.Close() })
+	if err := client.WaitGreeting(); err != nil {
+		t.Fatalf("WaitGreeting() = %v", err)
+	}
+	return client
+}
+
+// TestMalformedRespTextCodeDoesNotKillConnection is a regression test for a
+// response code whose argument does not fit its type taking down the whole
+// connection.
+//
+// A resp-text-code is advisory metadata attached to a status response. RFC 9051
+// Section 7.1 already requires a client to ignore codes it does not recognise,
+// so failing the connection over one it recognises but cannot parse is a much
+// harsher reaction than the protocol asks for.
+//
+// This is not hypothetical: dynadot sends a millisecond timestamp as
+// UIDVALIDITY, which does not fit the 32 bits RFC 9051 gives it. The client
+// could not talk to that server at all -- the first command failed with
+//
+//	in response-data: imapwire: expected number, got "]"
+//
+// and every command after it with "use of closed network connection".
+//
+// Upstream report: emersion/go-imap#612 by quzhi1.
+func TestMalformedRespTextCodeDoesNotKillConnection(t *testing.T) {
+	tests := []struct {
+		name string
+		resp string
+	}{
+		{
+			// The reported case: 1713632002544 > 2^32.
+			name: "UIDVALIDITY wider than 32 bits",
+			resp: "* OK [UIDVALIDITY 1713632002544] UIDs valid\r\n",
+		},
+		{
+			name: "UIDNEXT wider than 32 bits",
+			resp: "* OK [UIDNEXT 99999999999999] Predicted next UID\r\n",
+		},
+		{
+			name: "HIGHESTMODSEQ wider than 64 bits",
+			resp: "* OK [HIGHESTMODSEQ 184467440737095516160] Highest\r\n",
+		},
+		{
+			name: "UIDVALIDITY with no argument",
+			resp: "* OK [UIDVALIDITY] UIDs valid\r\n",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			client := newCodeServer(t, tc.resp)
+
+			if err := client.Noop().Wait(); err != nil {
+				t.Fatalf("Noop().Wait() = %v, want the malformed code to be ignored", err)
+			}
+			// The connection must still be usable afterwards.
+			if err := client.Noop().Wait(); err != nil {
+				t.Fatalf("second Noop().Wait() = %v, want the connection to survive", err)
+			}
+		})
+	}
+}
+
+// TestWellFormedRespTextCodeStillParsed is the guard for the change from the
+// Expect parsers to the tolerant ones: a well-formed code must still be read
+// and its value delivered, not quietly skipped.
+func TestWellFormedRespTextCodeStillParsed(t *testing.T) {
+	client := newCodeServer(t, "* OK [UIDVALIDITY 3857529045] UIDs valid\r\n"+
+		"* OK [UIDNEXT 4392] Predicted next UID\r\n"+
+		"* OK [HIGHESTMODSEQ 90060128194045800] Highest\r\n")
+
+	data, err := client.Select("INBOX", nil).Wait()
+	if err != nil {
+		t.Fatalf("Select().Wait() = %v", err)
+	}
+	if data.UIDValidity != 3857529045 {
+		t.Errorf("UIDValidity = %v, want 3857529045", data.UIDValidity)
+	}
+	if data.UIDNext != 4392 {
+		t.Errorf("UIDNext = %v, want 4392", data.UIDNext)
+	}
+	if data.HighestModSeq != 90060128194045800 {
+		t.Errorf("HighestModSeq = %v, want 90060128194045800", data.HighestModSeq)
+	}
+}
+
+// TestMalformedRespTextCodeKeepsStatusResponse checks that skipping a code does
+// not swallow the status response carrying it: a tagged NO must still be an
+// error, and its text must survive.
+func TestMalformedRespTextCodeKeepsStatusResponse(t *testing.T) {
+	clientConn, serverConn := net.Pipe()
+	defer clientConn.Close()
+
+	go func() {
+		defer serverConn.Close()
+		br := bufio.NewReader(serverConn)
+		io.WriteString(serverConn, "* OK [CAPABILITY IMAP4rev2] ready\r\n")
+		for {
+			line, err := br.ReadString('\n')
+			if err != nil {
+				return
+			}
+			fields := strings.Fields(line)
+			if len(fields) == 0 {
+				continue
+			}
+			io.WriteString(serverConn, fields[0]+" NO [UIDVALIDITY 1713632002544] mailbox is broken\r\n")
+		}
+	}()
+
+	client := imapclient.New(clientConn, nil)
+	defer client.Close()
+	if err := client.WaitGreeting(); err != nil {
+		t.Fatalf("WaitGreeting() = %v", err)
+	}
+
+	err := client.Noop().Wait()
+	if err == nil {
+		t.Fatal("Noop().Wait() = nil, want the tagged NO to surface as an error")
+	}
+	if !strings.Contains(err.Error(), "mailbox is broken") {
+		t.Errorf("Noop().Wait() = %v, want the server text preserved", err)
+	}
+}
+
+// appendUIDServer answers an APPEND with the given tagged completion line.
+func appendUIDServer(t *testing.T, taggedLine string) *imapclient.Client {
+	t.Helper()
+
+	clientConn, serverConn := net.Pipe()
+	t.Cleanup(func() { clientConn.Close() })
+
+	go func() {
+		defer serverConn.Close()
+		br := bufio.NewReader(serverConn)
+		io.WriteString(serverConn, "* OK [CAPABILITY IMAP4rev2] ready\r\n")
+		for {
+			line, err := br.ReadString('\n')
+			if err != nil {
+				return
+			}
+			fields := strings.Fields(line)
+			if len(fields) < 2 {
+				continue
+			}
+			if strings.EqualFold(fields[1], "APPEND") {
+				// IMAP4rev2 implies non-synchronizing literals, so the client
+				// does not wait for a continuation request: read exactly the
+				// announced number of bytes, then the CRLF after them.
+				open := strings.LastIndex(line, "{")
+				close := strings.LastIndex(line, "}")
+				if open < 0 || close < open {
+					return
+				}
+				size, err := strconv.Atoi(strings.TrimSuffix(line[open+1:close], "+"))
+				if err != nil {
+					return
+				}
+				if _, err := io.ReadFull(br, make([]byte, size)); err != nil {
+					return
+				}
+				if _, err := br.ReadString('\n'); err != nil {
+					return
+				}
+				io.WriteString(serverConn, fields[0]+" "+taggedLine+"\r\n")
+				continue
+			}
+			io.WriteString(serverConn, fields[0]+" OK completed\r\n")
+		}
+	}()
+
+	client := imapclient.New(clientConn, nil)
+	t.Cleanup(func() { client.Close() })
+	if err := client.WaitGreeting(); err != nil {
+		t.Fatalf("WaitGreeting() = %v", err)
+	}
+	return client
+}
+
+// TestMalformedAppendUIDDoesNotKillConnection covers the tagged-response code
+// parser, which is a separate switch from the untagged one. APPENDUID carries
+// a UIDVALIDITY too, so the same server that overflows it on SELECT overflows
+// it here.
+func TestMalformedAppendUIDDoesNotKillConnection(t *testing.T) {
+	const msg = "From: <a@example.org>\r\n\r\nbody\r\n"
+
+	client := appendUIDServer(t, "OK [APPENDUID 1713632002544 5] APPEND completed")
+
+	appendCmd := client.Append("INBOX", int64(len(msg)), nil)
+	appendCmd.Write([]byte(msg))
+	appendCmd.Close()
+	if _, err := appendCmd.Wait(); err != nil {
+		t.Fatalf("Append().Wait() = %v, want the malformed APPENDUID to be ignored", err)
+	}
+	if err := client.Noop().Wait(); err != nil {
+		t.Fatalf("Noop().Wait() = %v, want the connection to survive", err)
+	}
+}
+
+// TestWellFormedAppendUIDStillParsed is the matching guard.
+func TestWellFormedAppendUIDStillParsed(t *testing.T) {
+	const msg = "From: <a@example.org>\r\n\r\nbody\r\n"
+
+	client := appendUIDServer(t, "OK [APPENDUID 3857529045 5] APPEND completed")
+
+	appendCmd := client.Append("INBOX", int64(len(msg)), nil)
+	appendCmd.Write([]byte(msg))
+	appendCmd.Close()
+	data, err := appendCmd.Wait()
+	if err != nil {
+		t.Fatalf("Append().Wait() = %v", err)
+	}
+	if data.UIDValidity != 3857529045 {
+		t.Errorf("UIDValidity = %v, want 3857529045", data.UIDValidity)
+	}
+	if data.UID != 5 {
+		t.Errorf("UID = %v, want 5", data.UID)
+	}
+}


### PR DESCRIPTION
Fixes upstream issue **[emersion/go-imap#612](https://github.com/emersion/go-imap/issues/612)**, reported by [@quzhi1](https://github.com/quzhi1). No upstream fix exists. Fix and tests are ours.

## The bug (verified present on `sora`)

dynadot sends a **millisecond timestamp as UIDVALIDITY** — `* OK [UIDVALIDITY 1713632002544]` — which does not fit the 32 bits RFC 9051 gives it. One out-of-range number killed the connection permanently:

```
RESULT: Noop().Wait() = in response-data: imapwire: expected number, got "]"
RESULT: second Noop    = io: read/write on closed pipe
```

The client could not talk to that server **at all**.

A `resp-text-code` is advisory metadata attached to a status response, and RFC 9051 §7.1 already requires clients to ignore codes they do not recognise. Failing the connection over one we *do* recognise but cannot parse is far harsher than the protocol asks for — a code that will not parse is no more usable than one we have never heard of.

## The fix

Parse the numeric codes with the tolerant decoder methods (`Number`, `ModSeq`) instead of the `Expect` ones. They consume the digits and report failure **without setting the sticky decoder error**, so on failure we discard the rest of the code and clear its name — exactly what already happens for an unknown code.

**Both** response-code parsers are covered. I found the second one while checking a guard that passed unfixed:

- `readResponseData` — untagged responses: `UIDNEXT`, `UIDVALIDITY`, `HIGHESTMODSEQ`
- `readResponseTagged` — tagged responses, a separate switch, where **`APPENDUID` carries a UIDVALIDITY of its own** and so overflows on exactly the same servers. Confirmed red independently:

```
Append().Wait() = in resp-code-apnd: imapwire: expected number, got " "
```

## Scope — what I deliberately did NOT make tolerant

**Values inside message data**, specifically the oversized `BINARY.SIZE` of upstream [#630](https://github.com/emersion/go-imap/issues/630). I reproduced that one too (it kills the connection the same way), but it is a different class: that is data the caller *acts on*, not metadata attached to a status line. Quietly dropping it would hand the application a wrong answer instead of an error. Left failing loudly, on purpose.

Worth naming the residual risk on the fix itself: an app that relies on UIDVALIDITY for cache invalidation now sees `0` from such a server rather than a connection error. If the server's real UIDVALIDITY changed and both old and new values overflow, that change would go unnoticed. I judged this acceptable because the alternative is not a working client — it is no client at all — and because a server violating the 32-bit rule is already outside the contract that makes UIDVALIDITY meaningful.

## Red/green

| Test | Without fix | With fix |
|---|---|---|
| `TestMalformedRespTextCodeDoesNotKillConnection` (4 cases) | all 4 kill the connection | pass |
| `TestMalformedAppendUIDDoesNotKillConnection` | `expected number, got " "` | pass |
| `TestWellFormedRespTextCodeStillParsed` (guard) | pass | pass |
| `TestWellFormedAppendUIDStillParsed` (guard) | pass | pass |
| `TestMalformedRespTextCodeKeepsStatusResponse` (guard) | pass | pass |

The two well-formed guards assert the **values actually land** (`UIDValidity`, `UIDNext`, `HighestModSeq`, and APPENDUID's pair), which is the real risk of switching from `Expect*` to the tolerant parsers. Both pass before and after, so they are genuine regression guards.

Full `go test ./...` green, `-race` green, `-count=2 -race` on `imapclient`.