### PR TITLE
imapclient: bound BODYSTRUCTURE nesting depth

### DIFF
--- a/imapclient/bodystructure_depth_test.go
+++ b/imapclient/bodystructure_depth_test.go
@@ -1,0 +1,122 @@
+package imapclient
+
+import (
+	"bufio"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/emersion/go-imap/v2/internal/imapwire"
+)
+
+// TestReadBodyStructureDepthLimit is a regression test for unbounded recursion
+// while parsing BODYSTRUCTURE.
+//
+// A body structure nests: a multipart holds bodies, and a message/rfc822 part
+// holds another body. readBody recursed through both without a depth limit. The
+// decoder's own maxListDepth does not apply, because a body is opened with
+// ExpectSpecial('(') rather than through Decoder.List, so nothing counted the
+// nesting.
+//
+// A server is not required to send anything sane here, and this is remotely
+// reachable on any FETCH that asks for BODYSTRUCTURE.
+//
+// The concrete harm is the error path: every level wraps the error from the
+// level below with fmt.Errorf, so a nesting that fails anywhere inside costs
+// time and memory quadratic in the depth. Measured before the fix, on nesting
+// that ends in a parse error:
+//
+//	  5000 levels   0.04s
+//	 10000 levels   0.13s
+//	 20000 levels   0.51s
+//	 40000 levels   2.14s
+//	100000 levels   did not finish within 60s
+//
+// maxResponseSize caps a response at 8 MiB, which is hundreds of thousands of
+// levels, so a single response is enough to tie the connection up indefinitely.
+//
+// The recursion depth itself was also unbounded. That one did not crash in
+// testing -- Go grew the stack to 800000 frames without overflowing -- but
+// nothing was keeping it in check either.
+//
+// Upstream: emersion/go-imap#574 asks for exactly this ("Recursion limits for
+// BODYSTRUCTURE and SEARCH"). SEARCH is already bounded on the server side by
+// maxSearchKeyDepth.
+func TestReadBodyStructureDepthLimit(t *testing.T) {
+	// Deep enough that the old quadratic path takes seconds, so a regression
+	// shows up as a timeout rather than passing slowly.
+	const depth = 100000
+	// Valid nesting: every level is (<child> "MIXED"), so the limit is proven
+	// to trigger on well-formed input rather than on a parse error.
+	data := strings.Repeat("(", depth) +
+		`("TEXT" "PLAIN" NIL NIL NIL "7BIT" 10 1)` +
+		strings.Repeat(` "MIXED")`, depth)
+
+	done := make(chan error, 1)
+	go func() {
+		dec := imapwire.NewDecoder(bufio.NewReader(strings.NewReader(data)), imapwire.ConnSideClient)
+		_, err := readBody(dec, &Options{})
+		done <- err
+	}()
+
+	select {
+	case err := <-done:
+		if err == nil {
+			t.Fatal("readBody() = nil, want a depth-limit error")
+		}
+		if !strings.Contains(err.Error(), "nesting too deep") {
+			t.Fatalf("readBody() = %v, want a depth-limit error", err)
+		}
+		// The error must not carry a wrapper per level.
+		if n := strings.Count(err.Error(), "body-type-mpart"); n > 2*maxBodyStructureDepth {
+			t.Errorf("error wraps %v levels, want at most %v", n, 2*maxBodyStructureDepth)
+		}
+	case <-time.After(20 * time.Second):
+		t.Fatal("readBody() did not finish in 20s: nesting is not bounded")
+	}
+}
+
+// TestReadBodyStructureNestingAllowed is the guard: nesting that any real
+// message could plausibly use must still parse.
+func TestReadBodyStructureNestingAllowed(t *testing.T) {
+	// 20 levels of multipart, far beyond anything real mail produces.
+	const depth = 20
+	data := strings.Repeat("(", depth) +
+		`("TEXT" "PLAIN" NIL NIL NIL "7BIT" 10 1)` +
+		strings.Repeat(` "MIXED")`, depth)
+
+	dec := imapwire.NewDecoder(bufio.NewReader(strings.NewReader(data)), imapwire.ConnSideClient)
+	if _, err := readBody(dec, &Options{}); err != nil {
+		t.Fatalf("readBody() at depth %v = %v, want success", depth, err)
+	}
+}
+
+// TestReadBodyStructureMessageNestingCounted checks the other recursion path:
+// message/rfc822 parts nest through readBodyType1part, not readBodyTypeMpart.
+func TestReadBodyStructureMessageNestingCounted(t *testing.T) {
+	const depth = 100000
+	var sb strings.Builder
+	for i := 0; i < depth; i++ {
+		sb.WriteString(`("MESSAGE" "RFC822" NIL NIL NIL "7BIT" 10 (NIL "s" NIL NIL NIL NIL NIL NIL NIL NIL) `)
+	}
+	sb.WriteString(`("TEXT" "PLAIN" NIL NIL NIL "7BIT" 10 1)`)
+	for i := 0; i < depth; i++ {
+		sb.WriteString(` 1)`)
+	}
+
+	done := make(chan error, 1)
+	go func() {
+		dec := imapwire.NewDecoder(bufio.NewReader(strings.NewReader(sb.String())), imapwire.ConnSideClient)
+		_, err := readBody(dec, &Options{})
+		done <- err
+	}()
+
+	select {
+	case err := <-done:
+		if err == nil || !strings.Contains(err.Error(), "nesting too deep") {
+			t.Fatalf("readBody() = %v, want a depth-limit error", err)
+		}
+	case <-time.After(20 * time.Second):
+		t.Fatal("readBody() did not finish in 20s: message nesting is not bounded")
+	}
+}

