### PR TITLE
imapclient: make the response and literal read timeouts configurable

### DIFF
--- a/imapclient/client.go
+++ b/imapclient/client.go
@@ -90,6 +90,45 @@ type Options struct {
 	// buffer in memory (e.g., for FetchMessageBuffer.Collect). Larger
 	// literals must be consumed via the streaming API. Default 64 MiB.
 	MaxLiteralSize int64
+	// ResponseTimeout bounds how long to wait for a response while a command
+	// is in flight, including the wait for its first byte. This is the window
+	// in which an unresponsive server is detected. If zero, 30 seconds is used.
+	//
+	// It does not apply while IDLE is running, where silence is expected and
+	// the much longer idle timeout governs instead.
+	//
+	// Lower it to notice a dead peer sooner; raise it for servers that are slow
+	// to answer expensive commands. There is deliberately no value meaning "no
+	// timeout": a client that never gives up is the bug this bounds.
+	ResponseTimeout time.Duration
+	// LiteralReadTimeout bounds how long to wait while reading a literal, i.e.
+	// a message body or other large payload. If zero, 5 minutes is used.
+	//
+	// Raise it when fetching large messages over slow links. As with
+	// ResponseTimeout, there is no value meaning "no timeout".
+	LiteralReadTimeout time.Duration
+}
+
+// responseTimeout returns ResponseTimeout, or the default if it is unset.
+//
+// Zero means "use the default" rather than "no timeout", so that an Options
+// value written before these fields existed keeps its deadlines. setReadTimeout
+// clears the deadline entirely for a non-positive duration, so passing the raw
+// field through would silently leave such callers waiting forever.
+func (options *Options) responseTimeout() time.Duration {
+	if options.ResponseTimeout <= 0 {
+		return respReadTimeout
+	}
+	return options.ResponseTimeout
+}
+
+// literalTimeout returns LiteralReadTimeout, or the default if it is unset.
+// See responseTimeout for why zero means the default.
+func (options *Options) literalTimeout() time.Duration {
+	if options.LiteralReadTimeout <= 0 {
+		return literalReadTimeout
+	}
+	return options.LiteralReadTimeout
 }
 
 func (options *Options) wrapReadWriter(rw io.ReadWriter) io.ReadWriter {
@@ -331,7 +370,7 @@ func (c *Client) readTimeoutLocked() time.Duration {
 		pending = true
 	}
 	if pending {
-		return respReadTimeout
+		return c.options.responseTimeout()
 	}
 	return idleReadTimeout
 }
@@ -685,7 +724,7 @@ func (c *Client) read() {
 		c.closeWithError(cmdErr)
 	}()
 
-	c.setReadTimeout(respReadTimeout) // We're waiting for the greeting
+	c.setReadTimeout(c.options.responseTimeout()) // We're waiting for the greeting
 	for {
 		// Arm the deadline for the wait that is about to happen. dec.EOF blocks
 		// until the first byte of the next response arrives, so this is where a
@@ -712,7 +751,7 @@ func (c *Client) read() {
 func (c *Client) readResponse() error {
 	// The read loop re-arms the deadline for the next wait, so there is nothing
 	// to restore on the way out.
-	c.setReadTimeout(respReadTimeout)
+	c.setReadTimeout(c.options.responseTimeout())
 
 	// Apply the MaxSize budget per response rather than cumulatively.
 	c.dec.ResetCount()

--- a/imapclient/fetch.go
+++ b/imapclient/fetch.go
@@ -907,12 +907,12 @@ func (c *Client) handleFetch(seqNum uint32) error {
 		}
 
 		if done != nil {
-			c.setReadTimeout(literalReadTimeout)
+			c.setReadTimeout(c.options.literalTimeout())
 		}
 		items <- item
 		if done != nil {
 			<-done
-			c.setReadTimeout(respReadTimeout)
+			c.setReadTimeout(c.options.responseTimeout())
 		}
 		return nil
 	})

--- a/imapclient/options_test.go
+++ b/imapclient/options_test.go
@@ -1,0 +1,58 @@
+package imapclient
+
+import (
+	"testing"
+	"time"
+)
+
+// TestOptionsTimeoutDefaults pins the rule that makes these fields safe to add:
+// the zero value means "use the default", never "no timeout".
+//
+// setReadTimeout clears the deadline entirely for a non-positive duration, so
+// passing the raw field through would leave every caller that predates these
+// fields -- i.e. every caller writing Options{...} today -- waiting forever.
+// That would reinstate the hang bounded by the response timeout, without a
+// single compile error to warn anyone.
+func TestOptionsTimeoutDefaults(t *testing.T) {
+	tests := []struct {
+		name                  string
+		options               Options
+		wantResponse, wantLit time.Duration
+	}{
+		{
+			name:         "zero value uses the defaults",
+			options:      Options{},
+			wantResponse: respReadTimeout,
+			wantLit:      literalReadTimeout,
+		},
+		{
+			name:         "configured values are used",
+			options:      Options{ResponseTimeout: 2 * time.Second, LiteralReadTimeout: 90 * time.Second},
+			wantResponse: 2 * time.Second,
+			wantLit:      90 * time.Second,
+		},
+		{
+			name:         "negative falls back to the defaults",
+			options:      Options{ResponseTimeout: -1, LiteralReadTimeout: -1},
+			wantResponse: respReadTimeout,
+			wantLit:      literalReadTimeout,
+		},
+		{
+			name:         "each field is independent",
+			options:      Options{ResponseTimeout: 5 * time.Second},
+			wantResponse: 5 * time.Second,
+			wantLit:      literalReadTimeout,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := tc.options.responseTimeout(); got != tc.wantResponse {
+				t.Errorf("responseTimeout() = %v, want %v", got, tc.wantResponse)
+			}
+			if got := tc.options.literalTimeout(); got != tc.wantLit {
+				t.Errorf("literalTimeout() = %v, want %v", got, tc.wantLit)
+			}
+		})
+	}
+}

