### PR TITLE
imapclient: wait for the greeting before writing a command

### DIFF
--- a/imapclient/client.go
+++ b/imapclient/client.go
@@ -531,7 +531,36 @@ func (c *Client) Close() error {
 // The command name and a space are written.
 //
 // The caller must call commandEncoder.end.
+// awaitGreeting blocks until the server greeting has been read, or until the
+// connection fails.
+//
+// A greeting that reported an error is not surfaced here: the caller still gets
+// to write its command, which then fails through the usual paths. The point is
+// only to establish ordering.
+func (c *Client) awaitGreeting() {
+	select {
+	case <-c.greetingCh:
+	case <-c.decCh:
+	}
+}
+
 func (c *Client) beginCommand(name string, cmd command) *commandEncoder {
+	// No command may be written before the greeting has been read. The greeting
+	// is what says which state the connection starts in -- OK for not
+	// authenticated, PREAUTH for already authenticated, BYE for refused -- so
+	// composing a command ahead of it is speaking out of turn.
+	//
+	// It is also actively harmful. A server hardened against pre-auth plaintext
+	// command injection (CVE-2011-0411 and relatives) discards whatever the
+	// client sent before the session was ready, exactly so injected commands
+	// cannot be replayed into the authenticated session. The command is then
+	// lost and its tag is never answered. Cyrus IMAP does this, which is what
+	// emersion/go-imap#600 hit: LOGIN issued straight after dialling hung.
+	//
+	// The read goroutine arms a read timeout for the greeting, so this wait is
+	// bounded, and it unblocks early if the connection fails.
+	c.awaitGreeting()
+
 	c.encMutex.Lock() // unlocked by commandEncoder.end
 
 	c.mutex.Lock()

--- a/imapclient/greeting_test.go
+++ b/imapclient/greeting_test.go
@@ -1,0 +1,134 @@
+package imapclient_test
+
+import (
+	"bufio"
+	"io"
+	"net"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/emersion/go-imap/v2/imapclient"
+)
+
+// preGreetingServer is a server that throws away anything the client sends
+// before the greeting has been written.
+//
+// This is not a contrived failure mode. Servers hardened against the pre-auth
+// plaintext command injection class of bugs (CVE-2011-0411 and relatives)
+// deliberately discard client input buffered before the session is ready,
+// precisely so that injected commands cannot be replayed into the authenticated
+// session. Cyrus IMAP does it, which is what emersion/go-imap#600 ran into: the
+// client's LOGIN was swallowed and the server never answered its tag.
+type preGreetingServer struct {
+	ln net.Listener
+
+	mu        sync.Mutex
+	discarded string
+}
+
+func newPreGreetingServer(t *testing.T) *preGreetingServer {
+	t.Helper()
+
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("net.Listen() = %v", err)
+	}
+	s := &preGreetingServer{ln: ln}
+	t.Cleanup(func() { ln.Close() })
+
+	go s.serve()
+	return s
+}
+
+func (s *preGreetingServer) serve() {
+	conn, err := s.ln.Accept()
+	if err != nil {
+		return
+	}
+	defer conn.Close()
+
+	// Give a client that does not wait for the greeting time to get its bytes
+	// into the socket, then drain and discard whatever arrived.
+	time.Sleep(250 * time.Millisecond)
+	conn.SetReadDeadline(time.Now().Add(100 * time.Millisecond))
+	buf := make([]byte, 4096)
+	if n, _ := conn.Read(buf); n > 0 {
+		s.mu.Lock()
+		s.discarded = string(buf[:n])
+		s.mu.Unlock()
+	}
+	conn.SetReadDeadline(time.Time{})
+
+	// Advertising the capabilities in the greeting keeps the client from
+	// sending its own CAPABILITY probe, so the only thing on the wire is what
+	// the test asked for.
+	io.WriteString(conn, "* OK [CAPABILITY IMAP4rev2] Cyrus-like server ready\r\n")
+
+	br := bufio.NewReader(conn)
+	for {
+		line, err := br.ReadString('\n')
+		if err != nil {
+			return
+		}
+		fields := strings.Fields(line)
+		if len(fields) < 2 {
+			continue
+		}
+		tag := fields[0]
+		switch strings.ToUpper(fields[1]) {
+		case "CAPABILITY":
+			io.WriteString(conn, "* CAPABILITY IMAP4rev2\r\n")
+			io.WriteString(conn, tag+" OK Completed\r\n")
+		case "LOGIN":
+			io.WriteString(conn, tag+" OK User logged in\r\n")
+		default:
+			io.WriteString(conn, tag+" OK Completed\r\n")
+		}
+	}
+}
+
+func (s *preGreetingServer) addr() string { return s.ln.Addr().String() }
+
+func (s *preGreetingServer) discardedBytes() string {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.discarded
+}
+
+// TestLoginWaitsForGreeting is the regression test for emersion/go-imap#600
+// (reported by tomas-kucera against Cyrus IMAP 2.5).
+//
+// A client that writes a command before the greeting has arrived is speaking
+// out of turn: until the greeting is read it does not know whether the
+// connection is in the Not Authenticated state, is PREAUTH, or is being
+// refused with BYE. Against a server that discards pre-greeting input the
+// command is simply lost and its tag is never answered, so Wait blocks until
+// the response timeout fires.
+//
+// Note that the reporter's own workaround -- calling WaitGreeting first -- is
+// deliberately NOT used here. Needing it is the bug.
+func TestLoginWaitsForGreeting(t *testing.T) {
+	s := newPreGreetingServer(t)
+
+	conn, err := net.Dial("tcp", s.addr())
+	if err != nil {
+		t.Fatalf("net.Dial() = %v", err)
+	}
+
+	// A short response timeout keeps the red case fast: without it this test
+	// would sit on the 30s default before reporting the hang.
+	client := imapclient.New(conn, &imapclient.Options{ResponseTimeout: 3 * time.Second})
+	defer client.Close()
+
+	if err := client.Login("user", "pass").Wait(); err != nil {
+		t.Errorf("Login().Wait() = %v; the command was written before the greeting and the server discarded it", err)
+	}
+
+	// The precise statement of the fix: nothing at all may reach the server
+	// ahead of its greeting.
+	if got := s.discardedBytes(); got != "" {
+		t.Errorf("client sent %q before the greeting, want nothing", got)
+	}
+}


### PR DESCRIPTION
Adopted from upstream issue [emersion/go-imap#600](https://github.com/emersion/go-imap/issues/600), reported by [@tomas-kucera](https://github.com/tomas-kucera) against Cyrus IMAP 2.5. Upstream has no fix; the issue was reopened specifically because the workaround is not one.

## The bug

`beginCommand` wrote to the socket without waiting for the server greeting, so a command issued straight after dialling raced it. The reporter's trace shows the client's `LOGIN` going out *ahead* of the greeting, and the server then answering `T2` but never `T1`:

```
T1 LOGIN "<redacted>" "<redacted>"
* OK [CAPABILITIES ...] Cyrus IMAP 2.5.10 server ready
T2 CAPABILITY
* CAPABILITY ...
T2 OK Completed          <- T1 never answered
```

Two independent things are wrong with sending early:

1. **It is out of turn.** The greeting is what tells the client which state the connection starts in — `OK` (not authenticated), `PREAUTH` (already authenticated), or `BYE` (refused). Issuing `LOGIN` before reading it means acting without knowing whether `LOGIN` is even legal on this connection.

2. **Hardened servers discard it.** Servers mitigating pre-auth plaintext command injection (CVE-2011-0411 and relatives) deliberately throw away client input buffered before the session is ready — that is the whole point of the mitigation, so injected commands cannot be replayed into the authenticated session. The command is swallowed and its tag is never answered. Cyrus does this.

The reporter's workaround was to call `WaitGreeting()` by hand. Needing it is the bug — every caller has to know to do it, and the failure when you forget is a hang rather than an error.

## Impact on sora

Live, though no longer unbounded. Since #35/#39 the wait is capped by the response timeout, so this now surfaces as `i/o timeout` after 30s instead of hanging forever. It is still a failed login against a server that other clients handle fine — relevant wherever we connect out to third-party servers.

## The fix

`beginCommand` waits for the greeting before taking `encMutex` and writing.

- **Bounded.** The read goroutine already arms a read timeout for the greeting, so a silent server surfaces as a timeout, not a hang.
- **Fails fast on a dead connection.** The wait also selects on the decoder channel, so it unblocks if the connection dies.
- **No deadlock.** The only command issued from the read path (`setCaps` → `Capability()`) already detaches into its own goroutine, so it unblocks as soon as the read goroutine closes the greeting channel.
- **Ordering only.** A greeting that reported an error is not surfaced here; the command is still written and fails through the existing paths.

## Tests

`TestLoginWaitsForGreeting` runs against a server that drains and discards anything received before it writes its greeting — a direct model of the Cyrus behaviour. It deliberately does **not** call `WaitGreeting` first, since needing that is the bug. It asserts both that `LOGIN` completes and that nothing reached the server ahead of the greeting.

Red (fix reverted, test kept) — reproduces the reported symptom:

```
--- FAIL: TestLoginWaitsForGreeting (6.25s)
    Login().Wait() = in response: cannot read tag: ... i/o timeout
    client sent "T1 LOGIN \"user\" \"pass\"\r\n" before the greeting, want nothing
```

Green: `--- PASS (0.35s)`, and 10/10 under `-race`.

Full suite `go test ./... -race` green, `gofmt` and `go vet` clean. This one changes ordering for *every* command, so the whole suite passing is the load-bearing check here.