### PR TITLE
imapwire, imapserver: stop applying UTF-7 escaping to UTF-8 mailbox names

### DIFF
--- a/imapserver/list.go
+++ b/imapserver/list.go
@@ -290,11 +290,13 @@ func readListMailbox(dec *imapwire.Decoder) (string, error) {
 		}
 	}
 
+	// Same rule as Decoder.ExpectMailbox: in UTF-8 mode the pattern is taken
+	// verbatim, since modified UTF-7 does not apply there and '&' is an
+	// ordinary character.
 	if dec.QuotedUTF8 {
-		return utf7.Unescape(mailbox)
-	} else {
-		return utf7.Decode(mailbox)
+		return mailbox, nil
 	}
+	return utf7.Decode(mailbox)
 }
 
 func isListChar(ch byte) bool {

--- a/imapserver/list_mailbox_utf8_test.go
+++ b/imapserver/list_mailbox_utf8_test.go
@@ -1,0 +1,61 @@
+package imapserver
+
+import (
+	"bufio"
+	"strings"
+	"testing"
+
+	"github.com/emersion/go-imap/v2/internal/imapwire"
+)
+
+// TestReadListMailboxUTF8NoUnescaping covers the LIST mailbox pattern, which
+// has its own decode path separate from Decoder.ExpectMailbox.
+//
+// The rule is the same: with UTF-8 mode negotiated, modified UTF-7 does not
+// apply (RFC 9051 Appendix E, RFC 6855 §3), so '&' is an ordinary character and
+// the pattern is taken verbatim. Unescaping here would turn a client's LIST of
+// "A&-B" -- four literal characters -- into a LIST of "A&B", quietly matching
+// the wrong mailboxes.
+func TestReadListMailboxUTF8NoUnescaping(t *testing.T) {
+	for _, tc := range []struct {
+		wire string
+		want string
+	}{
+		{`"R&D"`, "R&D"},
+		{`"A&-B"`, "A&-B"},
+		{`"Sales & Marketing"`, "Sales & Marketing"},
+		{`"&"`, "&"},
+		// Wildcards must survive untouched alongside '&'.
+		{`"R&D/*"`, "R&D/*"},
+		{`"plain"`, "plain"},
+	} {
+		t.Run(tc.wire, func(t *testing.T) {
+			dec := imapwire.NewDecoder(bufio.NewReader(strings.NewReader(tc.wire+"\r\n")), imapwire.ConnSideServer)
+			dec.QuotedUTF8 = true
+
+			got, err := readListMailbox(dec)
+			if err != nil {
+				t.Fatalf("readListMailbox(%s) = error %v", tc.wire, err)
+			}
+			if got != tc.want {
+				t.Errorf("readListMailbox(%s) = %q, want %q", tc.wire, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestReadListMailboxUTF7ModeStillDecodes is the counterpart guard: with UTF-8
+// mode off we are speaking IMAP4rev1, where the pattern really is modified
+// UTF-7 and "&-" really does mean a literal '&'.
+func TestReadListMailboxUTF7ModeStillDecodes(t *testing.T) {
+	dec := imapwire.NewDecoder(bufio.NewReader(strings.NewReader("\"R&-D\"\r\n")), imapwire.ConnSideServer)
+	dec.QuotedUTF8 = false
+
+	got, err := readListMailbox(dec)
+	if err != nil {
+		t.Fatalf("readListMailbox() = error %v", err)
+	}
+	if got != "R&D" {
+		t.Errorf("readListMailbox(%q) = %q, want %q", "R&-D", got, "R&D")
+	}
+}

--- a/internal/imapwire/decoder.go
+++ b/internal/imapwire/decoder.go
@@ -602,12 +602,15 @@ func (dec *Decoder) ExpectMailbox(ptr *string) bool {
 		return true
 	}
 
-	var err error
+	// The mirror of Encoder.Mailbox: in UTF-8 mode the bytes on the wire are
+	// the name. Unescaping "&-" here would fold a mailbox genuinely called
+	// "A&-B" -- four ordinary characters to a conformant peer -- down to "A&B".
 	if dec.QuotedUTF8 {
-		name, err = utf7.Unescape(name)
-	} else {
-		name, err = utf7.Decode(name)
+		*ptr = name
+		return true
 	}
+
+	name, err := utf7.Decode(name)
 	if err == nil {
 		*ptr = name
 	}

--- a/internal/imapwire/encoder.go
+++ b/internal/imapwire/encoder.go
@@ -180,14 +180,16 @@ func (enc *Encoder) stringLiteral(s string) {
 func (enc *Encoder) Mailbox(name string) *Encoder {
 	if strings.EqualFold(name, "INBOX") {
 		return enc.Atom("INBOX")
-	} else {
-		if enc.QuotedUTF8 {
-			name = utf7.Escape(name)
-		} else {
-			name = utf7.Encode(name)
-		}
-		return enc.String(name)
 	}
+	// In UTF-8 mode the name goes out verbatim. Modified UTF-7 is not merely
+	// unnecessary there, it is forbidden: RFC 9051 Appendix E removes it from
+	// IMAP4rev2, and RFC 6855 §3 rules it out once UTF8=ACCEPT is enabled. So
+	// '&' carries no special meaning and must not be escaped -- escaping it
+	// would make a CREATE of "R&D" arrive as the name "R&-D".
+	if !enc.QuotedUTF8 {
+		name = utf7.Encode(name)
+	}
+	return enc.String(name)
 }
 
 func (enc *Encoder) NumSet(numSet imap.NumSet) *Encoder {

--- a/internal/imapwire/mailbox_utf8_test.go
+++ b/internal/imapwire/mailbox_utf8_test.go
@@ -1,0 +1,115 @@
+package imapwire
+
+import (
+	"bufio"
+	"bytes"
+	"strings"
+	"testing"
+)
+
+// Mailbox names that exercise '&', the one character modified UTF-7 gives a
+// special meaning to (RFC 3501 §5.1.3: a literal '&' is sent as "&-").
+//
+// In UTF-8 mode that special meaning is gone. RFC 9051 Appendix E removes
+// modified UTF-7 from IMAP4rev2 outright, and RFC 6855 §3 forbids it once
+// UTF8=ACCEPT is enabled, so '&' is an ordinary character and the name goes on
+// the wire verbatim.
+//
+// These are not exotic names: "R&D" and "Sales & Marketing" are the kind of
+// folder people actually have.
+var utf8MailboxNames = []struct {
+	name string // the mailbox name the application asked for
+	wire string // exactly what UTF-8 mode must put between the quotes
+}{
+	{"R&D", "R&D"},
+	{"Sales & Marketing", "Sales & Marketing"},
+	// A name that literally contains the modified-UTF-7 escape sequence. In
+	// UTF-8 mode it is four ordinary characters and must survive untouched.
+	{"A&-B", "A&-B"},
+	{"&", "&"},
+	{"plain", "plain"},
+}
+
+// TestEncodeMailboxUTF8NoUTF7Escaping checks that UTF-8 mode puts the mailbox
+// name on the wire verbatim.
+//
+// Escaping '&' here corrupts the name for any conformant peer: a server reading
+// IMAP4rev2 takes the bytes literally, so a CREATE of "R&D" that goes out as
+// "R&-D" creates a mailbox actually named "R&-D".
+func TestEncodeMailboxUTF8NoUTF7Escaping(t *testing.T) {
+	for _, tc := range utf8MailboxNames {
+		t.Run(tc.name, func(t *testing.T) {
+			var buf bytes.Buffer
+			bw := bufio.NewWriter(&buf)
+			enc := NewEncoder(bw, ConnSideClient)
+			enc.QuotedUTF8 = true
+			enc.Mailbox(tc.name)
+			if err := bw.Flush(); err != nil {
+				t.Fatalf("flush: %v", err)
+			}
+
+			got := buf.String()
+			// The encoder may pick a quoted string or an atom; compare the
+			// payload rather than the framing.
+			payload := strings.Trim(got, `"`)
+			if payload != tc.wire {
+				t.Errorf("Mailbox(%q) put %q on the wire, want %q", tc.name, payload, tc.wire)
+			}
+		})
+	}
+}
+
+// TestDecodeMailboxUTF8NoUTF7Unescaping is the receiving half: in UTF-8 mode
+// the bytes on the wire are the name, with no unescaping applied.
+//
+// Unescaping here corrupts names sent by conformant clients: a client that
+// creates a mailbox genuinely called "A&-B" has that name silently folded to
+// "A&B".
+func TestDecodeMailboxUTF8NoUTF7Unescaping(t *testing.T) {
+	for _, tc := range utf8MailboxNames {
+		t.Run(tc.name, func(t *testing.T) {
+			input := `"` + tc.wire + `"` + "\r\n"
+			dec := NewDecoder(bufio.NewReader(strings.NewReader(input)), ConnSideServer)
+			dec.QuotedUTF8 = true
+
+			var got string
+			if !dec.ExpectMailbox(&got) {
+				t.Fatalf("ExpectMailbox() failed: %v", dec.Err())
+			}
+			if got != tc.name {
+				t.Errorf("wire %q decoded to %q, want %q", tc.wire, got, tc.name)
+			}
+		})
+	}
+}
+
+// TestMailboxUTF7ModeStillEscapes guards the other half of the switch: with
+// UTF-8 mode off we are speaking IMAP4rev1, where modified UTF-7 very much does
+// apply and a literal '&' must still be sent as "&-".
+//
+// Without this, "stop escaping in UTF-8 mode" could be satisfied by never
+// escaping at all, which would break every IMAP4rev1 peer.
+func TestMailboxUTF7ModeStillEscapes(t *testing.T) {
+	var buf bytes.Buffer
+	bw := bufio.NewWriter(&buf)
+	enc := NewEncoder(bw, ConnSideClient)
+	enc.QuotedUTF8 = false
+	enc.Mailbox("R&D")
+	if err := bw.Flush(); err != nil {
+		t.Fatalf("flush: %v", err)
+	}
+
+	if payload := strings.Trim(buf.String(), `"`); payload != "R&-D" {
+		t.Errorf("Mailbox(%q) in modified UTF-7 mode put %q on the wire, want %q", "R&D", payload, "R&-D")
+	}
+
+	dec := NewDecoder(bufio.NewReader(strings.NewReader("\"R&-D\"\r\n")), ConnSideServer)
+	dec.QuotedUTF8 = false
+	var got string
+	if !dec.ExpectMailbox(&got) {
+		t.Fatalf("ExpectMailbox() failed: %v", dec.Err())
+	}
+	if got != "R&D" {
+		t.Errorf("modified UTF-7 wire %q decoded to %q, want %q", "R&-D", got, "R&D")
+	}
+}

--- a/internal/utf7/decoder.go
+++ b/internal/utf7/decoder.go
@@ -116,34 +116,3 @@ func decode(b64 []byte) []byte {
 	}
 	return s[:j]
 }
-
-// Unescape passes through raw UTF-8 as-is and unescapes the special UTF-7 marker
-// (the "&-" sequence back to "&").
-func Unescape(src string) (string, error) {
-	if !utf8.ValidString(src) {
-		return "", errors.New("invalid UTF-8")
-	}
-
-	var sb strings.Builder
-	sb.Grow(len(src))
-
-	for i := 0; i < len(src); i++ {
-		ch := src[i]
-
-		if ch != '&' {
-			sb.WriteByte(ch)
-			continue
-		}
-
-		// Check if this is an escape sequence "&-"
-		if i+1 < len(src) && src[i+1] == '-' {
-			sb.WriteByte('&')
-			i++ // Skip the '-'
-		} else {
-			// This is not an escape sequence, keep the '&' as-is
-			sb.WriteByte(ch)
-		}
-	}
-
-	return sb.String(), nil
-}

--- a/internal/utf7/encoder.go
+++ b/internal/utf7/encoder.go
@@ -70,19 +70,3 @@ func encode(s []byte) []byte {
 	b64[n-1] = '-'
 	return b64
 }
-
-// Escape passes through raw UTF-8 as-is and escapes the special UTF-7 marker
-// (the ampersand character).
-func Escape(src string) string {
-	var sb strings.Builder
-	sb.Grow(len(src))
-
-	for _, ch := range src {
-		sb.WriteRune(ch)
-		if ch == '&' {
-			sb.WriteByte('-')
-		}
-	}
-
-	return sb.String()
-}


### PR DESCRIPTION
Found via [emersion/go-imap#734](https://github.com/emersion/go-imap/pull/734) by [@arnt](https://github.com/arnt), which makes the same correction to the encoder and decoder upstream.

This one is worth flagging as a **live interop bug**, not a feature port. It corrupts ordinary mailbox names — `R&D`, `Sales & Marketing` — against any third-party server.

## The rule

In UTF-8 mode the mailbox name on the wire *is* the name. Modified UTF-7 is not merely unnecessary there, it is excluded:

- **RFC 9051 Appendix E** — "Support for the Modified UTF-7 encoding of mailbox names is removed. Mailbox names are now encoded in UTF-8."
- **RFC 6855 §3** — modified UTF-7 must not be used once `UTF8=ACCEPT` is enabled.

So `&` is an ordinary character, and the `&` → `&-` escape that modified UTF-7 defines (RFC 3501 §5.1.3) must not be applied.

## Three sites applied it anyway

| Site | Did |
|---|---|
| `imapwire.Encoder.Mailbox` | escaped `&` via `utf7.Escape` |
| `imapwire.Decoder.ExpectMailbox` | unescaped `&-` via `utf7.Unescape` |
| `imapserver.readListMailbox` | same, for LIST patterns |

**Outbound is the severe direction.** Every mailbox name containing `&` was corrupted for a conformant peer:

```
Mailbox("R&D")               put "R&-D"               on the wire, want "R&D"
Mailbox("Sales & Marketing") put "Sales &- Marketing" on the wire, want "Sales & Marketing"
Mailbox("A&-B")              put "A&--B"              on the wire, want "A&-B"
```

Creating `R&D` against Dovecot or Cyrus actually created a mailbox named `R&-D`.

**Inbound was narrower**, because the unescape was lenient about a bare `&`: only names that genuinely contain `&-` were hit. A client asking for `A&-B` — four ordinary characters — silently got `A&B`, and a LIST pattern of `A&-B` quietly matched the wrong mailboxes.

## Why our tests could not have caught it

The encode and decode halves were **exact inverses**. Any name round-tripped through this library came back unchanged; only the bytes exchanged between two independent peers were wrong. `utf7.Escape` and `utf7.Unescape` had no tests at all.

So the new tests assert **wire bytes**, not round-trips. That is the only formulation that can see this class of bug.

There are also counterpart guards (`TestMailboxUTF7ModeStillEscapes`, `TestReadListMailboxUTF7ModeStillDecodes`) pinning IMAP4rev1 behaviour, since "stop escaping in UTF-8 mode" could otherwise be satisfied by never escaping at all — which would break every IMAP4rev1 peer.

## Verified discriminating

With all three fix sites reverted and the tests kept:

```
mailbox_utf8_test.go:56: Mailbox("R&D") put "R&-D" on the wire, want "R&D"
mailbox_utf8_test.go:80: wire "A&-B" decoded to "A&B", want "A&-B"
list_mailbox_utf8_test.go:41: readListMailbox("A&-B") = "A&B", want "A&-B"
```

## Rollout note

**End-to-end behaviour between our own client and server does not change** — the escape and unescape cancelled out, so names already stored are the true names.

What changes is interop. One mixed-rollout caveat worth knowing: an **unfixed client against a fixed server** will create `&` names carrying a literal `&-` until both ends are updated. The reverse pairing is unaffected, because the old unescape left a bare `&` alone.

## Also removed

`utf7.Escape` and `utf7.Unescape` are deleted. Both are now unused, and they encode the very assumption that caused this — leaving them invites re-introduction. `internal/` only, so no exported API changes.

`go test ./... -race` green, `go vet` and `gofmt` clean.