--- a/imapclient/options_timeout_test.go
+++ b/imapclient/options_timeout_test.go
@@ -1,0 +1,219 @@
+package imapclient_test
+
+import (
+	"bufio"
+	"io"
+	"net"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/emersion/go-imap/v2"
+	"github.com/emersion/go-imap/v2/imapclient"
+)
+
+// awaitDeadlineWithin waits until the client has armed a read deadline no more
+// than max away, and fails otherwise. It reports the deadline it settled on.
+func awaitDeadlineWithin(t *testing.T, rec *deadlineConn, max time.Duration) time.Duration {
+	t.Helper()
+	deadline := time.Now().Add(2 * time.Second)
+	var last time.Duration
+	for time.Now().Before(deadline) {
+		if got, ok := rec.lastDeadline(); ok {
+			last = time.Until(got)
+			if last <= max {
+				return last
+			}
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	t.Fatalf("read deadline is %v away, want at most %v", last.Round(time.Millisecond), max)
+	return 0
+}
+
+// awaitDeadlineAtLeast waits until the client has armed a read deadline at
+// least min away. The literal deadline is armed only just before the literal is
+// handed to the consumer, so a single sample can still see the response
+// deadline from earlier in the same response.
+func awaitDeadlineAtLeast(t *testing.T, rec *deadlineConn, min time.Duration) time.Duration {
+	t.Helper()
+	deadline := time.Now().Add(5 * time.Second)
+	var last time.Duration
+	for time.Now().Before(deadline) {
+		if got, ok := rec.lastDeadline(); ok {
+			last = time.Until(got)
+			if last >= min {
+				return last
+			}
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	t.Fatalf("read deadline is %v away, want at least %v", last.Round(time.Millisecond), min)
+	return 0
+}
+
+// TestOptionsResponseTimeoutApplied checks that Options.ResponseTimeout reaches
+// the socket: the deadline armed while a command is pending must be the
+// configured one, not the 30s default.
+func TestOptionsResponseTimeoutApplied(t *testing.T) {
+	clientConn, serverConn := net.Pipe()
+	defer clientConn.Close()
+
+	cmdCh := make(chan struct{}, 1)
+	go func() {
+		defer serverConn.Close()
+		br := bufio.NewReader(serverConn)
+		io.WriteString(serverConn, "* OK [CAPABILITY IMAP4rev2] ready\r\n")
+		for {
+			if _, err := br.ReadString('\n'); err != nil {
+				return
+			}
+			select {
+			case cmdCh <- struct{}{}:
+			default:
+			}
+		}
+	}()
+
+	recorder := &deadlineConn{Conn: clientConn}
+	client := imapclient.New(recorder, &imapclient.Options{ResponseTimeout: 2 * time.Second})
+	defer client.Close()
+
+	if err := client.WaitGreeting(); err != nil {
+		t.Fatalf("WaitGreeting() = %v", err)
+	}
+	client.Noop()
+	<-cmdCh
+
+	// Well under the 30s default, so this can only be the configured value.
+	got := awaitDeadlineWithin(t, recorder, 5*time.Second)
+	if got <= 0 {
+		t.Fatalf("read deadline already expired (%v)", got)
+	}
+}
+
+// TestOptionsResponseTimeoutDefaultUnchanged is the compatibility guard: an
+// Options value that does not mention the new fields -- which is every caller
+// written before them -- must keep the 30s default rather than losing its
+// deadline.
+func TestOptionsResponseTimeoutDefaultUnchanged(t *testing.T) {
+	for _, tc := range []struct {
+		name    string
+		options *imapclient.Options
+	}{
+		{name: "nil options", options: nil},
+		{name: "empty options", options: &imapclient.Options{}},
+		{name: "unrelated field set", options: &imapclient.Options{MaxLiteralSize: 1 << 20}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			clientConn, serverConn := net.Pipe()
+			defer clientConn.Close()
+
+			cmdCh := make(chan struct{}, 1)
+			go func() {
+				defer serverConn.Close()
+				br := bufio.NewReader(serverConn)
+				io.WriteString(serverConn, "* OK [CAPABILITY IMAP4rev2] ready\r\n")
+				for {
+					if _, err := br.ReadString('\n'); err != nil {
+						return
+					}
+					select {
+					case cmdCh <- struct{}{}:
+					default:
+					}
+				}
+			}()
+
+			recorder := &deadlineConn{Conn: clientConn}
+			client := imapclient.New(recorder, tc.options)
+			defer client.Close()
+
+			if err := client.WaitGreeting(); err != nil {
+				t.Fatalf("WaitGreeting() = %v", err)
+			}
+			client.Noop()
+			<-cmdCh
+
+			// The default is 30s. Crucially it must also not be unbounded:
+			// a cleared deadline shows up as the zero time, i.e. far in the past.
+			got := awaitDeadlineWithin(t, recorder, 40*time.Second)
+			if got < 20*time.Second {
+				t.Errorf("read deadline is %v away, want ~30s: the default was lost", got.Round(time.Second))
+			}
+		})
+	}
+}
+
+// TestOptionsLiteralReadTimeoutApplied checks the second field: while a literal
+// is open the armed deadline must be the configured literal timeout, which is
+// distinguishable from both the response timeout and the 5 minute default.
+func TestOptionsLiteralReadTimeoutApplied(t *testing.T) {
+	clientConn, serverConn := net.Pipe()
+	defer clientConn.Close()
+
+	const literal = "0123456789"
+	literalOpen := make(chan struct{})
+	finishLiteral := make(chan struct{})
+
+	go func() {
+		defer serverConn.Close()
+		br := bufio.NewReader(serverConn)
+		io.WriteString(serverConn, "* OK [CAPABILITY IMAP4rev2] ready\r\n")
+		for {
+			line, err := br.ReadString('\n')
+			if err != nil {
+				return
+			}
+			fields := strings.Fields(line)
+			if len(fields) < 2 {
+				continue
+			}
+			if strings.EqualFold(fields[1], "FETCH") {
+				io.WriteString(serverConn, "* 1 FETCH (BODY[] {"+strconv.Itoa(len(literal))+"}\r\n")
+				close(literalOpen)
+				<-finishLiteral
+				io.WriteString(serverConn, literal+")\r\n")
+				io.WriteString(serverConn, fields[0]+" OK FETCH completed\r\n")
+				continue
+			}
+			io.WriteString(serverConn, fields[0]+" OK completed\r\n")
+		}
+	}()
+
+	recorder := &deadlineConn{Conn: clientConn}
+	client := imapclient.New(recorder, &imapclient.Options{
+		ResponseTimeout:    2 * time.Second,
+		LiteralReadTimeout: 45 * time.Second,
+	})
+	defer client.Close()
+
+	if err := client.WaitGreeting(); err != nil {
+		t.Fatalf("WaitGreeting() = %v", err)
+	}
+
+	fetchCmd := client.Fetch(imap.SeqSetNum(1), &imap.FetchOptions{
+		BodySection: []*imap.FetchItemBodySection{{}},
+	})
+	resCh := make(chan error, 1)
+	go func() {
+		_, err := fetchCmd.Collect()
+		resCh <- err
+	}()
+
+	<-literalOpen
+	// 45s is chosen to sit clear of every value it could be confused with: the
+	// 2s configured response timeout, the 30s response default, and the 5
+	// minute literal default. Only the configured literal timeout lands in
+	// (35s, 90s), so this cannot pass by observing one of the others.
+	got := awaitDeadlineAtLeast(t, recorder, 35*time.Second)
+	if got > 90*time.Second {
+		t.Errorf("read deadline is %v away while a literal is open, want ~45s: the literal default was used instead of the configured value", got.Round(time.Second))
+	}
+
+	close(finishLiteral)
+	if err := <-resCh; err != nil {
+		t.Fatalf("Fetch().Collect() = %v", err)
+	}
+}


### PR DESCRIPTION
> **Stacked on #35** (`client-response-timeout`) — `readTimeoutLocked`, introduced there, is the main consumer of the response timeout, so basing on `sora` would have left the option not reaching the path that matters most. Retarget to `sora` once #35 lands.

Follows the discussion on exposing the client timeout constants.

## What changes

Two new `Options` fields, resolved through helpers where **zero means the default, never "no timeout"**:

| Field | Default | Why expose it |
|---|---|---|
| `ResponseTimeout` | 30s | After #35 this *is* the dead-peer detection window. A client sending a periodic NOOP wants it shorter. |
| `LiteralReadTimeout` | 5 min | Large mailboxes over slow links want it longer. |

## The zero-value rule is the whole safety of this change

[`setReadTimeout`](imapclient/client.go#L314) clears the deadline **entirely** for a non-positive duration:

```go
if dur > 0 {
    c.conn.SetReadDeadline(time.Now().Add(dur))
} else {
    c.conn.SetReadDeadline(time.Time{})   // ← no deadline at all
}
```

So passing the raw fields through would silently strip the deadlines from **every caller written before these fields existed** — they all pass `&Options{}` without them — reinstating the exact 30-minute hang that #35 just fixed, with nothing failing to compile to warn anyone. That would compile cleanly and fail in production.

`TestOptionsResponseTimeoutDefaultUnchanged` covers all three shapes of that risk: `nil` options, an empty `Options{}`, and an `Options` with only an unrelated field set. Each must still arm ~30s.

## Compatibility

Adding fields is otherwise safe here, and I checked rather than assumed:

- **Unkeyed literals** would break — but every `Options{…}` in the tree is keyed or empty, and `go vet -composites=true ./...` exits 0.
- `Options` stays **comparable** (all pointers/interfaces/`int64` + `time.Duration`).
- Embedding collisions resolve in the caller's favour (their field is at depth 0).
- `MaxLiteralSize` is existing precedent for a limit expressed as an `Options` field.
- The constants were **unexported**, so nothing is renamed or removed — this is purely additive.

## Deliberately still unexported

- **`idleReadTimeout`** (30 min) — coupled to `idleRestartInterval` (28 min) for RFC 2177 re-IDLE. A caller setting it below that would break IDLE rather than tune it.
- **`maxResponseSize`** (8 MiB) — a DoS bound. Making it adjustable invites raising it, undoing the protection added in #30 and #38.

## Tests

`TestOptionsTimeoutDefaults` is a table over the helpers (zero, configured, negative, one-field-set). The two wiring tests assert the deadline the client actually **arms** on the socket, so they stay fast, and **both were confirmed to fail when the options are not consulted** (28s instead of ≤5s; 5m0s instead of ~45s).

The literal test uses 45s deliberately — clear of the 2s configured response timeout, the 30s response default *and* the 5 minute literal default, so it cannot pass by observing any of those. My first version used a looser band and passed for the wrong reason when unwired; that is fixed.

Full `go test ./...` green, `-race` green, and 8 consecutive `-race` runs of `imapclient` clean.

## Also in this branch: a flaky-test fix (commit `2d3b28c`, pushed to #35)

Stress-testing this work surfaced an intermittent failure in `TestClientLiteralNotCutShortByConcurrentCommand` from #35 — roughly one run in three under `-race`. **The product was fine; the test was imprecise.** It took its baseline as soon as the server finished writing the literal header, but that write completes when the *client consumes the bytes*, which can precede the reader arming the literal deadline. In that window `awaitingResp` is still true, so a concurrent command retunes the deadline by design — harmlessly, since the reader arms its own immediately after — and that legitimate retune was being reported as a 30s deadline set mid-literal.

Fixed by waiting for the literal deadline to appear before taking the baseline. It still catches what it was written for: **5 failures out of 5** with the `awaitingResp` guard removed, **0 out of 10** with it in place.