--- a/imapclient/fetch.go
+++ b/imapclient/fetch.go
@@ -1016,7 +1016,27 @@ func parseMsgIDList(s string) ([]string, error) {
 	return h.MsgIDList("In-Reply-To")
 }
 
+// maxBodyStructureDepth bounds how deeply a BODYSTRUCTURE may nest.
+//
+// A body nests two ways -- a multipart holds bodies, and a message/rfc822 part
+// holds one more -- and neither goes through Decoder.List, so the decoder's own
+// maxListDepth never sees them. Without a bound here a server can nest as
+// deeply as maxResponseSize allows, which is millions of levels, and because
+// each level wraps the error below it the failure alone is quadratic.
+//
+// Real messages nest in single digits. This matches maxListDepth, which bounds
+// the equivalent recursion everywhere else in the decoder.
+// See https://github.com/emersion/go-imap/issues/574
+const maxBodyStructureDepth = 1000
+
 func readBody(dec *imapwire.Decoder, options *Options) (imap.BodyStructure, error) {
+	return readBodyDepth(dec, options, 0)
+}
+
+func readBodyDepth(dec *imapwire.Decoder, options *Options, depth int) (imap.BodyStructure, error) {
+	if depth > maxBodyStructureDepth {
+		return nil, fmt.Errorf("body structure nesting too deep (over %v levels)", maxBodyStructureDepth)
+	}
 	if !dec.ExpectSpecial('(') {
 		return nil, dec.Err()
 	}
@@ -1043,14 +1063,14 @@ func readBody(dec *imapwire.Decoder, options *Options) (imap.BodyStructure, erro
 		var subtype string
 		if hasSP && dec.String(&subtype) {
 			token = "body-type-1part"
-			bs, err = readBodyType1part(dec, mediaType, subtype, options)
+			bs, err = readBodyType1part(dec, mediaType, subtype, options, depth)
 		} else {
 			token = "body-type-mpart"
 			bs, err = readChildlessBodyTypeMpart(dec, mediaType, hasSP, options)
 		}
 	} else {
 		token = "body-type-mpart"
-		bs, err = readBodyTypeMpart(dec, options)
+		bs, err = readBodyTypeMpart(dec, options, depth)
 	}
 	if err != nil {
 		return nil, fmt.Errorf("in %v: %w", token, err)
@@ -1072,7 +1092,7 @@ func readBody(dec *imapwire.Decoder, options *Options) (imap.BodyStructure, erro
 // readBodyType1part reads a body-type-1part whose media type and subtype have
 // already been consumed by readBody, which needs them to tell a single part
 // from a childless multipart.
-func readBodyType1part(dec *imapwire.Decoder, typ, subtype string, options *Options) (*imap.BodyStructureSinglePart, error) {
+func readBodyType1part(dec *imapwire.Decoder, typ, subtype string, options *Options, depth int) (*imap.BodyStructureSinglePart, error) {
 	bs := imap.BodyStructureSinglePart{Type: typ, Subtype: subtype}
 
 	if !dec.ExpectSP() {
@@ -1117,7 +1137,7 @@ func readBodyType1part(dec *imapwire.Decoder, typ, subtype string, options *Opti
 			return nil, dec.Err()
 		}
 
-		msg.BodyStructure, err = readBody(dec, options)
+		msg.BodyStructure, err = readBodyDepth(dec, options, depth+1)
 		if err != nil {
 			return nil, err
 		}
@@ -1208,11 +1228,11 @@ func readChildlessBodyTypeMpart(dec *imapwire.Decoder, subtype string, hasSP boo
 	return &bs, nil
 }
 
-func readBodyTypeMpart(dec *imapwire.Decoder, options *Options) (*imap.BodyStructureMultiPart, error) {
+func readBodyTypeMpart(dec *imapwire.Decoder, options *Options, depth int) (*imap.BodyStructureMultiPart, error) {
 	var bs imap.BodyStructureMultiPart
 
 	for {
-		child, err := readBody(dec, options)
+		child, err := readBodyDepth(dec, options, depth+1)
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
> **Stacked on #36** (`bodystructure-childless-multipart`) — it touches the same `readBody` signatures, so this is based on that branch and targets it. Retarget to `sora` once #36 lands.

Addresses the BODYSTRUCTURE half of upstream issue **[emersion/go-imap#574](https://github.com/emersion/go-imap/issues/574)** ("Recursion limits for BODYSTRUCTURE and SEARCH") by [@emersion](https://github.com/emersion). No upstream fix exists.

## The gap (verified present on `sora`)

A body structure nests two ways — a multipart holds bodies, and a `message/rfc822` part holds one more — and `readBody` recursed through both with **no limit**. The decoder's own `maxListDepth` never applied, because a body is opened with `ExpectSpecial('(')` rather than through `Decoder.List`, so nothing counted the nesting at all.

This is remotely reachable on any FETCH that asks for BODYSTRUCTURE, and the **server** picks the depth.

## Measured harm

The concrete problem is the error path: every level wraps the error below it with `fmt.Errorf`, so nesting that fails anywhere inside is **quadratic** in depth.

| depth | parse time |
|---|---|
| 5 000 | 0.04s |
| 10 000 | 0.13s |
| 20 000 | 0.51s |
| 40 000 | 2.14s |
| 100 000 | **did not finish within 60s** |

`maxResponseSize` caps a response at 8 MiB — hundreds of thousands of levels — so a single response is enough to tie a connection up indefinitely.

**Being precise about what I did not observe:** the unbounded recursion itself did *not* crash. I tested valid nesting at 800 000 levels and Go grew the stack without overflowing. So the claim here is only that nothing was bounding it, not that it was a remote crash.

## The fix

Thread a depth counter through both recursion paths and cap at **1000**, matching `maxListDepth`, which bounds the equivalent recursion everywhere else in the decoder. Real messages nest in single digits.

## Red/green

| Test | Without fix | With fix |
|---|---|---|
| `TestReadBodyStructureDepthLimit` (100k multipart levels) | parses 100k levels, no error | depth-limit error |
| `TestReadBodyStructureMessageNestingCounted` (100k `message/rfc822` levels) | parses, no error | depth-limit error |
| `TestReadBodyStructureNestingAllowed` (20 levels, guard) | pass | pass |

The two failing tests use **valid** nesting, so the limit is proven to trigger on well-formed input rather than incidentally on a parse error. Both are wrapped in a 20s timeout so a regression shows up as a failure rather than hanging the suite. The guard at 20 levels is far beyond anything real mail produces.

Full `go test ./...` green, `-race` green.

## Also checked, already done

The **SEARCH half of #574 needs nothing** — `readSearchKeyDepth` already bounds server-side SEARCH keys at `maxSearchKeyDepth` (100), with coverage in `audit_l_fixes_test.go`. Command size limits are also already in place (`maxCommandSize`, per-command `MaxSize`).