### PR TITLE
imapserver: implement the NOTIFY extension (RFC 5465)

### DIFF
--- a/imap.go
+++ b/imap.go
@@ -59,6 +59,12 @@ const (
 	MailboxAttrSubscribed    MailboxAttr = "\\Subscribed"
 	MailboxAttrRemote        MailboxAttr = "\\Remote"
 
+	// MailboxAttrNoAccess reports that the client can LIST the mailbox but
+	// lacks a right required to monitor it with NOTIFY (RFC 5465 sections 3.1
+	// and 5.9). Deciding when it applies is up to the backend, which owns the
+	// access-control model.
+	MailboxAttrNoAccess MailboxAttr = "\\NoAccess"
+
 	// Role (aka. "special-use") attributes
 	MailboxAttrAll       MailboxAttr = "\\All"
 	MailboxAttrArchive   MailboxAttr = "\\Archive"

--- a/imapclient/client.go
+++ b/imapclient/client.go
@@ -1309,7 +1309,25 @@ type UnilateralDataMailbox struct {
 type UnilateralDataHandler struct {
 	Expunge func(seqNum uint32)
 	Mailbox func(data *UnilateralDataMailbox)
-	Fetch   func(msg *FetchMessageData)
+
+	// Fetch is called for an unsolicited FETCH response, such as the flag
+	// update a NOTIFY FlagChange event produces for the selected mailbox
+	// (RFC 5465 §5.1).
+	//
+	// One case is not routed here: a FETCH command is in flight and the
+	// notification concerns a message inside its set. Nothing distinguishes
+	// the two at the point the response must be attributed — the data items
+	// have not been read yet, and FLAGS legitimately accompany a command's own
+	// data (a FETCH that implicitly sets \Seen reports the new flags the same
+	// way) — so the notification is attributed to the command. The cost is
+	// real: that message's buffer then holds the notification's items instead
+	// of the requested ones, and the command's own response for it, arriving
+	// afterwards, is treated as unsolicited and reaches this handler instead.
+	// A client that runs FETCH commands while watching FlagChange on the
+	// selected mailbox should therefore treat a message buffer that lacks a
+	// requested item as incomplete and re-fetch it, or keep FlagChange out of
+	// the SELECTED specifier of its watch.
+	Fetch func(msg *FetchMessageData)
 
 	// Requires ENABLE QRESYNC.
 	Vanished func(data *imap.VanishedData)

--- a/imapclient/client.go
+++ b/imapclient/client.go
@@ -1465,12 +1465,25 @@ type UnilateralDataHandler struct {
 	//
 	// Used with NOTIFY MailboxName events (RFC 5465) to detect mailbox
 	// creation, deletion, or renaming, and for subscription changes.
+	//
+	// A LIST command in flight absorbs the unsolicited LIST responses whose
+	// mailbox its reference and pattern match: those reach the command's
+	// result instead of this handler (the two are indistinguishable on the
+	// wire). An application that needs every notification should avoid running
+	// LIST while it depends on this handler, or reconcile the command's own
+	// results against the changes it expected to be notified of.
 	List func(data *imap.ListData)
 
 	// Called when the server sends an unsolicited STATUS response.
 	//
 	// Commonly used with NOTIFY to receive mailbox status updates
 	// for non-selected mailboxes (RFC 5465).
+	//
+	// A STATUS command in flight absorbs the unsolicited STATUS responses for
+	// the mailbox it asked about: they are merged into the command's result
+	// and do not reach this handler. An application that needs every
+	// notification should avoid running STATUS for a watched mailbox while it
+	// depends on this handler.
 	Status func(data *imap.StatusData)
 
 	// Called when the server sends NOTIFICATIONOVERFLOW (RFC 5465).

--- a/imapclient/client_test.go
+++ b/imapclient/client_test.go
@@ -106,6 +106,7 @@ func newMemClientServerPair(t *testing.T) (net.Conn, io.Closer) {
 			imap.CapCondStore:                 {},
 			imap.CapQResync:                   {},
 			imap.CapMetadata:                  {},
+			imap.CapNotify:                    {},
 			imap.Cap("THREAD=REFERENCES"):     {},
 			imap.Cap("THREAD=ORDEREDSUBJECT"): {},
 			imap.Cap("MULTISEARCH"):           {},

--- a/imapclient/fetch.go
+++ b/imapclient/fetch.go
@@ -87,6 +87,18 @@ func (c *Client) Fetch(numSet imap.NumSet, options *imap.FetchOptions) *FetchCom
 	return cmd
 }
 
+// hasFetchItems reports whether options select at least one data item, i.e.
+// whether writeFetchItems would produce a non-empty list.
+func hasFetchItems(options *imap.FetchOptions) bool {
+	if options == nil {
+		return false
+	}
+	return options.UID || options.BodyStructure != nil || options.Envelope ||
+		options.Flags || options.InternalDate || options.RFC822Size ||
+		options.ModSeq || len(options.BodySection) > 0 ||
+		len(options.BinarySection) > 0 || len(options.BinarySectionSize) > 0
+}
+
 func writeFetchItems(enc *imapwire.Encoder, numKind imapwire.NumKind, options *imap.FetchOptions) {
 	listEnc := enc.BeginList()
 
@@ -704,6 +716,14 @@ func (c *Client) handleFetch(seqNum uint32) error {
 			if !ok {
 				return false
 			}
+
+			// Note: an unsolicited FETCH (a NOTIFY FlagChange for the
+			// selected mailbox, RFC 5465 §5.1) for a message inside this
+			// command's set is indistinguishable from the command's own
+			// response at this point — the items have not been read yet, and
+			// FLAGS legitimately accompany requested data items (a FETCH that
+			// implicitly sets \Seen reports it the same way). It is therefore
+			// attributed to the command; see UnilateralDataHandler.Fetch.
 
 			// Skip if we haven't requested or already handled this message
 			if _, ok := cmd.numSet.(imap.UIDSet); ok {

--- a/imapclient/list.go
+++ b/imapclient/list.go
@@ -67,6 +67,8 @@ func getReturnOpts(options *imap.ListOptions) []string {
 func (c *Client) List(ref, pattern string, options *imap.ListOptions) *ListCommand {
 	cmd := &ListCommand{
 		mailboxes:      make(chan *imap.ListData, 64),
+		ref:            ref,
+		pattern:        pattern,
 		returnStatus:   options != nil && options.ReturnStatus != nil,
 		returnMetadata: options != nil && options.ReturnMetadata != nil,
 	}
@@ -109,7 +111,7 @@ func (c *Client) handleList() error {
 	cmd := c.findPendingCmdFunc(func(cmd command) bool {
 		switch cmd := cmd.(type) {
 		case *ListCommand:
-			return true // TODO: match pattern, check if already handled
+			return cmd.matches(data)
 		case *SelectCommand:
 			return cmd.mailbox == data.Mailbox && cmd.data.List == nil
 		default:
@@ -144,9 +146,51 @@ type ListCommand struct {
 	commandBase
 	mailboxes chan *imap.ListData
 
+	ref            string
+	pattern        string
 	returnStatus   bool
 	returnMetadata bool
 	pendingData    *imap.ListData
+}
+
+// matches reports whether a LIST response belongs to this command rather than
+// being unsolicited. With NOTIFY (RFC 5465 §5.4, §5.5) a LIST response can
+// arrive at any time, including while a LIST command is in flight.
+//
+// The test is deliberately lopsided: mistaking the command's own response for
+// an unsolicited one loses data the caller asked for, while the reverse merely
+// adds a mailbox to the results. So anything that could plausibly answer this
+// command is claimed, and only a clear mismatch is treated as unsolicited.
+func (cmd *ListCommand) matches(data *imap.ListData) bool {
+	if data.ChildInfo != nil {
+		// A RECURSIVEMATCH parent is reported because of its children, so it
+		// need not match the pattern itself.
+		return true
+	}
+	if cmd.pattern == "" {
+		// RFC 9051 §6.3.9: an empty mailbox name asks for the hierarchy
+		// delimiter, answered with the reference's root — which by definition
+		// does not match the (empty) pattern.
+		return true
+	}
+	// The wire form is what the server matched against: INBOX is canonicalized
+	// to upper case in both directions (RFC 9051 §6.3.9 has the server match
+	// and report the uppercase spelling), so compare the canonical forms.
+	return internal.MatchList(data.Mailbox, data.Delim, canonicalMailbox(cmd.ref), canonicalMailbox(cmd.pattern))
+}
+
+// canonicalMailbox spells a mailbox name the way the encoder puts it on the
+// wire, so that a name coming back from the server can be compared with it.
+//
+// It mirrors Encoder.Mailbox exactly: only a name that is entirely "INBOX" is
+// rewritten. Anything else is sent verbatim, so rewriting a mere prefix here
+// would compare against a string the server never saw — and drop the response.
+func canonicalMailbox(name string) string {
+	const inbox = "INBOX"
+	if strings.EqualFold(name, inbox) {
+		return inbox
+	}
+	return name
 }
 
 // Next advances to the next mailbox.

--- a/imapclient/list_test.go
+++ b/imapclient/list_test.go
@@ -362,3 +362,46 @@ func TestListReturnMetadata(t *testing.T) {
 		t.Fatalf("List() did not return all metadata")
 	}
 }
+
+// TestListMatchesOwnResponses checks the forms whose LIST responses must be
+// attributed to the command rather than treated as unsolicited: a
+// case-insensitive INBOX, a non-empty reference, and the empty mailbox name of
+// RFC 9051 section 6.3.9.
+func TestListMatchesOwnResponses(t *testing.T) {
+	client, server := newClientServerPair(t, imap.ConnStateAuthenticated)
+	defer client.Close()
+	defer server.Close()
+
+	if err := client.Create("INBOX/Sub", nil).Wait(); err != nil {
+		t.Fatalf("Create() = %v", err)
+	}
+	if err := client.Create("inboxfoo", nil).Wait(); err != nil {
+		t.Fatalf("Create() = %v", err)
+	}
+
+	for _, tc := range []struct {
+		name    string
+		ref     string
+		pattern string
+		want    int
+	}{
+		{name: "LowercaseInboxPattern", ref: "", pattern: "inbox", want: 1},
+		{name: "UppercaseInboxPattern", ref: "", pattern: "INBOX", want: 1},
+		{name: "LowercaseInboxRef", ref: "inbox", pattern: "%", want: 1},
+		{name: "UppercaseInboxRef", ref: "INBOX", pattern: "%", want: 1},
+		{name: "EmptyMailboxName", ref: "INBOX", pattern: "", want: 1},
+		// Only a whole "INBOX" is canonicalized, so a mailbox that merely
+		// starts with those letters must not be rewritten.
+		{name: "InboxPrefixedName", ref: "", pattern: "inboxfoo", want: 1},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			mailboxes, err := client.List(tc.ref, tc.pattern, nil).Collect()
+			if err != nil {
+				t.Fatalf("List(%q, %q) = %v", tc.ref, tc.pattern, err)
+			}
+			if len(mailboxes) != tc.want {
+				t.Errorf("List(%q, %q) returned %v mailboxes, want %v", tc.ref, tc.pattern, len(mailboxes), tc.want)
+			}
+		})
+	}
+}

--- a/imapclient/notify.go
+++ b/imapclient/notify.go
@@ -82,8 +82,11 @@ func encodeNotifyOptions(enc *imapwire.Encoder, options *imap.NotifyOptions) err
 					enc.SP()
 				}
 				enc.Atom(string(ev))
-				if ev == imap.NotifyEventMessageNew && item.MessageNewFetch != nil {
-					// MessageNew [SP "(" fetch-att *(SP fetch-att) ")"]
+				// message-event = "MessageNew" [SP "(" fetch-att
+				// *(SP fetch-att) ")"] — the group must hold at least one
+				// fetch-att (RFC 5465 §8), so fetch options that select
+				// nothing are encoded as a bare MessageNew.
+				if ev == imap.NotifyEventMessageNew && hasFetchItems(item.MessageNewFetch) {
 					enc.SP()
 					writeFetchItems(enc, imapwire.NumKindSeq, item.MessageNewFetch)
 				}

--- a/imapclient/notify.go
+++ b/imapclient/notify.go
@@ -41,10 +41,10 @@ func encodeNotifyOptions(enc *imapwire.Encoder, options *imap.NotifyOptions) err
 
 	enc.SP().Atom("SET")
 
+	// status-indicator = SP "STATUS" (RFC 5465 section 8): a bare atom, not
+	// a parenthesized list.
 	if options.Status {
-		enc.SP().List(1, func(i int) {
-			enc.Atom("STATUS")
-		})
+		enc.SP().Atom("STATUS")
 	}
 
 	for _, item := range options.Items {
@@ -52,26 +52,45 @@ func encodeNotifyOptions(enc *imapwire.Encoder, options *imap.NotifyOptions) err
 			return fmt.Errorf("invalid NOTIFY item: must specify either MailboxSpec or Mailboxes")
 		}
 
-		enc.SP().List(1, func(_ int) {
-			if item.MailboxSpec != "" {
-				enc.Atom(string(item.MailboxSpec))
+		enc.SP().Special('(')
+		if item.MailboxSpec != "" {
+			enc.Atom(string(item.MailboxSpec))
+		} else {
+			// filter-mailboxes-other = ("subtree" SP one-or-more-mailbox) /
+			//                          ("mailboxes" SP one-or-more-mailbox)
+			// The MAILBOXES keyword is required by the grammar; without it the
+			// group is not valid RFC 5465 syntax.
+			if item.Subtree {
+				enc.Atom("SUBTREE")
 			} else {
-				// len(item.Mailboxes) > 0, as per the check above.
-				if item.Subtree {
-					enc.Atom("SUBTREE").SP()
+				enc.Atom("MAILBOXES")
+			}
+			enc.SP().List(len(item.Mailboxes), func(j int) {
+				enc.Mailbox(item.Mailboxes[j])
+			})
+		}
+
+		// events = ("(" event *(SP event) ")") / "NONE": the events part is
+		// mandatory in each event-group, an empty list is spelled NONE.
+		enc.SP()
+		if len(item.Events) == 0 {
+			enc.Atom("NONE")
+		} else {
+			enc.Special('(')
+			for j, ev := range item.Events {
+				if j > 0 {
+					enc.SP()
 				}
-				enc.List(len(item.Mailboxes), func(j int) {
-					enc.Mailbox(item.Mailboxes[j])
-				})
+				enc.Atom(string(ev))
+				if ev == imap.NotifyEventMessageNew && item.MessageNewFetch != nil {
+					// MessageNew [SP "(" fetch-att *(SP fetch-att) ")"]
+					enc.SP()
+					writeFetchItems(enc, imapwire.NumKindSeq, item.MessageNewFetch)
+				}
 			}
-
-			if len(item.Events) > 0 {
-				enc.SP().List(len(item.Events), func(j int) {
-					enc.Atom(string(item.Events[j]))
-				})
-			}
-		})
-
+			enc.Special(')')
+		}
+		enc.Special(')')
 	}
 
 	return nil

--- a/imapclient/notify_encode_test.go
+++ b/imapclient/notify_encode_test.go
@@ -145,7 +145,7 @@ func TestEncodeNotifyOptions(t *testing.T) {
 					},
 				},
 			},
-			expected: ` SET ((INBOX "Sent") (MessageNew MessageExpunge FlagChange))` + "\r\n",
+			expected: ` SET (MAILBOXES (INBOX "Sent") (MessageNew MessageExpunge FlagChange))` + "\r\n",
 		},
 		{
 			name: "StatusIndicator",
@@ -161,7 +161,7 @@ func TestEncodeNotifyOptions(t *testing.T) {
 					},
 				},
 			},
-			expected: " SET (STATUS) (SELECTED (MessageNew MessageExpunge))\r\n",
+			expected: " SET STATUS (SELECTED (MessageNew MessageExpunge))\r\n",
 		},
 		{
 			name: "MultipleItems",
@@ -222,7 +222,7 @@ func TestEncodeNotifyOptions(t *testing.T) {
 					},
 				},
 			},
-			expected: " SET (SELECTED)\r\n",
+			expected: " SET (SELECTED NONE)\r\n",
 		},
 		{
 			name: "ComplexMixed",
@@ -251,7 +251,26 @@ func TestEncodeNotifyOptions(t *testing.T) {
 					},
 				},
 			},
-			expected: ` SET (STATUS) (SELECTED (MessageNew MessageExpunge)) (SUBTREE (INBOX) (MessageNew)) (("Drafts" "Sent") (FlagChange))` + "\r\n",
+			expected: ` SET STATUS (SELECTED (MessageNew MessageExpunge)) (SUBTREE (INBOX) (MessageNew)) (MAILBOXES ("Drafts" "Sent") (FlagChange))` + "\r\n",
+		},
+		{
+			name: "MessageNewFetchAtts",
+			options: &imap.NotifyOptions{
+				Items: []imap.NotifyItem{
+					{
+						MailboxSpec: imap.NotifyMailboxSpecSelected,
+						Events: []imap.NotifyEvent{
+							imap.NotifyEventMessageNew,
+							imap.NotifyEventMessageExpunge,
+						},
+						MessageNewFetch: &imap.FetchOptions{
+							UID:   true,
+							Flags: true,
+						},
+					},
+				},
+			},
+			expected: " SET (SELECTED (MessageNew (UID FLAGS) MessageExpunge))\r\n",
 		},
 		{
 			name: "MailboxWithSpecialChars",
@@ -265,7 +284,7 @@ func TestEncodeNotifyOptions(t *testing.T) {
 					},
 				},
 			},
-			expected: ` SET ((INBOX "Foo Bar" "Test&-Mailbox") (MessageNew))` + "\r\n",
+			expected: ` SET (MAILBOXES (INBOX "Foo Bar" "Test&-Mailbox") (MessageNew))` + "\r\n",
 		},
 	}
 

--- a/imapclient/notify_server_test.go
+++ b/imapclient/notify_server_test.go
@@ -413,3 +413,165 @@ func TestNotifyIntegration_BadEvent(t *testing.T) {
 		t.Errorf("response code = %v, want BADEVENT", imapErr.Code)
 	}
 }
+
+// TestNotifyIntegration_MetadataChange verifies that a metadata change in a
+// watched mailbox reaches the client's unilateral METADATA handler. RFC 5464
+// section 4.4 requires the unsolicited form to carry entry names only, which is
+// also the only form imapclient reports as unsolicited.
+func TestNotifyIntegration_MetadataChange(t *testing.T) {
+	addr, _, closer := newNotifyIntegrationServer(t, "INBOX")
+	defer closer()
+
+	type metadataNotification struct {
+		mailbox string
+		entries []string
+	}
+	metadataCh := make(chan metadataNotification, 8)
+	client := dialNotifyClient(t, addr, &imapclient.Options{
+		UnilateralDataHandler: &imapclient.UnilateralDataHandler{
+			Metadata: func(mailbox string, entries []string) {
+				metadataCh <- metadataNotification{mailbox: mailbox, entries: entries}
+			},
+		},
+	})
+	defer client.Close()
+
+	cmd, err := client.Notify(&imap.NotifyOptions{
+		Items: []imap.NotifyItem{{
+			MailboxSpec: imap.NotifyMailboxSpecPersonal,
+			Events:      []imap.NotifyEvent{imap.NotifyEventMailboxMetadataChange},
+		}},
+	})
+	if err != nil {
+		t.Fatalf("Notify() = %v", err)
+	}
+	if err := cmd.Wait(); err != nil {
+		t.Fatalf("Notify().Wait() = %v", err)
+	}
+
+	// A second connection changes an annotation of the watched mailbox.
+	other := dialNotifyClient(t, addr, nil)
+	defer other.Close()
+	value := []byte("hello")
+	if err := other.SetMetadata("INBOX", map[string]*[]byte{"/private/comment": &value}).Wait(); err != nil {
+		t.Fatalf("SetMetadata() = %v", err)
+	}
+
+	select {
+	case notification := <-metadataCh:
+		if notification.mailbox != "INBOX" {
+			t.Errorf("METADATA for mailbox %q, want INBOX", notification.mailbox)
+		}
+		if len(notification.entries) != 1 || notification.entries[0] != "/private/comment" {
+			t.Errorf("METADATA entries = %v, want [/private/comment]", notification.entries)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("timeout waiting for the unsolicited METADATA notification")
+	}
+}
+
+// TestNotifyIntegration_UnsolicitedListNotAbsorbed verifies that an unsolicited
+// LIST arriving while a LIST command is in flight is reported to the unilateral
+// handler instead of being appended to the command's results (RFC 5465 section
+// 5.4 delivers MailboxName events this way, at any time).
+func TestNotifyIntegration_UnsolicitedListNotAbsorbed(t *testing.T) {
+	addr, user, closer := newNotifyIntegrationServer(t, "Box1", "Box2")
+	defer closer()
+
+	listCh := make(chan *imap.ListData, 8)
+	client := dialNotifyClient(t, addr, &imapclient.Options{
+		UnilateralDataHandler: &imapclient.UnilateralDataHandler{
+			List: func(data *imap.ListData) { listCh <- data },
+		},
+	})
+	defer client.Close()
+
+	cmd, err := client.Notify(&imap.NotifyOptions{
+		Items: []imap.NotifyItem{{
+			MailboxSpec: imap.NotifyMailboxSpecPersonal,
+			Events:      []imap.NotifyEvent{imap.NotifyEventMailboxName},
+		}},
+	})
+	if err != nil {
+		t.Fatalf("Notify() = %v", err)
+	}
+	if err := cmd.Wait(); err != nil {
+		t.Fatalf("Notify().Wait() = %v", err)
+	}
+
+	// Create a mailbox outside the pattern the client is about to list. The
+	// notification races the LIST command's own responses.
+	if err := user.Create(context.Background(), "OutOfBand", nil); err != nil {
+		t.Fatalf("Create() = %v", err)
+	}
+
+	mailboxes, err := client.List("", "Box*", nil).Collect()
+	if err != nil {
+		t.Fatalf("List() = %v", err)
+	}
+	for _, data := range mailboxes {
+		if data.Mailbox == "OutOfBand" {
+			t.Errorf("unsolicited LIST was absorbed by the LIST command: %v", data.Mailbox)
+		}
+	}
+
+	select {
+	case data := <-listCh:
+		if data.Mailbox != "OutOfBand" {
+			t.Errorf("unilateral LIST for %q, want OutOfBand", data.Mailbox)
+		}
+	case <-time.After(5 * time.Second):
+		t.Error("timeout waiting for the unsolicited LIST notification")
+	}
+}
+
+// TestNotifyIntegration_UnsolicitedStatusNotAbsorbed verifies that a second
+// STATUS response for the mailbox of an in-flight STATUS command is treated as
+// unsolicited (RFC 5465 sections 5.1-5.3) instead of overwriting its result.
+func TestNotifyIntegration_UnsolicitedStatusNotAbsorbed(t *testing.T) {
+	addr, user, closer := newNotifyIntegrationServer(t, "Archive")
+	defer closer()
+
+	statusCh := make(chan *imap.StatusData, 8)
+	client := dialNotifyClient(t, addr, &imapclient.Options{
+		UnilateralDataHandler: &imapclient.UnilateralDataHandler{
+			Status: func(data *imap.StatusData) { statusCh <- data },
+		},
+	})
+	defer client.Close()
+
+	cmd, err := client.Notify(&imap.NotifyOptions{
+		Items: []imap.NotifyItem{{
+			MailboxSpec: imap.NotifyMailboxSpecPersonal,
+			Events: []imap.NotifyEvent{
+				imap.NotifyEventMessageNew,
+				imap.NotifyEventMessageExpunge,
+			},
+		}},
+	})
+	if err != nil {
+		t.Fatalf("Notify() = %v", err)
+	}
+	if err := cmd.Wait(); err != nil {
+		t.Fatalf("Notify().Wait() = %v", err)
+	}
+
+	if _, err := user.Append(context.Background(), "Archive", newNotifyLiteral(notifyTestMessage), &imap.AppendOptions{}); err != nil {
+		t.Fatalf("Append() = %v", err)
+	}
+	select {
+	case <-statusCh:
+	case <-time.After(5 * time.Second):
+		t.Fatal("timeout waiting for the unsolicited STATUS")
+	}
+
+	// The STATUS command must still get its own answer, with the items it
+	// asked for.
+	data, err := client.Status("Archive", &imap.StatusOptions{NumMessages: true}).Wait()
+	if err != nil {
+		t.Fatalf("Status() = %v", err)
+	}
+	if data.NumMessages == nil || *data.NumMessages != 1 {
+		t.Errorf("STATUS NumMessages = %v, want 1", data.NumMessages)
+	}
+}

--- a/imapclient/notify_server_test.go
+++ b/imapclient/notify_server_test.go
@@ -1,0 +1,386 @@
+package imapclient_test
+
+import (
+	"context"
+	"errors"
+	"net"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/emersion/go-imap/v2"
+	"github.com/emersion/go-imap/v2/imapclient"
+	"github.com/emersion/go-imap/v2/imapserver"
+	"github.com/emersion/go-imap/v2/imapserver/imapmemserver"
+)
+
+// notifyLiteral adapts a byte slice to imap.LiteralReader for direct
+// server-side appends (simulating external delivery, e.g. by an MDA).
+type notifyLiteral struct {
+	*strings.Reader
+}
+
+func (l notifyLiteral) Size() int64 {
+	return int64(l.Reader.Size())
+}
+
+func newNotifyLiteral(s string) notifyLiteral {
+	return notifyLiteral{strings.NewReader(s)}
+}
+
+const notifyTestMessage = "From: sender@example.com\r\n" +
+	"To: recipient@example.com\r\n" +
+	"Subject: NOTIFY test\r\n" +
+	"\r\n" +
+	"body\r\n"
+
+// newNotifyIntegrationServer starts an in-memory server with NOTIFY enabled
+// and returns its address plus the backing user, so tests can trigger
+// server-side events directly.
+func newNotifyIntegrationServer(t *testing.T, mailboxes ...string) (addr string, user *imapmemserver.User, closer func()) {
+	t.Helper()
+
+	user = imapmemserver.NewUser(testUsername, testPassword)
+	for _, name := range mailboxes {
+		if err := user.Create(context.Background(), name, nil); err != nil {
+			t.Fatalf("Create(%q) = %v", name, err)
+		}
+	}
+
+	memServer := imapmemserver.New()
+	memServer.AddUser(user)
+
+	server := imapserver.New(&imapserver.Options{
+		NewSession: func(conn *imapserver.Conn) (imapserver.Session, *imapserver.GreetingData, error) {
+			return memServer.NewSession(), nil, nil
+		},
+		InsecureAuth: true,
+		Caps: imap.CapSet{
+			imap.CapIMAP4rev1: {},
+			imap.CapCondStore: {},
+			imap.CapNotify:    {},
+		},
+	})
+
+	ln, err := net.Listen("tcp", "localhost:0")
+	if err != nil {
+		t.Fatalf("net.Listen() = %v", err)
+	}
+	go func() {
+		if err := server.Serve(ln); err != nil {
+			t.Errorf("Serve() = %v", err)
+		}
+	}()
+
+	return ln.Addr().String(), user, func() { server.Close() }
+}
+
+func dialNotifyClient(t *testing.T, addr string, options *imapclient.Options) *imapclient.Client {
+	t.Helper()
+
+	conn, err := net.Dial("tcp", addr)
+	if err != nil {
+		t.Fatalf("net.Dial() = %v", err)
+	}
+	client := imapclient.New(conn, options)
+	if err := client.Login(testUsername, testPassword).Wait(); err != nil {
+		t.Fatalf("Login() = %v", err)
+	}
+	return client
+}
+
+// TestNotifyIntegration_StatusOnExternalAppend verifies that a message
+// delivered to a non-selected mailbox is reported with an unsolicited STATUS
+// response (RFC 5465 section 5.2), and that message events for the selected
+// mailbox stay queued until the next command when no SELECTED specifier is
+// active (RFC 5465 section 3.1).
+func TestNotifyIntegration_StatusOnExternalAppend(t *testing.T) {
+	addr, user, closer := newNotifyIntegrationServer(t, "INBOX", "Archive")
+	defer closer()
+
+	statusCh := make(chan *imap.StatusData, 8)
+	existsCh := make(chan uint32, 8)
+	client := dialNotifyClient(t, addr, &imapclient.Options{
+		UnilateralDataHandler: &imapclient.UnilateralDataHandler{
+			Status: func(data *imap.StatusData) {
+				statusCh <- data
+			},
+			Mailbox: func(data *imapclient.UnilateralDataMailbox) {
+				if data.NumMessages != nil {
+					existsCh <- *data.NumMessages
+				}
+			},
+		},
+	})
+	defer client.Close()
+
+	if _, err := client.Select("INBOX", nil).Wait(); err != nil {
+		t.Fatalf("Select() = %v", err)
+	}
+
+	cmd, err := client.Notify(&imap.NotifyOptions{
+		Items: []imap.NotifyItem{
+			{
+				MailboxSpec: imap.NotifyMailboxSpecPersonal,
+				Events: []imap.NotifyEvent{
+					imap.NotifyEventMessageNew,
+					imap.NotifyEventMessageExpunge,
+				},
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("Notify() = %v", err)
+	}
+	if err := cmd.Wait(); err != nil {
+		t.Fatalf("Notify().Wait() = %v", err)
+	}
+
+	// External delivery to the non-selected mailbox: unsolicited STATUS.
+	if _, err := user.Append(context.Background(), "Archive", newNotifyLiteral(notifyTestMessage), &imap.AppendOptions{}); err != nil {
+		t.Fatalf("Append(Archive) = %v", err)
+	}
+	select {
+	case data := <-statusCh:
+		if data.Mailbox != "Archive" {
+			t.Errorf("STATUS for mailbox %q, want Archive", data.Mailbox)
+		}
+		if data.NumMessages == nil || *data.NumMessages != 1 {
+			t.Errorf("STATUS NumMessages = %v, want 1", data.NumMessages)
+		}
+		if data.UIDNext != 2 {
+			t.Errorf("STATUS UIDNext = %v, want 2", data.UIDNext)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("timeout waiting for unsolicited STATUS after external append")
+	}
+
+	// External delivery to the selected mailbox: no SELECTED specifier is
+	// active, so nothing may arrive until the client issues a command.
+	if _, err := user.Append(context.Background(), "INBOX", newNotifyLiteral(notifyTestMessage), &imap.AppendOptions{}); err != nil {
+		t.Fatalf("Append(INBOX) = %v", err)
+	}
+	select {
+	case n := <-existsCh:
+		t.Fatalf("unexpected EXISTS %v for the selected mailbox without a SELECTED specifier", n)
+	case data := <-statusCh:
+		t.Fatalf("unexpected STATUS for %q: the selected mailbox must not be matched by PERSONAL", data.Mailbox)
+	case <-time.After(300 * time.Millisecond):
+		// expected: nothing
+	}
+
+	// The queued EXISTS is flushed by the next command (implicit NOOP sync).
+	if err := client.Noop().Wait(); err != nil {
+		t.Fatalf("Noop() = %v", err)
+	}
+	select {
+	case n := <-existsCh:
+		if n != 1 {
+			t.Errorf("EXISTS = %v, want 1", n)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("timeout waiting for EXISTS after NOOP")
+	}
+}
+
+// TestNotifyIntegration_MessageNewFetchAtts verifies that MessageNew fetch
+// attributes produce an unsolicited FETCH response following EXISTS for new
+// messages in the selected mailbox (RFC 5465 section 5.2).
+func TestNotifyIntegration_MessageNewFetchAtts(t *testing.T) {
+	addr, user, closer := newNotifyIntegrationServer(t, "INBOX")
+	defer closer()
+
+	existsCh := make(chan uint32, 8)
+	fetchCh := make(chan *imapclient.FetchMessageBuffer, 8)
+	client := dialNotifyClient(t, addr, &imapclient.Options{
+		UnilateralDataHandler: &imapclient.UnilateralDataHandler{
+			Mailbox: func(data *imapclient.UnilateralDataMailbox) {
+				if data.NumMessages != nil {
+					existsCh <- *data.NumMessages
+				}
+			},
+			Fetch: func(msg *imapclient.FetchMessageData) {
+				buf, err := msg.Collect()
+				if err != nil {
+					t.Errorf("Collect() = %v", err)
+					return
+				}
+				fetchCh <- buf
+			},
+		},
+	})
+	defer client.Close()
+
+	if _, err := client.Select("INBOX", nil).Wait(); err != nil {
+		t.Fatalf("Select() = %v", err)
+	}
+
+	cmd, err := client.Notify(&imap.NotifyOptions{
+		Items: []imap.NotifyItem{
+			{
+				MailboxSpec: imap.NotifyMailboxSpecSelected,
+				Events: []imap.NotifyEvent{
+					imap.NotifyEventMessageNew,
+					imap.NotifyEventMessageExpunge,
+				},
+				MessageNewFetch: &imap.FetchOptions{
+					UID:   true,
+					Flags: true,
+				},
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("Notify() = %v", err)
+	}
+	if err := cmd.Wait(); err != nil {
+		t.Fatalf("Notify().Wait() = %v", err)
+	}
+
+	if _, err := user.Append(context.Background(), "INBOX", newNotifyLiteral(notifyTestMessage), &imap.AppendOptions{}); err != nil {
+		t.Fatalf("Append(INBOX) = %v", err)
+	}
+
+	select {
+	case n := <-existsCh:
+		if n != 1 {
+			t.Errorf("EXISTS = %v, want 1", n)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("timeout waiting for unsolicited EXISTS")
+	}
+	select {
+	case buf := <-fetchCh:
+		if buf.UID != 1 {
+			t.Errorf("unsolicited FETCH UID = %v, want 1", buf.UID)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("timeout waiting for unsolicited FETCH with MessageNew attributes")
+	}
+}
+
+// TestNotifyIntegration_SelectedDelayedExpunge verifies that SELECTED-DELAYED
+// defers EXPUNGE delivery to the next command sync point (RFC 5465 section
+// 6.1.2).
+func TestNotifyIntegration_SelectedDelayedExpunge(t *testing.T) {
+	addr, user, closer := newNotifyIntegrationServer(t, "INBOX")
+	defer closer()
+
+	for i := 0; i < 2; i++ {
+		if _, err := user.Append(context.Background(), "INBOX", newNotifyLiteral(notifyTestMessage), &imap.AppendOptions{}); err != nil {
+			t.Fatalf("Append(INBOX) = %v", err)
+		}
+	}
+
+	expungeCh := make(chan uint32, 8)
+	watcher := dialNotifyClient(t, addr, &imapclient.Options{
+		UnilateralDataHandler: &imapclient.UnilateralDataHandler{
+			Expunge: func(seqNum uint32) {
+				expungeCh <- seqNum
+			},
+		},
+	})
+	defer watcher.Close()
+
+	if _, err := watcher.Select("INBOX", nil).Wait(); err != nil {
+		t.Fatalf("Select() = %v", err)
+	}
+
+	cmd, err := watcher.Notify(&imap.NotifyOptions{
+		Items: []imap.NotifyItem{
+			{
+				MailboxSpec: imap.NotifyMailboxSpecSelectedDelayed,
+				Events: []imap.NotifyEvent{
+					imap.NotifyEventMessageNew,
+					imap.NotifyEventMessageExpunge,
+				},
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("Notify() = %v", err)
+	}
+	if err := cmd.Wait(); err != nil {
+		t.Fatalf("Notify().Wait() = %v", err)
+	}
+
+	// A second connection expunges the first message.
+	other := dialNotifyClient(t, addr, nil)
+	defer other.Close()
+	if _, err := other.Select("INBOX", nil).Wait(); err != nil {
+		t.Fatalf("Select() = %v", err)
+	}
+	storeCmd := other.Store(imap.SeqSetNum(1), &imap.StoreFlags{
+		Op:     imap.StoreFlagsAdd,
+		Silent: true,
+		Flags:  []imap.Flag{imap.FlagDeleted},
+	}, nil)
+	if err := storeCmd.Close(); err != nil {
+		t.Fatalf("Store() = %v", err)
+	}
+	if err := other.Expunge().Close(); err != nil {
+		t.Fatalf("Expunge() = %v", err)
+	}
+
+	// SELECTED-DELAYED: the expunge must not be delivered asynchronously.
+	select {
+	case seqNum := <-expungeCh:
+		t.Fatalf("unexpected asynchronous EXPUNGE %v with SELECTED-DELAYED", seqNum)
+	case <-time.After(400 * time.Millisecond):
+		// expected: nothing
+	}
+
+	// The next command flushes it.
+	if err := watcher.Noop().Wait(); err != nil {
+		t.Fatalf("Noop() = %v", err)
+	}
+	select {
+	case seqNum := <-expungeCh:
+		if seqNum != 1 {
+			t.Errorf("EXPUNGE seqnum = %v, want 1", seqNum)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("timeout waiting for EXPUNGE after NOOP")
+	}
+}
+
+// TestNotifyIntegration_BadEvent verifies that an event unsupported by the
+// backend yields a tagged NO with the BADEVENT response code (RFC 5465
+// section 4).
+func TestNotifyIntegration_BadEvent(t *testing.T) {
+	addr, _, closer := newNotifyIntegrationServer(t, "INBOX")
+	defer closer()
+
+	client := dialNotifyClient(t, addr, nil)
+	defer client.Close()
+
+	cmd, err := client.Notify(&imap.NotifyOptions{
+		Items: []imap.NotifyItem{
+			{
+				MailboxSpec: imap.NotifyMailboxSpecSelected,
+				Events: []imap.NotifyEvent{
+					imap.NotifyEventMessageNew,
+					imap.NotifyEventMessageExpunge,
+					imap.NotifyEventAnnotationChange,
+				},
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("Notify() = %v", err)
+	}
+	err = cmd.Wait()
+	if err == nil {
+		t.Fatal("Notify().Wait() succeeded, want NO [BADEVENT ...]")
+	}
+	var imapErr *imap.Error
+	if !errors.As(err, &imapErr) {
+		t.Fatalf("Notify().Wait() = %v, want *imap.Error", err)
+	}
+	if imapErr.Type != imap.StatusResponseTypeNo {
+		t.Errorf("status response type = %v, want NO", imapErr.Type)
+	}
+	if imapErr.Code != imap.ResponseCodeBadEvent {
+		t.Errorf("response code = %v, want BADEVENT", imapErr.Code)
+	}
+}

--- a/imapclient/notify_server_test.go
+++ b/imapclient/notify_server_test.go
@@ -169,9 +169,38 @@ func TestNotifyIntegration_StatusOnExternalAppend(t *testing.T) {
 		// expected: nothing
 	}
 
-	// The queued EXISTS is flushed by the next command (implicit NOOP sync).
+	// Not even at a command sync point: without a SELECTED specifier the client
+	// asked for no message events at all for the selected mailbox, which RFC
+	// 5465 section 3.1 defines as "the same as specifying SELECTED NONE". The
+	// update stays queued.
 	if err := client.Noop().Wait(); err != nil {
 		t.Fatalf("Noop() = %v", err)
+	}
+	select {
+	case n := <-existsCh:
+		t.Fatalf("unexpected EXISTS %v at a sync point without a SELECTED specifier", n)
+	case <-time.After(300 * time.Millisecond):
+		// expected: nothing
+	}
+
+	// Enabling message events for the selected mailbox flushes the accumulated
+	// changes: a successful NOTIFY SET implies a NOOP (RFC 5465 section 3.1).
+	cmd, err = client.Notify(&imap.NotifyOptions{
+		Items: []imap.NotifyItem{
+			{
+				MailboxSpec: imap.NotifyMailboxSpecSelected,
+				Events: []imap.NotifyEvent{
+					imap.NotifyEventMessageNew,
+					imap.NotifyEventMessageExpunge,
+				},
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("Notify() = %v", err)
+	}
+	if err := cmd.Wait(); err != nil {
+		t.Fatalf("Notify().Wait() = %v", err)
 	}
 	select {
 	case n := <-existsCh:
@@ -179,7 +208,7 @@ func TestNotifyIntegration_StatusOnExternalAppend(t *testing.T) {
 			t.Errorf("EXISTS = %v, want 1", n)
 		}
 	case <-time.After(5 * time.Second):
-		t.Fatal("timeout waiting for EXISTS after NOOP")
+		t.Fatal("timeout waiting for EXISTS after NOTIFY SET (SELECTED ...)")
 	}
 }
 

--- a/imapclient/status.go
+++ b/imapclient/status.go
@@ -61,6 +61,11 @@ func (c *Client) handleStatus() error {
 	cmd := c.findPendingCmdFunc(func(cmd command) bool {
 		switch cmd := cmd.(type) {
 		case *StatusCommand:
+			// A NOTIFY notification for this mailbox (RFC 5465 §5.1-§5.3) can
+			// arrive while the command is in flight, and arrival order does not
+			// say which is which. Claim every STATUS response for the mailbox
+			// and merge them: the command then reports at least the items it
+			// asked for, whichever response carried them.
 			return cmd.mailbox == data.Mailbox
 		case *ListCommand:
 			return cmd.returnStatus && cmd.pendingData != nil && cmd.pendingData.Mailbox == data.Mailbox
@@ -77,7 +82,8 @@ func (c *Client) handleStatus() error {
 	}
 	switch cmd := cmd.(type) {
 	case *StatusCommand:
-		cmd.data = *data
+		cmd.received = true
+		mergeStatusData(&cmd.data, data)
 	case *ListCommand:
 		cmd.pendingData.Status = data
 		cmd.mailboxes <- cmd.pendingData
@@ -90,8 +96,43 @@ func (c *Client) handleStatus() error {
 // StatusCommand is a STATUS command.
 type StatusCommand struct {
 	commandBase
-	mailbox string
-	data    imap.StatusData
+	mailbox  string
+	received bool // a STATUS response has been attributed to this command
+	data     imap.StatusData
+}
+
+// mergeStatusData copies the items src reports into dst, keeping items dst
+// already has. STATUS responses for one mailbox may be split across several
+// responses, and an unsolicited one carries only what its event requires.
+func mergeStatusData(dst, src *imap.StatusData) {
+	dst.Mailbox = src.Mailbox
+	if src.NumMessages != nil {
+		dst.NumMessages = src.NumMessages
+	}
+	if src.UIDNext != 0 {
+		dst.UIDNext = src.UIDNext
+	}
+	if src.UIDValidity != 0 {
+		dst.UIDValidity = src.UIDValidity
+	}
+	if src.NumUnseen != nil {
+		dst.NumUnseen = src.NumUnseen
+	}
+	if src.NumDeleted != nil {
+		dst.NumDeleted = src.NumDeleted
+	}
+	if src.Size != nil {
+		dst.Size = src.Size
+	}
+	if src.AppendLimit != nil {
+		dst.AppendLimit = src.AppendLimit
+	}
+	if src.DeletedStorage != nil {
+		dst.DeletedStorage = src.DeletedStorage
+	}
+	if src.HighestModSeq != 0 {
+		dst.HighestModSeq = src.HighestModSeq
+	}
 }
 
 func (cmd *StatusCommand) Wait() (*imap.StatusData, error) {

--- a/imapserver/authenticate.go
+++ b/imapserver/authenticate.go
@@ -141,12 +141,16 @@ func (c *Conn) handleUnauthenticate(dec *imapwire.Decoder) error {
 	if !ok {
 		return newClientBugError("UNAUTHENTICATE is not supported")
 	}
+	// Stop the NOTIFY pump BEFORE tearing down the backend's session state:
+	// SessionNotify guarantees no NotifyPoll call is in flight when the watch
+	// is torn down, and Unauthenticate drops that state. Stopping first also
+	// means the pump can no longer write to a connection that is about to
+	// re-enter the not-authenticated state.
+	c.stopNotifyPump()
+
 	if err := session.Unauthenticate(c.ctx); err != nil {
 		return err
 	}
-	// NOTIFY state does not survive re-authentication: stop the pump. The
-	// backend is expected to drop its watch state in Unauthenticate.
-	c.stopNotifyPump()
 	c.state = imap.ConnStateNotAuthenticated
 	c.mutex.Lock()
 	c.enabled = make(imap.CapSet)

--- a/imapserver/authenticate.go
+++ b/imapserver/authenticate.go
@@ -147,6 +147,10 @@ func (c *Conn) handleUnauthenticate(dec *imapwire.Decoder) error {
 	// means the pump can no longer write to a connection that is about to
 	// re-enter the not-authenticated state.
 	c.stopNotifyPump()
+	// The watch belongs to the authenticated session: a connection returning to
+	// the not-authenticated state also returns to the pre-NOTIFY notification
+	// behaviour of RFC 5465 §3.1.
+	c.resetNotifySelectedEvents()
 
 	if err := session.Unauthenticate(c.ctx); err != nil {
 		return err

--- a/imapserver/authenticate.go
+++ b/imapserver/authenticate.go
@@ -146,15 +146,20 @@ func (c *Conn) handleUnauthenticate(dec *imapwire.Decoder) error {
 	// is torn down, and Unauthenticate drops that state. Stopping first also
 	// means the pump can no longer write to a connection that is about to
 	// re-enter the not-authenticated state.
+	hadPump := c.notifyPumpRunning()
 	c.stopNotifyPump()
+
+	if err := session.Unauthenticate(c.ctx); err != nil {
+		// The command failed, so the session — and with it the client's watch —
+		// is still in effect. Put the pump back.
+		c.restartNotifyPump(hadPump)
+		return err
+	}
+
 	// The watch belongs to the authenticated session: a connection returning to
 	// the not-authenticated state also returns to the pre-NOTIFY notification
 	// behaviour of RFC 5465 §3.1.
 	c.resetNotifySelectedEvents()
-
-	if err := session.Unauthenticate(c.ctx); err != nil {
-		return err
-	}
 	c.state = imap.ConnStateNotAuthenticated
 	c.mutex.Lock()
 	c.enabled = make(imap.CapSet)

--- a/imapserver/authenticate.go
+++ b/imapserver/authenticate.go
@@ -144,6 +144,9 @@ func (c *Conn) handleUnauthenticate(dec *imapwire.Decoder) error {
 	if err := session.Unauthenticate(c.ctx); err != nil {
 		return err
 	}
+	// NOTIFY state does not survive re-authentication: stop the pump. The
+	// backend is expected to drop its watch state in Unauthenticate.
+	c.stopNotifyPump()
 	c.state = imap.ConnStateNotAuthenticated
 	c.mutex.Lock()
 	c.enabled = make(imap.CapSet)

--- a/imapserver/capability.go
+++ b/imapserver/capability.go
@@ -136,6 +136,12 @@ func (c *Conn) availableCaps() []imap.Cap {
 			caps = append(caps, imap.CapUnauthenticate)
 		}
 
+		// NOTIFY requires an optional session interface; advertise it only
+		// when the session implements it.
+		if _, ok := c.session.(SessionNotify); ok && available.Has(imap.CapNotify) {
+			caps = append(caps, imap.CapNotify)
+		}
+
 		// METADATA capability
 		if _, ok := c.session.(SessionMetadata); ok && available.Has(imap.CapMetadata) {
 			caps = append(caps, imap.CapMetadata)

--- a/imapserver/cond_caps.go
+++ b/imapserver/cond_caps.go
@@ -23,7 +23,17 @@ func (c *Conn) supportsCondStore() bool {
 		sessionCaps := capSession.GetCapabilities()
 		return sessionCaps.Has(imap.CapCondStore) || sessionCaps.Has(imap.CapIMAP4rev2)
 	}
-	return c.enabledHas(imap.CapIMAP4rev2) || c.availableCapsSet().Has(imap.CapCondStore) || c.availableCapsSet().Has(imap.CapIMAP4rev2)
+	// Read the server's configured capabilities directly rather than
+	// availableCapsSet(), which is connection-state dependent and reads
+	// c.state/c.conn without synchronization. supportsCondStore is reached
+	// from the NOTIFY pump goroutine (via WriteMessageFlags and
+	// UpdateWriter.CondStoreEnabled) concurrently with command-goroutine state
+	// transitions; the configured CapSet is immutable after construction and
+	// CONDSTORE/IMAP4rev2 are backend-support capabilities that do not vary by
+	// state, so this is both race-free and equivalent in the authenticated/
+	// selected states where the pump runs. c.enabledHas already locks c.mutex.
+	serverCaps := c.server.options.caps()
+	return c.enabledHas(imap.CapIMAP4rev2) || serverCaps.Has(imap.CapCondStore) || serverCaps.Has(imap.CapIMAP4rev2)
 }
 
 // markCondStoreEnabled records that the client has issued a CONDSTORE-enabling

--- a/imapserver/conn.go
+++ b/imapserver/conn.go
@@ -93,6 +93,19 @@ type Conn struct {
 	notifyStop  chan struct{}
 	notifyDone  chan error
 
+	// notifyUsed reports whether the client has issued a NOTIFY command on this
+	// connection. Until it does, the legacy behaviour of RFC 5465 §3.1 applies:
+	// message events for the selected mailbox are reported while a command is
+	// being processed.
+	//
+	// notifySelectedEvents is the set of message events requested with the
+	// SELECTED/SELECTED-DELAYED specifier. It is empty after NOTIFY NONE, or
+	// when NOTIFY SET carried no such event group — which RFC 5465 §3.1 defines
+	// as "the same as specifying SELECTED NONE". Both are guarded by
+	// notifyMutex, as the pump goroutine reads them.
+	notifyUsed           bool
+	notifySelectedEvents map[imap.NotifyEvent]bool
+
 	// activeCmd is the name of the command currently being processed by the
 	// command goroutine ("" between commands). The NOTIFY pump consults it to
 	// avoid delivering EXPUNGE/VANISHED updates while a command that forbids
@@ -663,6 +676,18 @@ func (c *Conn) poll(cmd string) error {
 		return nil
 	}
 
+	// RFC 5465 §3.1: once NOTIFY has been used, message events for the selected
+	// mailbox are reported only when the client asked for them with the
+	// SELECTED/SELECTED-DELAYED specifier. Omitting that specifier "is the same
+	// as specifying SELECTED NONE", and NOTIFY NONE disables everything — in
+	// both cases the pending updates must stay queued rather than be flushed at
+	// this sync point, which is what makes NOTIFY SET ... NONE usable as the
+	// snapshot facility of RFC 5465 §5 and what keeps sequence numbers stable
+	// for clients that rely on it.
+	if !c.notifySelectedMessageEventsEnabled() {
+		return nil
+	}
+
 	// EXPUNGE renumbers the sequence space, so it must not be delivered by the
 	// post-command poll of a command that referenced messages by sequence
 	// number (RFC 3501 §5.5): FETCH, STORE, SEARCH and their SORT/THREAD
@@ -828,6 +853,68 @@ func (c *Conn) notifyExpungeAllowed() bool {
 	}
 }
 
+// setNotifySelectedEvents records the message events the client requested for
+// the selected mailbox with the SELECTED/SELECTED-DELAYED specifier. options is
+// nil for NOTIFY NONE. It is called by the NOTIFY handler once the backend has
+// accepted the new watch.
+func (c *Conn) setNotifySelectedEvents(options *imap.NotifyOptions) {
+	events := make(map[imap.NotifyEvent]bool)
+	if options != nil {
+		for _, item := range options.Items {
+			if item.MailboxSpec != imap.NotifyMailboxSpecSelected &&
+				item.MailboxSpec != imap.NotifyMailboxSpecSelectedDelayed {
+				continue
+			}
+			for _, event := range item.Events {
+				events[event] = true
+			}
+		}
+	}
+
+	c.notifyMutex.Lock()
+	c.notifyUsed = true
+	c.notifySelectedEvents = events
+	c.notifyMutex.Unlock()
+}
+
+// resetNotifySelectedEvents restores the pre-NOTIFY behaviour. It is called
+// when the session is torn down (UNAUTHENTICATE), since the watch belongs to
+// the authenticated session rather than to the connection.
+func (c *Conn) resetNotifySelectedEvents() {
+	c.notifyMutex.Lock()
+	c.notifyUsed = false
+	c.notifySelectedEvents = nil
+	c.notifyMutex.Unlock()
+}
+
+// notifySelectedEventEnabled reports whether the given message event may be
+// reported for the selected mailbox (RFC 5465 §3.1). It is always true until
+// the client uses NOTIFY for the first time.
+func (c *Conn) notifySelectedEventEnabled(event imap.NotifyEvent) bool {
+	c.notifyMutex.Lock()
+	defer c.notifyMutex.Unlock()
+	if !c.notifyUsed {
+		return true
+	}
+	return c.notifySelectedEvents[event]
+}
+
+// notifySelectedMessageEventsEnabled reports whether any message event at all
+// may be reported for the selected mailbox.
+func (c *Conn) notifySelectedMessageEventsEnabled() bool {
+	c.notifyMutex.Lock()
+	defer c.notifyMutex.Unlock()
+	if !c.notifyUsed {
+		return true
+	}
+	for event := range c.notifySelectedEvents {
+		if event.IsMessageEvent() {
+			return true
+		}
+	}
+	return false
+}
+
 // UpdateWriter writes status updates.
 type UpdateWriter struct {
 	conn         *Conn
@@ -890,6 +977,17 @@ func (w *UpdateWriter) WriteStatus(data *imap.StatusData, options *imap.StatusOp
 func (w *UpdateWriter) WriteList(data *imap.ListData) error {
 	allowOldName := w.notify || w.conn.enabledHas(imap.CapIMAP4rev2)
 	return w.conn.writeListData(data, nil, allowOldName)
+}
+
+// WriteMetadata writes an untagged METADATA response (RFC 5464 §4.4.2). It is
+// used by NOTIFY (RFC 5465) to report MailboxMetadataChange events (with the
+// mailbox name) and ServerMetadataChange events (with an empty mailbox name).
+//
+// entries maps entry names to their new values; a nil value denotes a deleted
+// entry, which RFC 5465 §5.6 and §5.7 require to always be included. Writing an
+// empty map is a no-op.
+func (w *UpdateWriter) WriteMetadata(mailbox string, entries map[string]*[]byte) error {
+	return w.conn.writeMetadataResp(mailbox, entries)
 }
 
 // WriteNotificationOverflow writes an untagged OK response with the
@@ -969,6 +1067,15 @@ func (w *UpdateWriter) WriteMailboxFlags(flags []imap.Flag) error {
 // client can advance its per-message modseq from the unsolicited update rather than
 // falling back to a full re-sync (RFC 7162 §3.2). A zero modSeq is omitted.
 func (w *UpdateWriter) WriteMessageFlags(seqNum uint32, uid imap.UID, flags []imap.Flag, modSeq uint64) error {
+	// RFC 5465 §3.1: a client that used NOTIFY only receives the message events
+	// it asked for with the SELECTED/SELECTED-DELAYED specifier. Dropping an
+	// unrequested flag update is safe (unlike EXISTS/EXPUNGE, it carries no
+	// sequence-number change), so the whole tracker queue can still be drained
+	// while FlagChange stays filtered out.
+	if !w.conn.notifySelectedEventEnabled(imap.NotifyEventFlagChange) {
+		return nil
+	}
+
 	fetchWriter := &FetchWriter{conn: w.conn}
 	respWriter := fetchWriter.CreateMessage(seqNum)
 	if uid != 0 {

--- a/imapserver/conn.go
+++ b/imapserver/conn.go
@@ -106,6 +106,11 @@ type Conn struct {
 	notifyUsed           bool
 	notifySelectedEvents map[imap.NotifyEvent]bool
 
+	// notifyFetchWriterOptions holds the response-writer options of the
+	// MessageNew fetch-att list of the installed watch, so unsolicited FETCH
+	// responses use the data-item names the client asked for.
+	notifyFetchWriterOptions *fetchWriterOptions
+
 	// activeCmd is the name of the command currently being processed by the
 	// command goroutine ("" between commands). The NOTIFY pump consults it to
 	// avoid delivering EXPUNGE/VANISHED updates while a command that forbids
@@ -466,6 +471,18 @@ func (c *Conn) readCommand(dec *imapwire.Decoder) (err error) {
 
 	dec.DiscardLine()
 
+	// A command whose remaining octets could not be skipped leaves the stream
+	// pointing into client data rather than at a command boundary: whatever
+	// follows would be executed as commands. There is no way back from that, so
+	// end the connection instead of continuing to parse (RFC 9051 §2.2.1).
+	if dec.Desynchronized() {
+		_ = c.writeStatusResp("", &imap.StatusResponse{
+			Type: imap.StatusResponseTypeBye,
+			Text: "Unable to resynchronize command stream",
+		})
+		return fmt.Errorf("imapserver: command stream desynchronized")
+	}
+
 	var (
 		resp    *imap.StatusResponse
 		imapErr *imap.Error
@@ -668,6 +685,19 @@ func (c *Conn) setWriteTimeout(dur time.Duration) {
 	}
 }
 
+// expungeReportingCmd reports whether the command's own tagged OK must be
+// preceded by an untagged EXPUNGE for each removed message (RFC 9051 §6.4.3,
+// RFC 4315 §2.1 for the UID variant). CLOSE is deliberately absent: it removes
+// messages without reporting them.
+func expungeReportingCmd(cmd string) bool {
+	switch cmd {
+	case "EXPUNGE", "UID EXPUNGE":
+		return true
+	default:
+		return false
+	}
+}
+
 func (c *Conn) poll(cmd string) error {
 	switch c.state {
 	case imap.ConnStateAuthenticated, imap.ConnStateSelected:
@@ -684,7 +714,15 @@ func (c *Conn) poll(cmd string) error {
 	// this sync point, which is what makes NOTIFY SET ... NONE usable as the
 	// snapshot facility of RFC 5465 §5 and what keeps sequence numbers stable
 	// for clients that rely on it.
-	if !c.notifySelectedMessageEventsEnabled() {
+	//
+	// The filter covers notifications only. EXPUNGE and UID EXPUNGE MUST report
+	// each removed message with an untagged EXPUNGE before their tagged OK (RFC
+	// 9051 §6.4.3, RFC 4315 §2.1); that is command response data, which no
+	// NOTIFY setting suppresses. Flushing then necessarily also delivers
+	// whatever else the queue holds: updates are sequence-numbered, so a later
+	// EXPUNGE cannot be reported without the earlier ones that shift the
+	// numbering.
+	if !expungeReportingCmd(cmd) && !c.notifySelectedMessageEventsEnabled() {
 		return nil
 	}
 
@@ -857,7 +895,7 @@ func (c *Conn) notifyExpungeAllowed() bool {
 // the selected mailbox with the SELECTED/SELECTED-DELAYED specifier. options is
 // nil for NOTIFY NONE. It is called by the NOTIFY handler once the backend has
 // accepted the new watch.
-func (c *Conn) setNotifySelectedEvents(options *imap.NotifyOptions) {
+func (c *Conn) setNotifySelectedEvents(options *imap.NotifyOptions, fetchWriterOpts *fetchWriterOptions) {
 	events := make(map[imap.NotifyEvent]bool)
 	if options != nil {
 		for _, item := range options.Items {
@@ -874,6 +912,7 @@ func (c *Conn) setNotifySelectedEvents(options *imap.NotifyOptions) {
 	c.notifyMutex.Lock()
 	c.notifyUsed = true
 	c.notifySelectedEvents = events
+	c.notifyFetchWriterOptions = fetchWriterOpts
 	c.notifyMutex.Unlock()
 }
 
@@ -884,6 +923,7 @@ func (c *Conn) resetNotifySelectedEvents() {
 	c.notifyMutex.Lock()
 	c.notifyUsed = false
 	c.notifySelectedEvents = nil
+	c.notifyFetchWriterOptions = nil
 	c.notifyMutex.Unlock()
 }
 
@@ -948,6 +988,33 @@ func (w *UpdateWriter) ExpungeAllowed() bool {
 	return true
 }
 
+// DelayedExpungeAllowed reports whether an expunge withheld by the
+// SELECTED-DELAYED specifier may be released now.
+//
+// RFC 5465 §6.1.2 delays MessageExpunge "until the client issues a command that
+// allows returning information about expunged messages ... for example, till a
+// NOOP or an IDLE command has been issued". This reports true while such a
+// command is in progress, so a backend can release its delayed expunges from
+// NotifyPoll instead of leaving them queued until the command ends — which for
+// IDLE would mean holding them, and every update queued behind them, for the
+// entire IDLE.
+//
+// Between commands it returns false: a client using SELECTED-DELAYED is
+// entitled to stable sequence numbers until it asks.
+func (w *UpdateWriter) DelayedExpungeAllowed() bool {
+	if !w.ExpungeAllowed() {
+		return false
+	}
+	w.conn.cmdMutex.Lock()
+	defer w.conn.cmdMutex.Unlock()
+	switch w.conn.activeCmd {
+	case "NOOP", "IDLE", "CHECK", "EXPUNGE", "UID EXPUNGE":
+		return true
+	default:
+		return false
+	}
+}
+
 // CondStoreEnabled reports whether the client has become CONDSTORE-aware on
 // this connection. Backends use it to decide whether STATUS notifications may
 // carry HIGHESTMODSEQ (RFC 5465 §5.1, §5.2) and whether unsolicited FETCH
@@ -979,38 +1046,64 @@ func (w *UpdateWriter) WriteList(data *imap.ListData) error {
 	return w.conn.writeListData(data, nil, allowOldName)
 }
 
-// WriteMetadata writes an untagged METADATA response (RFC 5464 §4.4.2). It is
-// used by NOTIFY (RFC 5465) to report MailboxMetadataChange events (with the
+// WriteMetadata writes an unsolicited METADATA response (RFC 5464 §4.4.2). It
+// is used by NOTIFY (RFC 5465) to report MailboxMetadataChange events (with the
 // mailbox name) and ServerMetadataChange events (with an empty mailbox name).
 //
-// entries maps entry names to their new values; a nil value denotes a deleted
-// entry, which RFC 5465 §5.6 and §5.7 require to always be included. Writing an
-// empty map is a no-op.
-func (w *UpdateWriter) WriteMetadata(mailbox string, entries map[string]*[]byte) error {
-	return w.conn.writeMetadataResp(mailbox, entries)
+// entries lists the names of the changed annotations. Values are deliberately
+// not part of the API: RFC 5464 §4.4 requires that "unsolicited METADATA
+// responses MUST only contain entry names, not the values" — a client that
+// wants the new value retrieves it with GETMETADATA. Deleted entries are
+// reported like any other change (RFC 5465 §5.6, §5.7). Writing an empty list
+// is a no-op.
+func (w *UpdateWriter) WriteMetadata(mailbox string, entries []string) error {
+	return w.conn.writeMetadataEntryList(mailbox, entries)
 }
 
 // WriteNotificationOverflow writes an untagged OK response with the
 // NOTIFICATIONOVERFLOW response code (RFC 5465 §5.8).
 //
-// A backend calls this from NotifyPoll when it is unable or unwilling to
-// keep delivering the requested notifications. Per the RFC the server then
-// behaves as if NOTIFY NONE had been received: the backend must clear its own
-// watch state and return nil from NotifyPoll after writing the overflow
-// response.
+// A backend calls this from NotifyPoll when it is unable or unwilling to keep
+// delivering the requested notifications. Per the RFC the server then behaves
+// as if NOTIFY NONE had been received: the backend must clear its own watch
+// state and return nil from NotifyPoll after writing the overflow response.
+//
+// The connection-level watch is dropped here, which also ends the suppression
+// of message events for the selected mailbox: the connection returns to the
+// pre-NOTIFY behaviour of RFC 5465 §3.1, where those events are reported while
+// a command is being processed. That is a deliberate departure from a literal
+// reading of "behave as if a NOTIFY NONE command had just been received" —
+// staying frozen would leave the updates accumulated so far undeliverable and
+// the client's sequence numbers permanently stale, with no way for the server
+// to recover on its own. The client has been told its notifications are off,
+// and it gets a consistent view instead of a frozen one.
 func (w *UpdateWriter) WriteNotificationOverflow() error {
-	return w.conn.writeStatusResp("", &imap.StatusResponse{
+	if err := w.conn.writeStatusResp("", &imap.StatusResponse{
 		Type: imap.StatusResponseTypeOK,
 		Code: imap.ResponseCodeNotificationOverflow,
 		Text: "Notifications disabled",
-	})
+	}); err != nil {
+		return err
+	}
+	w.conn.resetNotifySelectedEvents()
+	return nil
 }
 
 // FetchWriter returns a writer for unsolicited FETCH responses. It is used
 // by NOTIFY (RFC 5465 §5.2) to send the fetch attributes requested for
 // MessageNew events in the selected mailbox.
+//
+// The writer is configured from the MessageNew fetch-att list of the installed
+// watch, so BODY/BODYSTRUCTURE are emitted and the obsolete RFC822 item names
+// are reported the way the client spelled them.
 func (w *UpdateWriter) FetchWriter() *FetchWriter {
-	return &FetchWriter{conn: w.conn}
+	fw := &FetchWriter{conn: w.conn}
+	w.conn.notifyMutex.Lock()
+	if opts := w.conn.notifyFetchWriterOptions; opts != nil {
+		fw.options = *opts
+	}
+	w.conn.notifyMutex.Unlock()
+	return fw
 }
 
 // WriteOK writes an untagged OK response carrying only informational text

--- a/imapserver/conn.go
+++ b/imapserver/conn.go
@@ -663,9 +663,14 @@ func (c *Conn) poll(cmd string) error {
 		return nil
 	}
 
+	// EXPUNGE renumbers the sequence space, so it must not be delivered by the
+	// post-command poll of a command that referenced messages by sequence
+	// number (RFC 3501 §5.5): FETCH, STORE, SEARCH and their SORT/THREAD
+	// extensions. The UID variants ("UID FETCH", …) key on stable UIDs and are
+	// exempt, so matching the bare names is correct.
 	allowExpunge := true
 	switch cmd {
-	case "FETCH", "STORE", "SEARCH":
+	case "FETCH", "STORE", "SEARCH", "SORT", "THREAD":
 		allowExpunge = false
 	}
 
@@ -806,13 +811,17 @@ func (c *Conn) setActiveCommand(name string) {
 }
 
 // notifyExpungeAllowed reports whether an asynchronous EXPUNGE/VANISHED
-// update may be sent right now: RFC 3501 §5.5 forbids sending EXPUNGE while a
-// FETCH, STORE or SEARCH command is in progress (the UID variants are exempt).
+// update may be sent right now: RFC 3501 §5.5 / RFC 9051 §5.5 forbid sending
+// EXPUNGE while a command that references messages by sequence number is in
+// progress, because expunging renumbers the sequence space underneath it. That
+// is FETCH, STORE and SEARCH, plus their SORT and THREAD extensions (all of
+// which emit sequence-numbered responses); the UID variants are exempt as they
+// key on stable UIDs.
 func (c *Conn) notifyExpungeAllowed() bool {
 	c.cmdMutex.Lock()
 	defer c.cmdMutex.Unlock()
 	switch c.activeCmd {
-	case "FETCH", "STORE", "SEARCH":
+	case "FETCH", "STORE", "SEARCH", "SORT", "THREAD":
 		return false
 	default:
 		return true
@@ -870,10 +879,17 @@ func (w *UpdateWriter) WriteStatus(data *imap.StatusData, options *imap.StatusOp
 // WriteList writes an untagged LIST response. It is used by NOTIFY
 // (RFC 5465) to report MailboxName and SubscriptionChange events: mailbox
 // creation, deletion (with the \NonExistent attribute), renames (with the
-// OLDNAME extended data item, when the client has enabled IMAP4rev2) and
-// subscription changes.
+// OLDNAME extended data item) and subscription changes.
+//
+// For a NOTIFY writer, OLDNAME is emitted regardless of ENABLE IMAP4rev2:
+// RFC 5465 §5.4 requires the extended LIST (RFC 5258) carrying OLDNAME for
+// renames, and a client that issued NOTIFY has, by using the extension,
+// opted into these extended responses — so an IMAP4rev1 NOTIFY client must
+// still learn a mailbox's new name. Non-NOTIFY callers keep the IMAP4rev2
+// gate.
 func (w *UpdateWriter) WriteList(data *imap.ListData) error {
-	return w.conn.writeListData(data, nil, w.conn.enabledHas(imap.CapIMAP4rev2))
+	allowOldName := w.notify || w.conn.enabledHas(imap.CapIMAP4rev2)
+	return w.conn.writeListData(data, nil, allowOldName)
 }
 
 // WriteNotificationOverflow writes an untagged OK response with the

--- a/imapserver/conn.go
+++ b/imapserver/conn.go
@@ -86,6 +86,19 @@ type Conn struct {
 	// read-only (RFC 4314 §5.2). Only touched from the command-loop goroutine,
 	// like state.
 	selectedReadOnly bool
+
+	// NOTIFY (RFC 5465) pump state. notifyStop/notifyDone are non-nil while a
+	// SessionNotify.NotifyPoll goroutine is running for this connection.
+	notifyMutex sync.Mutex
+	notifyStop  chan struct{}
+	notifyDone  chan error
+
+	// activeCmd is the name of the command currently being processed by the
+	// command goroutine ("" between commands). The NOTIFY pump consults it to
+	// avoid delivering EXPUNGE/VANISHED updates while a command that forbids
+	// them (FETCH/STORE/SEARCH, RFC 3501 §5.5) is in progress.
+	cmdMutex  sync.Mutex
+	activeCmd string
 }
 
 func newConn(c net.Conn, server *Server) *Conn {
@@ -228,6 +241,10 @@ func (c *Conn) serve() {
 		}
 	}()
 
+	// Stop the NOTIFY pump (if any) before the session is closed: deferred
+	// calls run in LIFO order, so this executes first on teardown.
+	defer c.stopNotifyPump()
+
 	// Capabilities that depend on optional session interfaces (IMAP4rev2,
 	// NAMESPACE, MOVE, UNAUTHENTICATE, ...) are advertised by availableCaps only
 	// when the session implements them, and each command handler returns a clean
@@ -320,6 +337,12 @@ func (c *Conn) readCommand(dec *imapwire.Decoder) (err error) {
 		name = "UID " + strings.ToUpper(subName)
 	}
 
+	// Record the in-progress command so the NOTIFY pump can defer
+	// EXPUNGE/VANISHED updates while commands that forbid them run (see
+	// UpdateWriter.ExpungeAllowed).
+	c.setActiveCommand(name)
+	defer c.setActiveCommand("")
+
 	// TODO: handle multiple commands concurrently
 	sendOK := true
 	switch name {
@@ -375,6 +398,9 @@ func (c *Conn) readCommand(dec *imapwire.Decoder) (err error) {
 		err = c.handleMyRights(dec)
 	case "IDLE":
 		err = c.handleIdle(dec)
+	case "NOTIFY":
+		err = c.handleNotify(tag, dec)
+		sendOK = false
 	case "SELECT", "EXAMINE":
 		err = c.handleSelect(tag, dec, name == "EXAMINE")
 		sendOK = false
@@ -773,10 +799,104 @@ func writeObsoleteRecent(enc *imapwire.Encoder, n uint32) error {
 	return enc.Atom("*").SP().Number(n).SP().Atom("RECENT").CRLF()
 }
 
+func (c *Conn) setActiveCommand(name string) {
+	c.cmdMutex.Lock()
+	c.activeCmd = name
+	c.cmdMutex.Unlock()
+}
+
+// notifyExpungeAllowed reports whether an asynchronous EXPUNGE/VANISHED
+// update may be sent right now: RFC 3501 §5.5 forbids sending EXPUNGE while a
+// FETCH, STORE or SEARCH command is in progress (the UID variants are exempt).
+func (c *Conn) notifyExpungeAllowed() bool {
+	c.cmdMutex.Lock()
+	defer c.cmdMutex.Unlock()
+	switch c.activeCmd {
+	case "FETCH", "STORE", "SEARCH":
+		return false
+	default:
+		return true
+	}
+}
+
 // UpdateWriter writes status updates.
 type UpdateWriter struct {
 	conn         *Conn
 	allowExpunge bool
+
+	// notify is set for writers handed to SessionNotify: expunge delivery is
+	// additionally gated on the command currently in progress (see
+	// ExpungeAllowed).
+	notify bool
+}
+
+// ExpungeAllowed reports whether EXPUNGE/VANISHED updates may be written in
+// the current context.
+//
+// For writers passed to SessionNotify methods this is dynamic: it returns
+// false while a command that forbids unsolicited expunges (FETCH, STORE,
+// SEARCH) is in progress on the connection. Backends running a NOTIFY watch
+// should consult it once per delivery batch and withhold expunge updates
+// (e.g. by passing it as the allowExpunge argument of SessionTracker.Poll)
+// when it reports false; withheld updates are delivered at the next sync
+// point. The check is advisory: a command may start between the check and the
+// write, which is the same ordering ambiguity a single-threaded server has
+// when a command arrives while an update is being written.
+func (w *UpdateWriter) ExpungeAllowed() bool {
+	if !w.allowExpunge {
+		return false
+	}
+	if w.notify {
+		return w.conn.notifyExpungeAllowed()
+	}
+	return true
+}
+
+// CondStoreEnabled reports whether the client has become CONDSTORE-aware on
+// this connection. Backends use it to decide whether STATUS notifications may
+// carry HIGHESTMODSEQ (RFC 5465 §5.1, §5.2) and whether unsolicited FETCH
+// responses may carry MODSEQ.
+func (w *UpdateWriter) CondStoreEnabled() bool {
+	return w.conn.supportsCondStore() && w.conn.CondStoreEnabled()
+}
+
+// WriteStatus writes an untagged STATUS response. It is used by NOTIFY
+// (RFC 5465) to report message events in mailboxes other than the selected
+// one. data must populate every field requested in options.
+func (w *UpdateWriter) WriteStatus(data *imap.StatusData, options *imap.StatusOptions) error {
+	return w.conn.writeStatus(data, options)
+}
+
+// WriteList writes an untagged LIST response. It is used by NOTIFY
+// (RFC 5465) to report MailboxName and SubscriptionChange events: mailbox
+// creation, deletion (with the \NonExistent attribute), renames (with the
+// OLDNAME extended data item, when the client has enabled IMAP4rev2) and
+// subscription changes.
+func (w *UpdateWriter) WriteList(data *imap.ListData) error {
+	return w.conn.writeListData(data, nil, w.conn.enabledHas(imap.CapIMAP4rev2))
+}
+
+// WriteNotificationOverflow writes an untagged OK response with the
+// NOTIFICATIONOVERFLOW response code (RFC 5465 §5.8).
+//
+// A backend calls this from NotifyPoll when it is unable or unwilling to
+// keep delivering the requested notifications. Per the RFC the server then
+// behaves as if NOTIFY NONE had been received: the backend must clear its own
+// watch state and return nil from NotifyPoll after writing the overflow
+// response.
+func (w *UpdateWriter) WriteNotificationOverflow() error {
+	return w.conn.writeStatusResp("", &imap.StatusResponse{
+		Type: imap.StatusResponseTypeOK,
+		Code: imap.ResponseCodeNotificationOverflow,
+		Text: "Notifications disabled",
+	})
+}
+
+// FetchWriter returns a writer for unsolicited FETCH responses. It is used
+// by NOTIFY (RFC 5465 §5.2) to send the fetch attributes requested for
+// MessageNew events in the selected mailbox.
+func (w *UpdateWriter) FetchWriter() *FetchWriter {
+	return &FetchWriter{conn: w.conn}
 }
 
 // WriteOK writes an untagged OK response carrying only informational text

--- a/imapserver/imapmemserver/mailbox.go
+++ b/imapserver/imapmemserver/mailbox.go
@@ -48,7 +48,7 @@ func (mbox *Mailbox) notifyEventLocked(kind memNotifyEventKind) {
 	if mbox.notify == nil {
 		return
 	}
-	mbox.notify(memNotifyEvent{kind: kind, mailbox: mbox.name})
+	mbox.notify(memNotifyEvent{kind: kind, mailbox: mbox.name, mbox: mbox})
 }
 
 // notifyEvent is notifyEventLocked for callers that do not hold the mailbox
@@ -60,7 +60,7 @@ func (mbox *Mailbox) notifyEvent(kind memNotifyEventKind) {
 	mbox.mutex.Lock()
 	name := mbox.name
 	mbox.mutex.Unlock()
-	mbox.notify(memNotifyEvent{kind: kind, mailbox: name})
+	mbox.notify(memNotifyEvent{kind: kind, mailbox: name, mbox: mbox})
 }
 
 type expungedMessage struct {

--- a/imapserver/imapmemserver/mailbox.go
+++ b/imapserver/imapmemserver/mailbox.go
@@ -24,6 +24,11 @@ type Mailbox struct {
 	tracker     *imapserver.MailboxTracker
 	uidValidity uint32
 
+	// notify broadcasts message change events to the owning user's NOTIFY
+	// watchers (nil when the mailbox is not attached to a user). Set once at
+	// creation, before the mailbox is shared.
+	notify func(memNotifyEvent)
+
 	mutex         sync.Mutex
 	name          string
 	subscribed    bool
@@ -34,6 +39,28 @@ type Mailbox struct {
 	expunged      []expungedMessage
 	metadata      map[string]*[]byte
 	acl           map[imap.RightsIdentifier]imap.RightSet
+}
+
+// notifyEventLocked broadcasts a message event for this mailbox to the
+// owning user's NOTIFY watchers. The mailbox mutex must be held by the
+// caller (the name is read under it); the broadcast itself never blocks.
+func (mbox *Mailbox) notifyEventLocked(kind memNotifyEventKind) {
+	if mbox.notify == nil {
+		return
+	}
+	mbox.notify(memNotifyEvent{kind: kind, mailbox: mbox.name})
+}
+
+// notifyEvent is notifyEventLocked for callers that do not hold the mailbox
+// mutex.
+func (mbox *Mailbox) notifyEvent(kind memNotifyEventKind) {
+	if mbox.notify == nil {
+		return
+	}
+	mbox.mutex.Lock()
+	name := mbox.name
+	mbox.mutex.Unlock()
+	mbox.notify(memNotifyEvent{kind: kind, mailbox: name})
 }
 
 type expungedMessage struct {
@@ -192,6 +219,7 @@ func (mbox *Mailbox) appendBytes(buf []byte, options *imap.AppendOptions) *imap.
 
 	mbox.l = append(mbox.l, msg)
 	mbox.tracker.QueueNumMessages(uint32(len(mbox.l)))
+	mbox.notifyEventLocked(evMessageNew)
 
 	return &imap.AppendData{
 		UIDValidity: mbox.uidValidity,
@@ -306,6 +334,9 @@ func (mbox *Mailbox) expungeLocked(expunged map[*message]struct{}) (seqNums []ui
 		}
 	}
 	mbox.l = mbox.l[:n]
+	if len(seqNums) > 0 {
+		mbox.notifyEventLocked(evMessageExpunge)
+	}
 	return seqNums
 }
 
@@ -384,6 +415,7 @@ func (mbox *MailboxView) Fetch(ctx context.Context, w *imapserver.FetchWriter, n
 	}
 
 	var err error
+	var flagsChanged bool
 	mbox.forEach(numSet, func(seqNum uint32, msg *message) {
 		if err != nil {
 			return
@@ -395,12 +427,16 @@ func (mbox *MailboxView) Fetch(ctx context.Context, w *imapserver.FetchWriter, n
 
 		if markSeen {
 			msg.flags[canonicalFlag(imap.FlagSeen)] = struct{}{}
+			flagsChanged = true
 			mbox.Mailbox.tracker.QueueMessageFlags(seqNum, msg.uid, msg.flagList(), 0, nil)
 		}
 
 		respWriter := w.CreateMessage(mbox.tracker.EncodeSeqNum(seqNum))
 		err = msg.fetch(respWriter, options)
 	})
+	if flagsChanged {
+		mbox.Mailbox.notifyEvent(evFlagChange)
+	}
 	return err
 }
 
@@ -669,12 +705,14 @@ func writeStoreFetchResponse(w *imapserver.FetchWriter, tracker *imapserver.Sess
 
 func (mbox *MailboxView) Store(ctx context.Context, w *imapserver.FetchWriter, numSet imap.NumSet, flags *imap.StoreFlags, options *imap.StoreOptions) error {
 	var modified []modifiedMessageData
+	var changedAny bool
 	mbox.forEach(numSet, func(seqNum uint32, msg *message) {
 		if options != nil && options.UnchangedSince > 0 && msg.modSeq > options.UnchangedSince {
 			return
 		}
 
 		if changed := msg.store(mbox.Mailbox, flags); changed {
+			changedAny = true
 			mbox.Mailbox.tracker.QueueMessageFlags(seqNum, msg.uid, msg.flagList(), msg.modSeq, mbox.tracker)
 
 			if !flags.Silent {
@@ -687,6 +725,9 @@ func (mbox *MailboxView) Store(ctx context.Context, w *imapserver.FetchWriter, n
 			}
 		}
 	})
+	if changedAny {
+		mbox.Mailbox.notifyEvent(evFlagChange)
+	}
 
 	if !flags.Silent {
 		for _, mod := range modified {

--- a/imapserver/imapmemserver/message.go
+++ b/imapserver/imapmemserver/message.go
@@ -28,7 +28,19 @@ type message struct {
 	modSeq uint64
 }
 
-func (msg *message) fetch(w *imapserver.FetchResponseWriter, options *imap.FetchOptions) error {
+func (msg *message) fetch(w *imapserver.FetchResponseWriter, options *imap.FetchOptions) (err error) {
+	// Close the response writer exactly once, even on an early error return.
+	// CreateMessage holds the connection's encMutex until Close, so a fetch
+	// that errored midway without closing would leak the mutex and wedge the
+	// connection. That is tolerable on the command path (the connection is
+	// torn down on error) but fatal on the NOTIFY pump path, where the
+	// connection stays alive.
+	defer func() {
+		if closeErr := w.Close(); err == nil {
+			err = closeErr
+		}
+	}()
+
 	w.WriteUID(msg.uid)
 
 	if options.Flags {
@@ -81,7 +93,8 @@ func (msg *message) fetch(w *imapserver.FetchResponseWriter, options *imap.Fetch
 		w.WriteBinarySectionSize(bss, n)
 	}
 
-	return w.Close()
+	// The deferred Close (see top) releases the encoder and returns its error.
+	return nil
 }
 
 func (msg *message) envelope() *imap.Envelope {

--- a/imapserver/imapmemserver/notify.go
+++ b/imapserver/imapmemserver/notify.go
@@ -173,15 +173,21 @@ var _ imapserver.SessionNotify = (*UserSession)(nil)
 
 // SetNotify implements imapserver.SessionNotify.
 func (sess *UserSession) SetNotify(ctx context.Context, options *imap.NotifyOptions, w *imapserver.UpdateWriter) error {
-	sess.notifyMutex.Lock()
-	sess.notifyUsed = true
-	sess.notifyMutex.Unlock()
-
 	if options == nil {
-		sess.stopNotifyEvents()
+		// RFC 5465 section 3.1: no events at all. The watch goes, but the
+		// event channel stays registered: the selected mailbox's updates keep
+		// queuing behind the suppression, and NotifyPoll — which the library
+		// runs for NOTIFY NONE too — needs the wake-ups to notice when that
+		// queue must be cut short (checkNotifyOverflow).
+		sess.notifyMutex.Lock()
+		sess.notifyWatch = nil
+		sess.startNotifyLocked()
+		sess.notifyMutex.Unlock()
 		return nil
 	}
 
+	// A rejected watch leaves the previous state in effect, the pre-NOTIFY one
+	// included, so nothing is touched before the events have been checked.
 	for _, item := range options.Items {
 		for _, ev := range item.Events {
 			switch ev {
@@ -248,13 +254,23 @@ func (sess *UserSession) SetNotify(ctx context.Context, options *imap.NotifyOpti
 	// Start capturing events before the watch goes live, so nothing raised
 	// between here and the first NotifyPoll is missed.
 	sess.notifyMutex.Lock()
+	sess.startNotifyLocked()
+	sess.notifyWatch = watch
+	sess.notifyMutex.Unlock()
+	return nil
+}
+
+// startNotifyLocked puts the session under NOTIFY's delivery rules (see
+// notifyOff) and registers its event channel with the user, unless both are
+// already the case. notifyMutex must be held.
+func (sess *UserSession) startNotifyLocked() {
+	if sess.notifyOff == nil {
+		sess.notifyOff = make(chan struct{})
+	}
 	if sess.notifyEvents == nil {
 		sess.notifyEvents = make(chan memNotifyEvent, 256)
 		sess.user.notify.register(sess.notifyEvents, sess)
 	}
-	sess.notifyWatch = watch
-	sess.notifyMutex.Unlock()
-	return nil
 }
 
 // stopNotifyEvents drops the watch and stops capturing events for it.
@@ -271,17 +287,16 @@ func (sess *UserSession) stopNotifyEvents() {
 }
 
 // NotifyPoll implements imapserver.SessionNotify.
+//
+// It runs after NOTIFY NONE as well, with no watch: then it delivers nothing
+// and only keeps the selected mailbox's queue of suppressed updates within
+// bounds (checkNotifyOverflow).
 func (sess *UserSession) NotifyPoll(ctx context.Context, w *imapserver.UpdateWriter, stop <-chan struct{}) error {
-	sess.notifyMutex.Lock()
-	watch := sess.notifyWatch
-	sess.notifyMutex.Unlock()
-	if watch == nil {
-		return nil
-	}
-
 	// The channel is registered by SetNotify and outlives this call: the
 	// library stops and restarts the pump around every change of the selected
-	// mailbox, and events raised in that window must be queued, not lost.
+	// mailbox, and events raised in that window must be queued, not lost. It
+	// is nil once NOTIFY is over — after a notification overflow, or when
+	// NOTIFY was never used on this session.
 	sess.notifyMutex.Lock()
 	ch := sess.notifyEvents
 	sess.notifyMutex.Unlock()
@@ -316,6 +331,10 @@ func (sess *UserSession) NotifyPoll(ctx context.Context, w *imapserver.UpdateWri
 // checkNotifyOverflow declares a notification overflow when the selected
 // mailbox has accumulated more undeliverable updates than the server is willing
 // to hold (RFC 5465 section 5.8). It reports whether the watch was dropped.
+//
+// The library then returns the connection to pre-NOTIFY delivery, so this
+// session does the same: the watch and the event channel go, and notifyOff is
+// closed so that an IDLE in progress resumes pushing updates.
 func (sess *UserSession) checkNotifyOverflow(w *imapserver.UpdateWriter) (bool, error) {
 	sess.notifyMutex.Lock()
 	mailbox := sess.mailbox
@@ -328,6 +347,13 @@ func (sess *UserSession) checkNotifyOverflow(w *imapserver.UpdateWriter) (bool, 
 		return false, err
 	}
 	sess.stopNotifyEvents()
+
+	sess.notifyMutex.Lock()
+	if sess.notifyOff != nil {
+		close(sess.notifyOff)
+		sess.notifyOff = nil
+	}
+	sess.notifyMutex.Unlock()
 	return true, nil
 }
 

--- a/imapserver/imapmemserver/notify.go
+++ b/imapserver/imapmemserver/notify.go
@@ -19,6 +19,8 @@ const (
 	evMailboxDeleted
 	evMailboxRenamed
 	evSubscriptionChange
+	evMailboxMetadataChange
+	evServerMetadataChange
 	evMessageNew
 	evMessageExpunge
 	evFlagChange
@@ -43,6 +45,10 @@ func (kind memNotifyEventKind) notifyEvent() imap.NotifyEvent {
 		return imap.NotifyEventMailboxName
 	case evSubscriptionChange:
 		return imap.NotifyEventSubscriptionChange
+	case evMailboxMetadataChange:
+		return imap.NotifyEventMailboxMetadataChange
+	case evServerMetadataChange:
+		return imap.NotifyEventServerMetadataChange
 	case evMessageNew:
 		return imap.NotifyEventMessageNew
 	case evMessageExpunge:
@@ -58,6 +64,15 @@ type memNotifyEvent struct {
 	kind    memNotifyEventKind
 	mailbox string // current mailbox name
 	oldName string // previous name, for evMailboxRenamed
+
+	// entries holds the changed annotations of a metadata event. A nil value
+	// denotes a deleted entry (RFC 5465 sections 5.6 and 5.7).
+	entries map[string]*[]byte
+
+	// source is the session that caused the event, when known. RFC 5465
+	// section 5: "The server SHOULD omit notifying the client if the event is
+	// caused by this client."
+	source *UserSession
 }
 
 // notifyRegistry fans change events out to the NOTIFY watchers of a user.
@@ -66,16 +81,16 @@ type memNotifyEvent struct {
 // would send NOTIFICATIONOVERFLOW instead).
 type notifyRegistry struct {
 	mutex    sync.Mutex
-	watchers map[chan<- memNotifyEvent]struct{}
+	watchers map[chan<- memNotifyEvent]*UserSession
 }
 
-func (r *notifyRegistry) register(ch chan<- memNotifyEvent) {
+func (r *notifyRegistry) register(ch chan<- memNotifyEvent, owner *UserSession) {
 	r.mutex.Lock()
 	defer r.mutex.Unlock()
 	if r.watchers == nil {
-		r.watchers = make(map[chan<- memNotifyEvent]struct{})
+		r.watchers = make(map[chan<- memNotifyEvent]*UserSession)
 	}
-	r.watchers[ch] = struct{}{}
+	r.watchers[ch] = owner
 }
 
 func (r *notifyRegistry) unregister(ch chan<- memNotifyEvent) {
@@ -87,7 +102,11 @@ func (r *notifyRegistry) unregister(ch chan<- memNotifyEvent) {
 func (r *notifyRegistry) broadcast(ev memNotifyEvent) {
 	r.mutex.Lock()
 	defer r.mutex.Unlock()
-	for ch := range r.watchers {
+	for ch, owner := range r.watchers {
+		// RFC 5465 section 5: don't notify the session that caused the event.
+		if ev.source != nil && owner == ev.source {
+			continue
+		}
 		select {
 		case ch <- ev:
 		default:
@@ -104,6 +123,8 @@ var memNotifySupportedEvents = []imap.NotifyEvent{
 	imap.NotifyEventFlagChange,
 	imap.NotifyEventMailboxName,
 	imap.NotifyEventSubscriptionChange,
+	imap.NotifyEventMailboxMetadataChange,
+	imap.NotifyEventServerMetadataChange,
 }
 
 // notifyWatch is the per-session NOTIFY state installed by SetNotify.
@@ -150,7 +171,8 @@ func (sess *UserSession) SetNotify(ctx context.Context, options *imap.NotifyOpti
 			switch ev {
 			case imap.NotifyEventMessageNew, imap.NotifyEventMessageExpunge,
 				imap.NotifyEventFlagChange, imap.NotifyEventMailboxName,
-				imap.NotifyEventSubscriptionChange:
+				imap.NotifyEventSubscriptionChange,
+				imap.NotifyEventMailboxMetadataChange, imap.NotifyEventServerMetadataChange:
 				// supported
 			default:
 				return &imapserver.UnsupportedNotifyEventError{
@@ -217,7 +239,7 @@ func (sess *UserSession) NotifyPoll(ctx context.Context, w *imapserver.UpdateWri
 	}
 
 	ch := make(chan memNotifyEvent, 256)
-	sess.user.notify.register(ch)
+	sess.user.notify.register(ch, sess)
 	defer sess.user.notify.unregister(ch)
 
 	for {
@@ -252,6 +274,15 @@ func (sess *UserSession) handleNotifyEvent(ev memNotifyEvent, w *imapserver.Upda
 		return sess.handleSelectedNotifyEvent(ev, watch, mailbox, w)
 	}
 
+	// RFC 5465 sections 5.7 and 8: ServerMetadataChange is a <user-event>, not
+	// tied to a mailbox, so it is enabled by any non-selected event group.
+	if ev.kind == evServerMetadataChange {
+		if !notifyEventRequested(watch, imap.NotifyEventServerMetadataChange) {
+			return nil
+		}
+		return w.WriteMetadata("", ev.entries)
+	}
+
 	events := sess.notifyEventsForMailbox(watch, ev.mailbox)
 	if !events[ev.kind.notifyEvent()] {
 		return nil
@@ -260,6 +291,10 @@ func (sess *UserSession) handleNotifyEvent(ev memNotifyEvent, w *imapserver.Upda
 	switch ev.kind {
 	case evMailboxCreated, evMailboxDeleted, evMailboxRenamed, evSubscriptionChange:
 		return w.WriteList(sess.notifyListData(ev))
+	case evMailboxMetadataChange:
+		// RFC 5465 section 5.6: report the changed annotations with an
+		// unsolicited METADATA response.
+		return w.WriteMetadata(ev.mailbox, ev.entries)
 	case evMessageNew, evMessageExpunge, evFlagChange:
 		// RFC 5465 sections 5.1-5.3: message events in non-selected
 		// mailboxes are reported with an unsolicited STATUS response.
@@ -357,6 +392,25 @@ func (sess *UserSession) writeNotifyNewMessages(watch *notifyWatch, mailbox *Mai
 		}
 	}
 	return nil
+}
+
+// notifyEventRequested reports whether any non-selected event group requests
+// the given event, regardless of the mailboxes it applies to. It is used for
+// server-wide events, which are not tied to a mailbox.
+func notifyEventRequested(watch *notifyWatch, event imap.NotifyEvent) bool {
+	for i := range watch.options.Items {
+		item := &watch.options.Items[i]
+		if item.MailboxSpec == imap.NotifyMailboxSpecSelected ||
+			item.MailboxSpec == imap.NotifyMailboxSpecSelectedDelayed {
+			continue
+		}
+		for _, ev := range item.Events {
+			if ev == event {
+				return true
+			}
+		}
+	}
+	return false
 }
 
 // notifyEventsForMailbox returns the union of events requested for the given

--- a/imapserver/imapmemserver/notify.go
+++ b/imapserver/imapmemserver/notify.go
@@ -1,0 +1,472 @@
+package imapmemserver
+
+import (
+	"context"
+	"sort"
+	"strings"
+	"sync"
+
+	"github.com/emersion/go-imap/v2"
+	"github.com/emersion/go-imap/v2/imapserver"
+)
+
+// memNotifyEventKind enumerates the internal change events broadcast to
+// NOTIFY watchers.
+type memNotifyEventKind int
+
+const (
+	evMailboxCreated memNotifyEventKind = iota
+	evMailboxDeleted
+	evMailboxRenamed
+	evSubscriptionChange
+	evMessageNew
+	evMessageExpunge
+	evFlagChange
+)
+
+// isMessageEvent reports whether the internal event maps to an RFC 5465
+// <message-event> (as opposed to a mailbox event).
+func (kind memNotifyEventKind) isMessageEvent() bool {
+	switch kind {
+	case evMessageNew, evMessageExpunge, evFlagChange:
+		return true
+	default:
+		return false
+	}
+}
+
+// notifyEvent maps the internal event kind to the RFC 5465 event a client
+// must have requested to receive it.
+func (kind memNotifyEventKind) notifyEvent() imap.NotifyEvent {
+	switch kind {
+	case evMailboxCreated, evMailboxDeleted, evMailboxRenamed:
+		return imap.NotifyEventMailboxName
+	case evSubscriptionChange:
+		return imap.NotifyEventSubscriptionChange
+	case evMessageNew:
+		return imap.NotifyEventMessageNew
+	case evMessageExpunge:
+		return imap.NotifyEventMessageExpunge
+	case evFlagChange:
+		return imap.NotifyEventFlagChange
+	default:
+		panic("imapmemserver: unknown notify event kind")
+	}
+}
+
+type memNotifyEvent struct {
+	kind    memNotifyEventKind
+	mailbox string // current mailbox name
+	oldName string // previous name, for evMailboxRenamed
+}
+
+// notifyRegistry fans change events out to the NOTIFY watchers of a user.
+// Watcher channels are buffered; events for a watcher that has fallen behind
+// are dropped (the in-memory server favors simplicity — a production backend
+// would send NOTIFICATIONOVERFLOW instead).
+type notifyRegistry struct {
+	mutex    sync.Mutex
+	watchers map[chan<- memNotifyEvent]struct{}
+}
+
+func (r *notifyRegistry) register(ch chan<- memNotifyEvent) {
+	r.mutex.Lock()
+	defer r.mutex.Unlock()
+	if r.watchers == nil {
+		r.watchers = make(map[chan<- memNotifyEvent]struct{})
+	}
+	r.watchers[ch] = struct{}{}
+}
+
+func (r *notifyRegistry) unregister(ch chan<- memNotifyEvent) {
+	r.mutex.Lock()
+	defer r.mutex.Unlock()
+	delete(r.watchers, ch)
+}
+
+func (r *notifyRegistry) broadcast(ev memNotifyEvent) {
+	r.mutex.Lock()
+	defer r.mutex.Unlock()
+	for ch := range r.watchers {
+		select {
+		case ch <- ev:
+		default:
+			// Watcher queue full: drop the event.
+		}
+	}
+}
+
+// memNotifySupportedEvents is the set of RFC 5465 events the in-memory
+// server supports, advertised in the BADEVENT response code.
+var memNotifySupportedEvents = []imap.NotifyEvent{
+	imap.NotifyEventMessageNew,
+	imap.NotifyEventMessageExpunge,
+	imap.NotifyEventFlagChange,
+	imap.NotifyEventMailboxName,
+	imap.NotifyEventSubscriptionChange,
+}
+
+// notifyWatch is the per-session NOTIFY state installed by SetNotify.
+type notifyWatch struct {
+	options *imap.NotifyOptions
+
+	// selected is the item with the SELECTED/SELECTED-DELAYED specifier, if
+	// any.
+	selected *imap.NotifyItem
+
+	// lastUIDNext is the UIDNEXT high-water mark of the selected mailbox,
+	// used to identify the new messages a MessageNew FETCH response must be
+	// generated for.
+	lastUIDNext imap.UID
+}
+
+// selectedEvents reports whether the selected-mailbox item requests the
+// given event.
+func (watch *notifyWatch) selectedEvents(event imap.NotifyEvent) bool {
+	if watch.selected == nil {
+		return false
+	}
+	for _, ev := range watch.selected.Events {
+		if ev == event {
+			return true
+		}
+	}
+	return false
+}
+
+var _ imapserver.SessionNotify = (*UserSession)(nil)
+
+// SetNotify implements imapserver.SessionNotify.
+func (sess *UserSession) SetNotify(ctx context.Context, options *imap.NotifyOptions, w *imapserver.UpdateWriter) error {
+	if options == nil {
+		sess.notifyMutex.Lock()
+		sess.notifyWatch = nil
+		sess.notifyMutex.Unlock()
+		return nil
+	}
+
+	for _, item := range options.Items {
+		for _, ev := range item.Events {
+			switch ev {
+			case imap.NotifyEventMessageNew, imap.NotifyEventMessageExpunge,
+				imap.NotifyEventFlagChange, imap.NotifyEventMailboxName,
+				imap.NotifyEventSubscriptionChange:
+				// supported
+			default:
+				return &imapserver.UnsupportedNotifyEventError{
+					Supported: memNotifySupportedEvents,
+				}
+			}
+		}
+	}
+
+	watch := &notifyWatch{options: options}
+	for i := range options.Items {
+		item := &options.Items[i]
+		if item.MailboxSpec == imap.NotifyMailboxSpecSelected ||
+			item.MailboxSpec == imap.NotifyMailboxSpecSelectedDelayed {
+			watch.selected = item
+		}
+	}
+
+	sess.notifyMutex.Lock()
+	selectedName := ""
+	if sess.mailbox != nil {
+		selectedName = sess.mailbox.name
+		watch.lastUIDNext = sess.mailbox.uidNext
+	}
+	sess.notifyMutex.Unlock()
+
+	// RFC 5465 section 3.1: with the STATUS indicator, send a STATUS
+	// response for each non-selected mailbox with message events enabled,
+	// before NOTIFY's tagged OK (SetNotify runs synchronously before the
+	// tagged response is written).
+	if options.Status {
+		for _, name := range sess.user.sortedMailboxNames() {
+			if name == selectedName {
+				continue
+			}
+			events := sess.notifyEventsForMailbox(watch, name)
+			statusOptions := notifyStatusOptions(events, w.CondStoreEnabled())
+			if statusOptions == nil {
+				continue
+			}
+			mbox, err := sess.user.mailbox(name)
+			if err != nil {
+				continue
+			}
+			if err := w.WriteStatus(mbox.StatusData(statusOptions), statusOptions); err != nil {
+				return err
+			}
+		}
+	}
+
+	sess.notifyMutex.Lock()
+	sess.notifyWatch = watch
+	sess.notifyMutex.Unlock()
+	return nil
+}
+
+// NotifyPoll implements imapserver.SessionNotify.
+func (sess *UserSession) NotifyPoll(ctx context.Context, w *imapserver.UpdateWriter, stop <-chan struct{}) error {
+	sess.notifyMutex.Lock()
+	watch := sess.notifyWatch
+	sess.notifyMutex.Unlock()
+	if watch == nil {
+		return nil
+	}
+
+	ch := make(chan memNotifyEvent, 256)
+	sess.user.notify.register(ch)
+	defer sess.user.notify.unregister(ch)
+
+	for {
+		select {
+		case <-stop:
+			return nil
+		case <-ctx.Done():
+			return nil
+		case ev := <-ch:
+			if err := sess.handleNotifyEvent(ev, w); err != nil {
+				return err
+			}
+		}
+	}
+}
+
+func (sess *UserSession) handleNotifyEvent(ev memNotifyEvent, w *imapserver.UpdateWriter) error {
+	sess.notifyMutex.Lock()
+	watch := sess.notifyWatch
+	mailbox := sess.mailbox
+	sess.notifyMutex.Unlock()
+	if watch == nil {
+		return nil
+	}
+
+	selectedName := ""
+	if mailbox != nil {
+		selectedName = mailbox.name
+	}
+
+	if ev.kind.isMessageEvent() && ev.mailbox == selectedName && mailbox != nil {
+		return sess.handleSelectedNotifyEvent(ev, watch, mailbox, w)
+	}
+
+	events := sess.notifyEventsForMailbox(watch, ev.mailbox)
+	if !events[ev.kind.notifyEvent()] {
+		return nil
+	}
+
+	switch ev.kind {
+	case evMailboxCreated, evMailboxDeleted, evMailboxRenamed, evSubscriptionChange:
+		return w.WriteList(sess.notifyListData(ev))
+	case evMessageNew, evMessageExpunge, evFlagChange:
+		// RFC 5465 sections 5.1-5.3: message events in non-selected
+		// mailboxes are reported with an unsolicited STATUS response.
+		statusOptions := notifyStatusOptions(map[imap.NotifyEvent]bool{ev.kind.notifyEvent(): true}, w.CondStoreEnabled())
+		if statusOptions == nil {
+			return nil
+		}
+		mbox, err := sess.user.mailbox(ev.mailbox)
+		if err != nil {
+			// The mailbox disappeared in the meantime.
+			return nil
+		}
+		return w.WriteStatus(mbox.StatusData(statusOptions), statusOptions)
+	}
+	return nil
+}
+
+// handleSelectedNotifyEvent delivers a message event for the currently
+// selected mailbox: pending tracker updates (EXISTS, EXPUNGE, FETCH) are
+// flushed, and MessageNew fetch attributes are honored (RFC 5465 section
+// 5.2).
+func (sess *UserSession) handleSelectedNotifyEvent(ev memNotifyEvent, watch *notifyWatch, mailbox *MailboxView, w *imapserver.UpdateWriter) error {
+	// RFC 5465 section 3.1: message events for the selected mailbox are
+	// only reported when requested with the SELECTED/SELECTED-DELAYED
+	// specifier. Without it, updates stay queued until the next command.
+	if !watch.selectedEvents(ev.kind.notifyEvent()) {
+		return nil
+	}
+
+	// SELECTED-DELAYED delays MessageExpunge until a command sync point
+	// (RFC 5465 section 6.1.2): leave expunges queued for the regular
+	// per-command Poll. Plain SELECTED delivers immediately, unless a
+	// command that forbids expunges is in progress.
+	allowExpunge := watch.selected.MailboxSpec == imap.NotifyMailboxSpecSelected && w.ExpungeAllowed()
+	if err := mailbox.tracker.Poll(w, allowExpunge); err != nil {
+		return err
+	}
+
+	if ev.kind == evMessageNew && watch.selected.MessageNewFetch != nil {
+		return sess.writeNotifyNewMessages(watch, mailbox, w)
+	}
+	return nil
+}
+
+// writeNotifyNewMessages sends the FETCH responses with the requested
+// MessageNew fetch attributes for messages that appeared in the selected
+// mailbox since the last notification.
+func (sess *UserSession) writeNotifyNewMessages(watch *notifyWatch, mailbox *MailboxView, w *imapserver.UpdateWriter) error {
+	type newMessage struct {
+		seqNum uint32
+		msg    *message
+	}
+
+	mailbox.mutex.Lock()
+	var newMsgs []newMessage
+	for i, msg := range mailbox.l {
+		if msg.uid >= watch.lastUIDNext {
+			newMsgs = append(newMsgs, newMessage{
+				seqNum: mailbox.tracker.EncodeSeqNum(uint32(i) + 1),
+				msg:    msg,
+			})
+		}
+	}
+	uidNext := mailbox.uidNext
+	mailbox.mutex.Unlock()
+
+	// Advance the high-water mark before writing: a write failure tears the
+	// connection down anyway, and this avoids duplicate FETCHes if delivery
+	// partially fails.
+	sess.notifyMutex.Lock()
+	watch.lastUIDNext = uidNext
+	sess.notifyMutex.Unlock()
+
+	fetchWriter := w.FetchWriter()
+	for _, nm := range newMsgs {
+		respWriter := fetchWriter.CreateMessage(nm.seqNum)
+		if err := nm.msg.fetch(respWriter, watch.selected.MessageNewFetch); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// notifyEventsForMailbox returns the union of events requested for the given
+// mailbox by all non-selected specifiers (RFC 5465 section 6: multiple event
+// groups can apply to the same mailbox; SELECTED/SELECTED-DELAYED are the
+// only specifiers matching the selected mailbox, which is handled
+// separately).
+func (sess *UserSession) notifyEventsForMailbox(watch *notifyWatch, name string) map[imap.NotifyEvent]bool {
+	events := make(map[imap.NotifyEvent]bool)
+	for i := range watch.options.Items {
+		item := &watch.options.Items[i]
+		match := false
+		switch item.MailboxSpec {
+		case imap.NotifyMailboxSpecSelected, imap.NotifyMailboxSpecSelectedDelayed:
+			continue
+		case imap.NotifyMailboxSpecPersonal:
+			// The in-memory server only has personal mailboxes.
+			match = true
+		case imap.NotifyMailboxSpecInboxes:
+			// RFC 5465 section 6.3: mailboxes an MDA may deliver to; INBOX
+			// for the in-memory server.
+			match = strings.EqualFold(name, "INBOX")
+		case imap.NotifyMailboxSpecSubscribed:
+			if mbox, err := sess.user.mailbox(name); err == nil {
+				mbox.mutex.Lock()
+				match = mbox.subscribed
+				mbox.mutex.Unlock()
+			}
+		default:
+			for _, root := range item.Mailboxes {
+				if name == root {
+					match = true
+					break
+				}
+				if item.Subtree && strings.HasPrefix(name, root+string(mailboxDelim)) {
+					match = true
+					break
+				}
+			}
+		}
+		if match {
+			for _, ev := range item.Events {
+				events[ev] = true
+			}
+		}
+	}
+	return events
+}
+
+// notifyListData builds the unsolicited LIST response for a mailbox event
+// (RFC 5465 sections 5.4 and 5.5).
+func (sess *UserSession) notifyListData(ev memNotifyEvent) *imap.ListData {
+	data := &imap.ListData{
+		Mailbox: ev.mailbox,
+		Delim:   mailboxDelim,
+	}
+	switch ev.kind {
+	case evMailboxDeleted:
+		data.Attrs = append(data.Attrs, imap.MailboxAttrNonExistent)
+	case evMailboxRenamed:
+		data.OldName = ev.oldName
+	}
+	// RFC 5465 section 5.5: include \Subscribed if and only if the mailbox
+	// is subscribed after the event.
+	if ev.kind != evMailboxDeleted {
+		if mbox, err := sess.user.mailbox(ev.mailbox); err == nil {
+			mbox.mutex.Lock()
+			if mbox.subscribed {
+				data.Attrs = append(data.Attrs, imap.MailboxAttrSubscribed)
+			}
+			mbox.mutex.Unlock()
+		}
+	}
+	return data
+}
+
+// notifyStatusOptions maps the message events enabled for a non-selected
+// mailbox to the STATUS items required by RFC 5465 sections 5.1-5.3, and
+// section 3.1 for the initial STATUS responses. It returns nil when no
+// message event is enabled (no STATUS response should be sent).
+func notifyStatusOptions(events map[imap.NotifyEvent]bool, condStore bool) *imap.StatusOptions {
+	options := &imap.StatusOptions{}
+	any := false
+	if events[imap.NotifyEventMessageNew] {
+		// RFC 5465 section 5.2: STATUS (UIDNEXT MESSAGES), UIDVALIDITY for
+		// the initial STATUS of section 3.1.
+		options.NumMessages = true
+		options.UIDNext = true
+		options.UIDValidity = true
+		any = true
+	}
+	if events[imap.NotifyEventMessageExpunge] {
+		// RFC 5465 section 5.3: STATUS (UIDNEXT MESSAGES).
+		options.NumMessages = true
+		options.UIDNext = true
+		any = true
+	}
+	if events[imap.NotifyEventFlagChange] {
+		// RFC 5465 section 5.1: UIDVALIDITY and HIGHESTMODSEQ when
+		// CONDSTORE/QRESYNC is enabled, otherwise UNSEEN (the server MAY
+		// include it; without it there would be nothing to report).
+		options.UIDValidity = true
+		if condStore {
+			options.HighestModSeq = true
+		} else {
+			options.NumUnseen = true
+		}
+		any = true
+	}
+	if !any {
+		return nil
+	}
+	if condStore {
+		options.HighestModSeq = true
+	}
+	return options
+}
+
+// sortedMailboxNames returns the user's mailbox names in a stable order.
+func (u *User) sortedMailboxNames() []string {
+	u.mutex.Lock()
+	names := make([]string, 0, len(u.mailboxes))
+	for name := range u.mailboxes {
+		names = append(names, name)
+	}
+	u.mutex.Unlock()
+	sort.Strings(names)
+	return names
+}

--- a/imapserver/imapmemserver/notify.go
+++ b/imapserver/imapmemserver/notify.go
@@ -18,6 +18,8 @@ const (
 	evMailboxCreated memNotifyEventKind = iota
 	evMailboxDeleted
 	evMailboxRenamed
+	evMailboxParent   // the direct parent of a created or deleted mailbox
+	evMailboxNoAccess // the client kept the 'l' right but lost another one
 	evSubscriptionChange
 	evMailboxMetadataChange
 	evServerMetadataChange
@@ -41,7 +43,7 @@ func (kind memNotifyEventKind) isMessageEvent() bool {
 // must have requested to receive it.
 func (kind memNotifyEventKind) notifyEvent() imap.NotifyEvent {
 	switch kind {
-	case evMailboxCreated, evMailboxDeleted, evMailboxRenamed:
+	case evMailboxCreated, evMailboxDeleted, evMailboxRenamed, evMailboxParent, evMailboxNoAccess:
 		return imap.NotifyEventMailboxName
 	case evSubscriptionChange:
 		return imap.NotifyEventSubscriptionChange
@@ -65,9 +67,15 @@ type memNotifyEvent struct {
 	mailbox string // current mailbox name
 	oldName string // previous name, for evMailboxRenamed
 
-	// entries holds the changed annotations of a metadata event. A nil value
-	// denotes a deleted entry (RFC 5465 sections 5.6 and 5.7).
-	entries map[string]*[]byte
+	// mbox identifies the mailbox a message event happened in. Events are
+	// routed by identity rather than by name, so a concurrent RENAME can
+	// neither misroute them nor race the name read.
+	mbox *Mailbox
+
+	// entries lists the names of the annotations changed by a metadata event,
+	// deletions included (RFC 5465 sections 5.6 and 5.7). Unsolicited METADATA
+	// responses carry names only (RFC 5464 section 4.4).
+	entries []string
 
 	// source is the session that caused the event, when known. RFC 5465
 	// section 5: "The server SHOULD omit notifying the client if the event is
@@ -115,6 +123,12 @@ func (r *notifyRegistry) broadcast(ev memNotifyEvent) {
 	}
 }
 
+// maxNotifyQueuedUpdates bounds how many undelivered updates the selected
+// mailbox may accumulate while the client's watch suppresses message events for
+// it. Past that, the in-memory server declares a notification overflow (RFC
+// 5465 section 5.8) rather than let a frozen view grow without bound.
+const maxNotifyQueuedUpdates = 1024
+
 // memNotifySupportedEvents is the set of RFC 5465 events the in-memory
 // server supports, advertised in the BADEVENT response code.
 var memNotifySupportedEvents = []imap.NotifyEvent{
@@ -159,10 +173,12 @@ var _ imapserver.SessionNotify = (*UserSession)(nil)
 
 // SetNotify implements imapserver.SessionNotify.
 func (sess *UserSession) SetNotify(ctx context.Context, options *imap.NotifyOptions, w *imapserver.UpdateWriter) error {
+	sess.notifyMutex.Lock()
+	sess.notifyUsed = true
+	sess.notifyMutex.Unlock()
+
 	if options == nil {
-		sess.notifyMutex.Lock()
-		sess.notifyWatch = nil
-		sess.notifyMutex.Unlock()
+		sess.stopNotifyEvents()
 		return nil
 	}
 
@@ -192,12 +208,18 @@ func (sess *UserSession) SetNotify(ctx context.Context, options *imap.NotifyOpti
 	}
 
 	sess.notifyMutex.Lock()
-	selectedName := ""
-	if sess.mailbox != nil {
-		selectedName = sess.mailbox.name
-		watch.lastUIDNext = sess.mailbox.uidNext
-	}
+	mailbox := sess.mailbox
 	sess.notifyMutex.Unlock()
+
+	// name and uidNext are guarded by the mailbox lock, not by notifyMutex:
+	// another session may be appending or renaming concurrently.
+	selectedName := ""
+	if mailbox != nil {
+		mailbox.mutex.Lock()
+		selectedName = mailbox.name
+		watch.lastUIDNext = mailbox.uidNext
+		mailbox.mutex.Unlock()
+	}
 
 	// RFC 5465 section 3.1: with the STATUS indicator, send a STATUS
 	// response for each non-selected mailbox with message events enabled,
@@ -223,10 +245,29 @@ func (sess *UserSession) SetNotify(ctx context.Context, options *imap.NotifyOpti
 		}
 	}
 
+	// Start capturing events before the watch goes live, so nothing raised
+	// between here and the first NotifyPoll is missed.
 	sess.notifyMutex.Lock()
+	if sess.notifyEvents == nil {
+		sess.notifyEvents = make(chan memNotifyEvent, 256)
+		sess.user.notify.register(sess.notifyEvents, sess)
+	}
 	sess.notifyWatch = watch
 	sess.notifyMutex.Unlock()
 	return nil
+}
+
+// stopNotifyEvents drops the watch and stops capturing events for it.
+func (sess *UserSession) stopNotifyEvents() {
+	sess.notifyMutex.Lock()
+	ch := sess.notifyEvents
+	sess.notifyEvents = nil
+	sess.notifyWatch = nil
+	sess.notifyMutex.Unlock()
+
+	if ch != nil {
+		sess.user.notify.unregister(ch)
+	}
 }
 
 // NotifyPoll implements imapserver.SessionNotify.
@@ -238,9 +279,15 @@ func (sess *UserSession) NotifyPoll(ctx context.Context, w *imapserver.UpdateWri
 		return nil
 	}
 
-	ch := make(chan memNotifyEvent, 256)
-	sess.user.notify.register(ch, sess)
-	defer sess.user.notify.unregister(ch)
+	// The channel is registered by SetNotify and outlives this call: the
+	// library stops and restarts the pump around every change of the selected
+	// mailbox, and events raised in that window must be queued, not lost.
+	sess.notifyMutex.Lock()
+	ch := sess.notifyEvents
+	sess.notifyMutex.Unlock()
+	if ch == nil {
+		return nil
+	}
 
 	for {
 		select {
@@ -252,8 +299,36 @@ func (sess *UserSession) NotifyPoll(ctx context.Context, w *imapserver.UpdateWri
 			if err := sess.handleNotifyEvent(ev, w); err != nil {
 				return err
 			}
+			overflowed, err := sess.checkNotifyOverflow(w)
+			if err != nil {
+				return err
+			}
+			if overflowed {
+				// RFC 5465 section 5.8: the server behaves as if NOTIFY NONE
+				// had been received, so the watch is gone and there is nothing
+				// left to pump.
+				return nil
+			}
 		}
 	}
+}
+
+// checkNotifyOverflow declares a notification overflow when the selected
+// mailbox has accumulated more undeliverable updates than the server is willing
+// to hold (RFC 5465 section 5.8). It reports whether the watch was dropped.
+func (sess *UserSession) checkNotifyOverflow(w *imapserver.UpdateWriter) (bool, error) {
+	sess.notifyMutex.Lock()
+	mailbox := sess.mailbox
+	sess.notifyMutex.Unlock()
+	if mailbox == nil || mailbox.tracker.QueuedUpdates() <= maxNotifyQueuedUpdates {
+		return false, nil
+	}
+
+	if err := w.WriteNotificationOverflow(); err != nil {
+		return false, err
+	}
+	sess.stopNotifyEvents()
+	return true, nil
 }
 
 func (sess *UserSession) handleNotifyEvent(ev memNotifyEvent, w *imapserver.UpdateWriter) error {
@@ -265,12 +340,9 @@ func (sess *UserSession) handleNotifyEvent(ev memNotifyEvent, w *imapserver.Upda
 		return nil
 	}
 
-	selectedName := ""
-	if mailbox != nil {
-		selectedName = mailbox.name
-	}
-
-	if ev.kind.isMessageEvent() && ev.mailbox == selectedName && mailbox != nil {
+	// Compare mailbox identity, not names: a concurrent RENAME would both race
+	// the name read and misroute the event.
+	if ev.kind.isMessageEvent() && mailbox != nil && ev.mbox != nil && ev.mbox == mailbox.Mailbox {
 		return sess.handleSelectedNotifyEvent(ev, watch, mailbox, w)
 	}
 
@@ -289,7 +361,7 @@ func (sess *UserSession) handleNotifyEvent(ev memNotifyEvent, w *imapserver.Upda
 	}
 
 	switch ev.kind {
-	case evMailboxCreated, evMailboxDeleted, evMailboxRenamed, evSubscriptionChange:
+	case evMailboxCreated, evMailboxDeleted, evMailboxRenamed, evMailboxParent, evMailboxNoAccess, evSubscriptionChange:
 		return w.WriteList(sess.notifyListData(ev))
 	case evMailboxMetadataChange:
 		// RFC 5465 section 5.6: report the changed annotations with an
@@ -324,19 +396,47 @@ func (sess *UserSession) handleSelectedNotifyEvent(ev memNotifyEvent, watch *not
 		return nil
 	}
 
-	// SELECTED-DELAYED delays MessageExpunge until a command sync point
-	// (RFC 5465 section 6.1.2): leave expunges queued for the regular
-	// per-command Poll. Plain SELECTED delivers immediately, unless a
-	// command that forbids expunges is in progress.
-	allowExpunge := watch.selected.MailboxSpec == imap.NotifyMailboxSpecSelected && w.ExpungeAllowed()
-	if err := mailbox.tracker.Poll(w, allowExpunge); err != nil {
-		return err
+	// SELECTED-DELAYED delays MessageExpunge until the client issues a command
+	// that allows reporting expunged messages (RFC 5465 section 6.1.2) — NOOP
+	// or IDLE, which DelayedExpungeAllowed reports. Withholding them past that
+	// would also head-of-line block every later EXISTS, since updates are
+	// delivered in order. Plain SELECTED delivers immediately, unless a command
+	// that forbids expunges is in progress.
+	var allowExpunge bool
+	if watch.selected.MailboxSpec == imap.NotifyMailboxSpecSelected {
+		allowExpunge = w.ExpungeAllowed()
+	} else {
+		allowExpunge = w.DelayedExpungeAllowed()
 	}
 
-	if ev.kind == evMessageNew && watch.selected.MessageNewFetch != nil {
-		return sess.writeNotifyNewMessages(watch, mailbox, w)
+	// The fetch-atts of the new messages are written while the delivery lock is
+	// still held: their sequence numbers are only valid for the state this Poll
+	// just delivered.
+	var after func() error
+	if watch.selected.MessageNewFetch != nil {
+		after = func() error { return sess.writeNotifyNewMessages(watch, mailbox, w) }
 	}
-	return nil
+	return mailbox.tracker.PollWith(w, allowExpunge, after)
+}
+
+// notifyPendingFetch writes any MessageNew fetch-atts that could not be sent
+// yet — a message whose EXISTS was still queued has no client-side sequence
+// number. It is called from the per-command sync point as well as from the
+// pump, because the sync point is what releases those queued updates and the
+// pump only wakes on new events.
+func (sess *UserSession) notifyPendingFetch(w *imapserver.UpdateWriter) error {
+	sess.notifyMutex.Lock()
+	watch, mailbox := sess.notifyWatch, sess.mailbox
+	sess.notifyMutex.Unlock()
+	if watch == nil || mailbox == nil || watch.selected == nil || watch.selected.MessageNewFetch == nil {
+		return nil
+	}
+	if !watch.selectedEvents(imap.NotifyEventMessageNew) {
+		return nil
+	}
+	return mailbox.tracker.PollWith(w, false, func() error {
+		return sess.writeNotifyNewMessages(watch, mailbox, w)
+	})
 }
 
 // writeNotifyNewMessages sends the FETCH responses with the requested
@@ -373,7 +473,11 @@ func (sess *UserSession) writeNotifyNewMessages(watch *notifyWatch, mailbox *Mai
 		}
 		newMsgs = append(newMsgs, newMessage{seqNum: seqNum, msg: msg})
 	}
-	mailbox.mutex.Unlock()
+
+	// The message fields the fetch renders (flags, modSeq, body) are guarded by
+	// the mailbox lock, so it is held across the writes. MailboxView.Fetch does
+	// the same, and nothing the fetch calls takes the mailbox lock again.
+	defer mailbox.mutex.Unlock()
 
 	// Advance the high-water mark past the announced messages only. A write
 	// failure tears the connection down anyway; advancing before the write
@@ -386,6 +490,11 @@ func (sess *UserSession) writeNotifyNewMessages(watch *notifyWatch, mailbox *Mai
 
 	fetchWriter := w.FetchWriter()
 	for _, nm := range newMsgs {
+		// RFC 5465 section 5.2: no FETCH response for a message this
+		// connection created itself.
+		if sess.takeOwnMessage(nm.msg.uid) {
+			continue
+		}
 		respWriter := fetchWriter.CreateMessage(nm.seqNum)
 		if err := nm.msg.fetch(respWriter, watch.selected.MessageNewFetch); err != nil {
 			return err
@@ -467,22 +576,39 @@ func (sess *UserSession) notifyListData(ev memNotifyEvent) *imap.ListData {
 		Mailbox: ev.mailbox,
 		Delim:   mailboxDelim,
 	}
-	switch ev.kind {
-	case evMailboxDeleted:
-		data.Attrs = append(data.Attrs, imap.MailboxAttrNonExistent)
-	case evMailboxRenamed:
+	if ev.kind == evMailboxRenamed {
 		data.OldName = ev.oldName
 	}
-	// RFC 5465 section 5.5: include \Subscribed if and only if the mailbox
-	// is subscribed after the event.
-	if ev.kind != evMailboxDeleted {
-		if mbox, err := sess.user.mailbox(ev.mailbox); err == nil {
-			mbox.mutex.Lock()
-			if mbox.subscribed {
-				data.Attrs = append(data.Attrs, imap.MailboxAttrSubscribed)
-			}
-			mbox.mutex.Unlock()
+	if ev.kind == evMailboxNoAccess {
+		// RFC 5465 section 5.9: report the loss of a right needed to monitor
+		// the mailbox, which the client can still see.
+		data.Attrs = append(data.Attrs, imap.MailboxAttrNoAccess)
+	}
+
+	mbox, err := sess.user.mailbox(ev.mailbox)
+	switch {
+	case ev.kind == evMailboxDeleted || err != nil:
+		// RFC 5465 section 5.4: "If, after the event, the mailbox name does not
+		// refer to a mailbox accessible to the client, the \Nonexistent flag
+		// MUST be included." A parent reported as affected by the creation or
+		// deletion of a child need not exist itself.
+		data.Attrs = append(data.Attrs, imap.MailboxAttrNonExistent)
+	default:
+		// RFC 5465 section 5.5: include \Subscribed if and only if the mailbox
+		// is subscribed after the event.
+		mbox.mutex.Lock()
+		if mbox.subscribed {
+			data.Attrs = append(data.Attrs, imap.MailboxAttrSubscribed)
 		}
+		mbox.mutex.Unlock()
+	}
+
+	// RFC 5465 section 5.4: the server SHOULD also report whether the mailbox
+	// has children.
+	if sess.user.hasChildren(ev.mailbox) {
+		data.Attrs = append(data.Attrs, imap.MailboxAttrHasChildren)
+	} else {
+		data.Attrs = append(data.Attrs, imap.MailboxAttrHasNoChildren)
 	}
 	return data
 }

--- a/imapserver/imapmemserver/notify.go
+++ b/imapserver/imapmemserver/notify.go
@@ -313,24 +313,40 @@ func (sess *UserSession) writeNotifyNewMessages(watch *notifyWatch, mailbox *Mai
 		msg    *message
 	}
 
+	sess.notifyMutex.Lock()
+	since := watch.lastUIDNext
+	sess.notifyMutex.Unlock()
+
 	mailbox.mutex.Lock()
 	var newMsgs []newMessage
+	nextSince := mailbox.uidNext // advance fully if every new message is announced
 	for i, msg := range mailbox.l {
-		if msg.uid >= watch.lastUIDNext {
-			newMsgs = append(newMsgs, newMessage{
-				seqNum: mailbox.tracker.EncodeSeqNum(uint32(i) + 1),
-				msg:    msg,
-			})
+		if msg.uid < since {
+			continue
 		}
+		// Only emit fetch-atts for messages the client has already been told
+		// about via EXISTS. If a message's EXISTS is still queued (e.g. behind
+		// a delayed expunge, or an expunge-unsafe command is in progress),
+		// EncodeSeqNum returns 0; emitting a FETCH now would produce a
+		// wire-invalid "* 0 FETCH". Stop here and retry from this UID on a
+		// later tick, after the EXISTS has been delivered (RFC 5465 §5.2
+		// requires EXISTS to precede the FETCH).
+		seqNum := mailbox.tracker.EncodeSeqNum(uint32(i) + 1)
+		if seqNum == 0 {
+			nextSince = msg.uid
+			break
+		}
+		newMsgs = append(newMsgs, newMessage{seqNum: seqNum, msg: msg})
 	}
-	uidNext := mailbox.uidNext
 	mailbox.mutex.Unlock()
 
-	// Advance the high-water mark before writing: a write failure tears the
-	// connection down anyway, and this avoids duplicate FETCHes if delivery
-	// partially fails.
+	// Advance the high-water mark past the announced messages only. A write
+	// failure tears the connection down anyway; advancing before the write
+	// avoids duplicate FETCHes if delivery partially fails.
 	sess.notifyMutex.Lock()
-	watch.lastUIDNext = uidNext
+	if nextSince > watch.lastUIDNext {
+		watch.lastUIDNext = nextSince
+	}
 	sess.notifyMutex.Unlock()
 
 	fetchWriter := w.FetchWriter()

--- a/imapserver/imapmemserver/session.go
+++ b/imapserver/imapmemserver/session.go
@@ -166,6 +166,23 @@ func (sess *UserSession) Poll(ctx context.Context, w *imapserver.UpdateWriter, a
 }
 
 func (sess *UserSession) Idle(ctx context.Context, w *imapserver.UpdateWriter, stop <-chan struct{}) error {
+	sess.notifyMutex.Lock()
+	watchActive := sess.notifyWatch != nil
+	sess.notifyMutex.Unlock()
+	if watchActive {
+		// A NOTIFY watch is the single event source for this connection: the
+		// pump delivers according to the client's NOTIFY filter. IDLE then
+		// only keeps the connection open. Delivering via tracker.Idle here
+		// would bypass the filter — e.g. a watch without a SELECTED specifier
+		// (RFC 5465 §3.1: "same as specifying SELECTED NONE") must not push
+		// selected-mailbox message events.
+		select {
+		case <-stop:
+		case <-ctx.Done():
+		}
+		return nil
+	}
+
 	if sess.mailbox == nil {
 		return nil // TODO
 	}

--- a/imapserver/imapmemserver/session.go
+++ b/imapserver/imapmemserver/session.go
@@ -41,16 +41,21 @@ type UserSession struct {
 	notifyMutex sync.Mutex
 	notifyWatch *notifyWatch
 
-	// notifyUsed records that the client issued NOTIFY on this session. It
-	// stays set after NOTIFY NONE: that command asks for no events at all
-	// (RFC 5465 section 3.1), so IDLE must not fall back to pushing the
-	// selected mailbox's updates either.
-	notifyUsed bool
+	// notifyOff is non-nil while NOTIFY governs delivery on this session, from
+	// the first NOTIFY command on. It stays so after NOTIFY NONE: that command
+	// asks for no events at all (RFC 5465 section 3.1), so IDLE must not fall
+	// back to pushing the selected mailbox's updates either. It is closed and
+	// cleared by a notification overflow, which returns the connection to
+	// pre-NOTIFY delivery (see checkNotifyOverflow); an IDLE waiting on it
+	// then takes over.
+	notifyOff chan struct{}
 
-	// notifyEvents receives the change events of the user while a watch is
-	// installed. It belongs to the session rather than to the NotifyPoll call,
-	// so events raised while the pump is stopped (the library fences it around
-	// every change of the selected mailbox) are queued instead of lost.
+	// notifyEvents receives the change events of the user while NOTIFY is in
+	// use — with a watch installed or after NOTIFY NONE, when it only wakes
+	// the pump to bound the queue of the selected mailbox. It belongs to the
+	// session rather than to the NotifyPoll call, so events raised while the
+	// pump is stopped (the library fences it around every change of the
+	// selected mailbox) are queued instead of lost.
 	notifyEvents chan memNotifyEvent
 }
 
@@ -294,9 +299,9 @@ func (sess *UserSession) Poll(ctx context.Context, w *imapserver.UpdateWriter, a
 
 func (sess *UserSession) Idle(ctx context.Context, w *imapserver.UpdateWriter, stop <-chan struct{}) error {
 	sess.notifyMutex.Lock()
-	notifyUsed := sess.notifyUsed
+	notifyOff := sess.notifyOff
 	sess.notifyMutex.Unlock()
-	if notifyUsed {
+	if notifyOff != nil {
 		// Once NOTIFY has been used, it is the single event source for this
 		// connection: the pump delivers according to the client's filter, and
 		// IDLE only keeps the connection open. Delivering via tracker.Idle
@@ -305,9 +310,16 @@ func (sess *UserSession) Idle(ctx context.Context, w *imapserver.UpdateWriter, s
 		// must not push selected-mailbox message events.
 		select {
 		case <-stop:
+			return nil
 		case <-ctx.Done():
+			return nil
+		case <-notifyOff:
+			// A notification overflow ended NOTIFY mid-IDLE: the pump is gone
+			// and delivery is back to the pre-NOTIFY rules, under which IDLE
+			// pushes the selected mailbox's updates. Fall through to
+			// tracker.Idle, which drains the ones accumulated behind the watch
+			// on entry and then carries on as usual.
 		}
-		return nil
 	}
 
 	if sess.mailbox == nil {

--- a/imapserver/imapmemserver/session.go
+++ b/imapserver/imapmemserver/session.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"sort"
 	"strings"
+	"sync"
 
 	"github.com/emersion/go-imap/v2"
 	"github.com/emersion/go-imap/v2/imapserver"
@@ -21,6 +22,13 @@ type (
 type UserSession struct {
 	*user    // immutable
 	*mailbox // may be nil
+
+	// notifyMutex guards notifyWatch, and synchronizes updates of the
+	// mailbox pointer (performed on the command goroutine) with reads from
+	// the NOTIFY pump goroutine. Command-goroutine reads need no locking:
+	// they run on the same goroutine as the writes.
+	notifyMutex sync.Mutex
+	notifyWatch *notifyWatch
 }
 
 var (
@@ -33,9 +41,26 @@ func NewUserSession(user *User) *UserSession {
 	return &UserSession{user: user}
 }
 
+// setMailbox updates the selected-mailbox pointer, keeping the NOTIFY pump's
+// view consistent (see notifyMutex).
+func (sess *UserSession) setMailbox(mbox *MailboxView) {
+	sess.notifyMutex.Lock()
+	sess.mailbox = mbox
+	if sess.notifyWatch != nil && mbox != nil {
+		// Rebind the MessageNew fetch-atts high-water mark to the newly
+		// selected mailbox: only messages arriving from now on are "new".
+		sess.notifyWatch.lastUIDNext = mbox.uidNext
+	}
+	sess.notifyMutex.Unlock()
+}
+
 func (sess *UserSession) Close() error {
-	if sess != nil && sess.mailbox != nil {
+	if sess == nil {
+		return nil
+	}
+	if sess.mailbox != nil {
 		sess.mailbox.Close()
+		sess.setMailbox(nil)
 	}
 	return nil
 }
@@ -48,13 +73,13 @@ func (sess *UserSession) Select(ctx context.Context, name string, options *imap.
 	if sess.mailbox != nil {
 		sess.mailbox.Close()
 	}
-	sess.mailbox = mbox.NewView()
+	sess.setMailbox(mbox.NewView())
 	return sess.mailbox.selectData(options)
 }
 
 func (sess *UserSession) Unselect(ctx context.Context) error {
 	sess.mailbox.Close()
-	sess.mailbox = nil
+	sess.setMailbox(nil)
 	return nil
 }
 

--- a/imapserver/imapmemserver/session.go
+++ b/imapserver/imapmemserver/session.go
@@ -23,12 +23,35 @@ type UserSession struct {
 	*user    // immutable
 	*mailbox // may be nil
 
+	// ownMessages records the UIDs this session created in the selected
+	// mailbox, so that no MessageNew fetch-att response is generated for them
+	// (RFC 5465 section 5.2: "A FETCH response SHOULD NOT be generated for a
+	// new message created by the client on this particular connection").
+	//
+	// Entries are recorded only while a watch that produces such responses is
+	// installed, consumed when the notification is emitted, and dropped
+	// wholesale when the selected mailbox changes — so the set stays bounded
+	// and can never outlive the mailbox it refers to. Guarded by notifyMutex.
+	ownMessages map[imap.UID]struct{}
+
 	// notifyMutex guards notifyWatch, and synchronizes updates of the
 	// mailbox pointer (performed on the command goroutine) with reads from
 	// the NOTIFY pump goroutine. Command-goroutine reads need no locking:
 	// they run on the same goroutine as the writes.
 	notifyMutex sync.Mutex
 	notifyWatch *notifyWatch
+
+	// notifyUsed records that the client issued NOTIFY on this session. It
+	// stays set after NOTIFY NONE: that command asks for no events at all
+	// (RFC 5465 section 3.1), so IDLE must not fall back to pushing the
+	// selected mailbox's updates either.
+	notifyUsed bool
+
+	// notifyEvents receives the change events of the user while a watch is
+	// installed. It belongs to the session rather than to the NotifyPoll call,
+	// so events raised while the pump is stopped (the library fences it around
+	// every change of the selected mailbox) are queued instead of lost.
+	notifyEvents chan memNotifyEvent
 }
 
 var (
@@ -44,12 +67,23 @@ func NewUserSession(user *User) *UserSession {
 // setMailbox updates the selected-mailbox pointer, keeping the NOTIFY pump's
 // view consistent (see notifyMutex).
 func (sess *UserSession) setMailbox(mbox *MailboxView) {
+	// Read uidNext under the mailbox lock that guards it, before taking
+	// notifyMutex: another session may be appending concurrently.
+	var uidNext imap.UID
+	if mbox != nil {
+		mbox.mutex.Lock()
+		uidNext = mbox.uidNext
+		mbox.mutex.Unlock()
+	}
+
 	sess.notifyMutex.Lock()
 	sess.mailbox = mbox
+	// The recorded UIDs belong to the mailbox being left.
+	sess.ownMessages = nil
 	if sess.notifyWatch != nil && mbox != nil {
 		// Rebind the MessageNew fetch-atts high-water mark to the newly
 		// selected mailbox: only messages arriving from now on are "new".
-		sess.notifyWatch.lastUIDNext = mbox.uidNext
+		sess.notifyWatch.lastUIDNext = uidNext
 	}
 	sess.notifyMutex.Unlock()
 }
@@ -58,6 +92,7 @@ func (sess *UserSession) Close() error {
 	if sess == nil {
 		return nil
 	}
+	sess.stopNotifyEvents()
 	if sess.mailbox != nil {
 		sess.mailbox.Close()
 		sess.setMailbox(nil)
@@ -87,6 +122,63 @@ func (sess *UserSession) Subscribe(ctx context.Context, name string) error {
 
 func (sess *UserSession) Unsubscribe(ctx context.Context, name string) error {
 	return sess.user.setSubscribed(name, false, sess)
+}
+
+// Append records the UID it creates before delegating, so the MessageNew
+// notification for the selected mailbox does not echo the message back to its
+// author (RFC 5465 section 5.2).
+func (sess *UserSession) Append(ctx context.Context, mailbox string, r imap.LiteralReader, options *imap.AppendOptions) (*imap.AppendData, error) {
+	data, err := sess.user.Append(ctx, mailbox, r, options)
+	if err != nil {
+		return nil, err
+	}
+	sess.recordOwnMessage(mailbox, data.UID)
+	return data, nil
+}
+
+// maxOwnMessages bounds the recorded set; past it, self-created messages are
+// simply reported like any other (the RFC 5465 section 5.2 rule is a SHOULD).
+const maxOwnMessages = 4096
+
+// recordOwnMessage remembers a message this session created in the mailbox it
+// has selected.
+func (sess *UserSession) recordOwnMessage(mailbox string, uid imap.UID) {
+	if uid == 0 {
+		return
+	}
+
+	sess.notifyMutex.Lock()
+	defer sess.notifyMutex.Unlock()
+
+	// Only messages that could produce a MessageNew fetch-att response are
+	// worth remembering: those in the selected mailbox, while such a watch is
+	// installed.
+	watch := sess.notifyWatch
+	if watch == nil || watch.selected == nil || watch.selected.MessageNewFetch == nil {
+		return
+	}
+	if sess.mailbox == nil || sess.mailbox.Mailbox != sess.user.mailboxIfExists(mailbox) {
+		return
+	}
+	if len(sess.ownMessages) >= maxOwnMessages {
+		return
+	}
+	if sess.ownMessages == nil {
+		sess.ownMessages = make(map[imap.UID]struct{})
+	}
+	sess.ownMessages[uid] = struct{}{}
+}
+
+// takeOwnMessage reports whether the message was created by this session,
+// forgetting it in the process.
+func (sess *UserSession) takeOwnMessage(uid imap.UID) bool {
+	sess.notifyMutex.Lock()
+	defer sess.notifyMutex.Unlock()
+	if _, ok := sess.ownMessages[uid]; !ok {
+		return false
+	}
+	delete(sess.ownMessages, uid)
+	return true
 }
 
 func (sess *UserSession) Select(ctx context.Context, name string, options *imap.SelectOptions) (*imap.SelectData, error) {
@@ -128,6 +220,12 @@ func (sess *UserSession) Copy(ctx context.Context, numSet imap.NumSet, destName 
 		sourceUIDs.AddNum(msg.uid)
 		destUIDs.AddNum(appendData.UID)
 	})
+
+	if uids, ok := destUIDs.Nums(); ok {
+		for _, uid := range uids {
+			sess.recordOwnMessage(destName, uid)
+		}
+	}
 
 	return &imap.CopyData{
 		UIDValidity: dest.uidValidity,
@@ -186,20 +284,25 @@ func (sess *UserSession) Poll(ctx context.Context, w *imapserver.UpdateWriter, a
 	if sess.mailbox == nil {
 		return nil
 	}
-	return sess.mailbox.Poll(ctx, w, allowExpunge)
+	if err := sess.mailbox.Poll(ctx, w, allowExpunge); err != nil {
+		return err
+	}
+	// This flush may have released the EXISTS a pending MessageNew fetch-att
+	// response was waiting for.
+	return sess.notifyPendingFetch(w)
 }
 
 func (sess *UserSession) Idle(ctx context.Context, w *imapserver.UpdateWriter, stop <-chan struct{}) error {
 	sess.notifyMutex.Lock()
-	watchActive := sess.notifyWatch != nil
+	notifyUsed := sess.notifyUsed
 	sess.notifyMutex.Unlock()
-	if watchActive {
-		// A NOTIFY watch is the single event source for this connection: the
-		// pump delivers according to the client's NOTIFY filter. IDLE then
-		// only keeps the connection open. Delivering via tracker.Idle here
-		// would bypass the filter — e.g. a watch without a SELECTED specifier
-		// (RFC 5465 §3.1: "same as specifying SELECTED NONE") must not push
-		// selected-mailbox message events.
+	if notifyUsed {
+		// Once NOTIFY has been used, it is the single event source for this
+		// connection: the pump delivers according to the client's filter, and
+		// IDLE only keeps the connection open. Delivering via tracker.Idle
+		// here would bypass the filter — a watch without a SELECTED specifier
+		// (RFC 5465 §3.1: "same as specifying SELECTED NONE"), or NOTIFY NONE,
+		// must not push selected-mailbox message events.
 		select {
 		case <-stop:
 		case <-ctx.Done():
@@ -391,12 +494,13 @@ func (sess *UserSession) SetMetadata(ctx context.Context, mailboxName string, en
 	}
 
 	// RFC 5465 sections 5.6 and 5.7: report the change to NOTIFY watchers with
-	// an unsolicited METADATA response. Deleted entries (nil values) are part
-	// of the change and must be reported too.
-	changed := make(map[string]*[]byte, len(entries))
-	for name, value := range entries {
-		changed[name] = value
+	// an unsolicited METADATA response naming the changed entries, deletions
+	// included. Sorted so the response order is deterministic.
+	changed := make([]string, 0, len(entries))
+	for name := range entries {
+		changed = append(changed, name)
 	}
+	sort.Strings(changed)
 	kind := evMailboxMetadataChange
 	if mailboxName == "" {
 		kind = evServerMetadataChange
@@ -559,6 +663,8 @@ func (sess *UserSession) SetACL(ctx context.Context, name string, identifier ima
 		rights = rights.Add(imap.RightSet("te"))
 	}
 
+	before := mbox.acl[imap.RightsIdentifier(sess.user.username)]
+
 	switch modification {
 	case imap.RightModificationReplace:
 		mbox.acl[identifier] = rights
@@ -568,12 +674,45 @@ func (sess *UserSession) SetACL(ctx context.Context, name string, identifier ima
 		mbox.acl[identifier] = currentRights.Remove(rights)
 	}
 
+	if kind, ok := aclNotifyEvent(before, mbox.acl[imap.RightsIdentifier(sess.user.username)]); ok {
+		sess.user.notify.broadcast(memNotifyEvent{kind: kind, mailbox: name, source: sess})
+	}
+
 	return nil
 }
 
 // DeleteACL removes the access control list entry for an identifier
 func (sess *UserSession) DeleteACL(ctx context.Context, name string, identifier imap.RightsIdentifier) error {
 	return sess.SetACL(ctx, name, identifier, imap.RightModificationReplace, nil)
+}
+
+// aclNotifyEvent maps a change of the current user's rights on a mailbox to the
+// NOTIFY event it must be reported as. RFC 5465 section 5.4: "granting or
+// revocation of the 'l' right to the current user on the affected mailbox MUST
+// be considered mailbox creation or deletion". Section 5.9 asks for a
+// \NoAccess LIST response when a right needed to monitor the mailbox is lost
+// while it stays listable.
+func aclNotifyEvent(before, after imap.RightSet) (memNotifyEventKind, bool) {
+	couldList, canList := hasRight(before, imap.RightLookup), hasRight(after, imap.RightLookup)
+	switch {
+	case !couldList && canList:
+		return evMailboxCreated, true
+	case couldList && !canList:
+		return evMailboxDeleted, true
+	case canList && hasRight(before, imap.RightRead) && !hasRight(after, imap.RightRead):
+		return evMailboxNoAccess, true
+	default:
+		return 0, false
+	}
+}
+
+func hasRight(rights imap.RightSet, right imap.Right) bool {
+	for _, r := range rights {
+		if r == right {
+			return true
+		}
+	}
+	return false
 }
 
 // ListRights lists the rights that can be granted to an identifier on a mailbox

--- a/imapserver/imapmemserver/session.go
+++ b/imapserver/imapmemserver/session.go
@@ -65,6 +65,30 @@ func (sess *UserSession) Close() error {
 	return nil
 }
 
+// Create, Delete, Rename, Subscribe and Unsubscribe shadow the methods
+// promoted from the embedded User to pass the originating session along: RFC
+// 5465 section 5 asks the server not to notify the client that caused an event.
+
+func (sess *UserSession) Create(ctx context.Context, name string, options *imap.CreateOptions) error {
+	return sess.user.create(name, sess)
+}
+
+func (sess *UserSession) Delete(ctx context.Context, name string) error {
+	return sess.user.delete(name, sess)
+}
+
+func (sess *UserSession) Rename(ctx context.Context, w *imapserver.RenameWriter, oldName, newName string, options *imap.RenameOptions) error {
+	return sess.user.rename(w, oldName, newName, sess)
+}
+
+func (sess *UserSession) Subscribe(ctx context.Context, name string) error {
+	return sess.user.setSubscribed(name, true, sess)
+}
+
+func (sess *UserSession) Unsubscribe(ctx context.Context, name string) error {
+	return sess.user.setSubscribed(name, false, sess)
+}
+
 func (sess *UserSession) Select(ctx context.Context, name string, options *imap.SelectOptions) (*imap.SelectData, error) {
 	mbox, err := sess.user.mailbox(name)
 	if err != nil {
@@ -359,6 +383,34 @@ func (sess *UserSession) GetMetadata(ctx context.Context, mailboxName string, en
 }
 
 func (sess *UserSession) SetMetadata(ctx context.Context, mailboxName string, entries map[string]*[]byte) error {
+	if err := sess.setMetadata(mailboxName, entries); err != nil {
+		return err
+	}
+	if len(entries) == 0 {
+		return nil
+	}
+
+	// RFC 5465 sections 5.6 and 5.7: report the change to NOTIFY watchers with
+	// an unsolicited METADATA response. Deleted entries (nil values) are part
+	// of the change and must be reported too.
+	changed := make(map[string]*[]byte, len(entries))
+	for name, value := range entries {
+		changed[name] = value
+	}
+	kind := evMailboxMetadataChange
+	if mailboxName == "" {
+		kind = evServerMetadataChange
+	}
+	sess.user.notify.broadcast(memNotifyEvent{
+		kind:    kind,
+		mailbox: mailboxName,
+		entries: changed,
+		source:  sess,
+	})
+	return nil
+}
+
+func (sess *UserSession) setMetadata(mailboxName string, entries map[string]*[]byte) error {
 	sess.user.mutex.Lock()
 	defer sess.user.mutex.Unlock()
 

--- a/imapserver/imapmemserver/user.go
+++ b/imapserver/imapmemserver/user.go
@@ -59,6 +59,13 @@ func (u *User) mailboxLocked(name string) (*Mailbox, error) {
 	return mbox, nil
 }
 
+// mailboxIfExists returns the mailbox with this name, or nil.
+func (u *User) mailboxIfExists(name string) *Mailbox {
+	u.mutex.Lock()
+	defer u.mutex.Unlock()
+	return u.mailboxes[name]
+}
+
 func (u *User) mailbox(name string) (*Mailbox, error) {
 	u.mutex.Lock()
 	defer u.mutex.Unlock()
@@ -166,7 +173,32 @@ func (u *User) create(name string, source *UserSession) error {
 
 	u.mailboxes[name] = mbox
 	u.notify.broadcast(memNotifyEvent{kind: evMailboxCreated, mailbox: name, source: source})
+	u.notifyParentLocked(name, source)
 	return nil
+}
+
+// notifyParentLocked reports the direct parent of a created or deleted mailbox,
+// which RFC 5465 section 5.4 also counts as affected ("the mailbox itself and
+// its direct parent (whether it is an existing mailbox or not)").
+func (u *User) notifyParentLocked(name string, source *UserSession) {
+	i := strings.LastIndexByte(name, byte(mailboxDelim))
+	if i <= 0 {
+		return
+	}
+	u.notify.broadcast(memNotifyEvent{kind: evMailboxParent, mailbox: name[:i], source: source})
+}
+
+// hasChildren reports whether any mailbox is subordinate to name.
+func (u *User) hasChildren(name string) bool {
+	u.mutex.Lock()
+	defer u.mutex.Unlock()
+	prefix := name + string(mailboxDelim)
+	for other := range u.mailboxes {
+		if strings.HasPrefix(other, prefix) {
+			return true
+		}
+	}
+	return false
 }
 
 func (u *User) Delete(ctx context.Context, name string) error {
@@ -184,6 +216,7 @@ func (u *User) delete(name string, source *UserSession) error {
 
 	delete(u.mailboxes, name)
 	u.notify.broadcast(memNotifyEvent{kind: evMailboxDeleted, mailbox: name, source: source})
+	u.notifyParentLocked(name, source)
 	return nil
 }
 

--- a/imapserver/imapmemserver/user.go
+++ b/imapserver/imapmemserver/user.go
@@ -16,6 +16,10 @@ const mailboxDelim rune = '/'
 type User struct {
 	username, password string
 
+	// notify fans mailbox and message change events out to the NOTIFY
+	// (RFC 5465) watchers of this user's sessions.
+	notify notifyRegistry
+
 	mutex           sync.Mutex
 	mailboxes       map[string]*Mailbox
 	prevUidValidity uint32
@@ -148,11 +152,13 @@ func (u *User) Create(ctx context.Context, name string, options *imap.CreateOpti
 	// same name.
 	u.prevUidValidity++
 	mbox := NewMailbox(name, u.prevUidValidity)
+	mbox.notify = u.notify.broadcast
 
 	// Initialize ACL with full rights for the owner
 	mbox.acl[imap.RightsIdentifier(u.username)] = imap.RightSetAll
 
 	u.mailboxes[name] = mbox
+	u.notify.broadcast(memNotifyEvent{kind: evMailboxCreated, mailbox: name})
 	return nil
 }
 
@@ -165,6 +171,7 @@ func (u *User) Delete(ctx context.Context, name string) error {
 	}
 
 	delete(u.mailboxes, name)
+	u.notify.broadcast(memNotifyEvent{kind: evMailboxDeleted, mailbox: name})
 	return nil
 }
 
@@ -193,6 +200,8 @@ func (u *User) Rename(ctx context.Context, w *imapserver.RenameWriter, oldName, 
 	delete(u.mailboxes, oldName)
 	u.mutex.Unlock()
 
+	u.notify.broadcast(memNotifyEvent{kind: evMailboxRenamed, mailbox: newName, oldName: oldName})
+
 	// RFC 9051 §6.3.6: announce the new name with the OLDNAME data item.
 	return w.WriteOldName(&imap.ListData{
 		Mailbox: newName,
@@ -207,6 +216,7 @@ func (u *User) Subscribe(ctx context.Context, name string) error {
 		return err
 	}
 	mbox.SetSubscribed(true)
+	u.notify.broadcast(memNotifyEvent{kind: evSubscriptionChange, mailbox: name})
 	return nil
 }
 
@@ -216,6 +226,7 @@ func (u *User) Unsubscribe(ctx context.Context, name string) error {
 		return err
 	}
 	mbox.SetSubscribed(false)
+	u.notify.broadcast(memNotifyEvent{kind: evSubscriptionChange, mailbox: name})
 	return nil
 }
 

--- a/imapserver/imapmemserver/user.go
+++ b/imapserver/imapmemserver/user.go
@@ -135,6 +135,13 @@ func (u *User) Append(ctx context.Context, mailbox string, r imap.LiteralReader,
 }
 
 func (u *User) Create(ctx context.Context, name string, options *imap.CreateOptions) error {
+	return u.create(name, nil)
+}
+
+// create is Create with the session that requested it, so that the resulting
+// notification can be withheld from it (RFC 5465 section 5). source may be nil
+// when the change does not originate from a session.
+func (u *User) create(name string, source *UserSession) error {
 	u.mutex.Lock()
 	defer u.mutex.Unlock()
 
@@ -158,11 +165,16 @@ func (u *User) Create(ctx context.Context, name string, options *imap.CreateOpti
 	mbox.acl[imap.RightsIdentifier(u.username)] = imap.RightSetAll
 
 	u.mailboxes[name] = mbox
-	u.notify.broadcast(memNotifyEvent{kind: evMailboxCreated, mailbox: name})
+	u.notify.broadcast(memNotifyEvent{kind: evMailboxCreated, mailbox: name, source: source})
 	return nil
 }
 
 func (u *User) Delete(ctx context.Context, name string) error {
+	return u.delete(name, nil)
+}
+
+// delete is Delete with the originating session (see create).
+func (u *User) delete(name string, source *UserSession) error {
 	u.mutex.Lock()
 	defer u.mutex.Unlock()
 
@@ -171,11 +183,16 @@ func (u *User) Delete(ctx context.Context, name string) error {
 	}
 
 	delete(u.mailboxes, name)
-	u.notify.broadcast(memNotifyEvent{kind: evMailboxDeleted, mailbox: name})
+	u.notify.broadcast(memNotifyEvent{kind: evMailboxDeleted, mailbox: name, source: source})
 	return nil
 }
 
 func (u *User) Rename(ctx context.Context, w *imapserver.RenameWriter, oldName, newName string, options *imap.RenameOptions) error {
+	return u.rename(w, oldName, newName, nil)
+}
+
+// rename is Rename with the originating session (see create).
+func (u *User) rename(w *imapserver.RenameWriter, oldName, newName string, source *UserSession) error {
 	u.mutex.Lock()
 
 	newName = strings.TrimRight(newName, string(mailboxDelim))
@@ -200,7 +217,7 @@ func (u *User) Rename(ctx context.Context, w *imapserver.RenameWriter, oldName, 
 	delete(u.mailboxes, oldName)
 	u.mutex.Unlock()
 
-	u.notify.broadcast(memNotifyEvent{kind: evMailboxRenamed, mailbox: newName, oldName: oldName})
+	u.notify.broadcast(memNotifyEvent{kind: evMailboxRenamed, mailbox: newName, oldName: oldName, source: source})
 
 	// RFC 9051 §6.3.6: announce the new name with the OLDNAME data item.
 	return w.WriteOldName(&imap.ListData{
@@ -211,22 +228,22 @@ func (u *User) Rename(ctx context.Context, w *imapserver.RenameWriter, oldName, 
 }
 
 func (u *User) Subscribe(ctx context.Context, name string) error {
-	mbox, err := u.mailbox(name)
-	if err != nil {
-		return err
-	}
-	mbox.SetSubscribed(true)
-	u.notify.broadcast(memNotifyEvent{kind: evSubscriptionChange, mailbox: name})
-	return nil
+	return u.setSubscribed(name, true, nil)
 }
 
 func (u *User) Unsubscribe(ctx context.Context, name string) error {
+	return u.setSubscribed(name, false, nil)
+}
+
+// setSubscribed is Subscribe/Unsubscribe with the originating session (see
+// create).
+func (u *User) setSubscribed(name string, subscribed bool, source *UserSession) error {
 	mbox, err := u.mailbox(name)
 	if err != nil {
 		return err
 	}
-	mbox.SetSubscribed(false)
-	u.notify.broadcast(memNotifyEvent{kind: evSubscriptionChange, mailbox: name})
+	mbox.SetSubscribed(subscribed)
+	u.notify.broadcast(memNotifyEvent{kind: evSubscriptionChange, mailbox: name, source: source})
 	return nil
 }
 

--- a/imapserver/list.go
+++ b/imapserver/list.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 
 	"github.com/emersion/go-imap/v2"
+	"github.com/emersion/go-imap/v2/internal"
 	"github.com/emersion/go-imap/v2/internal/imapwire"
 	"github.com/emersion/go-imap/v2/internal/utf7"
 )
@@ -89,6 +90,15 @@ func (c *Conn) writeListData(data *imap.ListData, opts *imap.ListOptions, allowO
 	enc := newResponseEncoder(c)
 	defer enc.end()
 
+	return writeListData(enc.Encoder, data, opts, allowOldName)
+}
+
+// writeListData encodes a LIST response into an already-open encoder. Callers
+// that hold the response encoder (such as SELECT, which writes LIST inside its
+// response block) must use this rather than Conn.writeListData: the encoder
+// mutex is not reentrant, so opening a second encoder would deadlock the
+// connection goroutine.
+func writeListData(enc *imapwire.Encoder, data *imap.ListData, opts *imap.ListOptions, allowOldName bool) error {
 	enc.Atom("*").SP().Atom("LIST").SP()
 	enc.List(len(data.Attrs), func(i int) {
 		enc.MailboxAttr(data.Attrs[i])
@@ -394,57 +404,5 @@ func (w *ListWriter) WriteList(data *imap.ListData) error {
 
 // MatchList checks whether a reference and a pattern matches a mailbox.
 func MatchList(name string, delim rune, reference, pattern string) bool {
-	var delimStr string
-	if delim != 0 {
-		delimStr = string(delim)
-	}
-
-	if delimStr != "" && strings.HasPrefix(pattern, delimStr) {
-		reference = ""
-		pattern = strings.TrimPrefix(pattern, delimStr)
-	}
-	if reference != "" {
-		if delimStr != "" && !strings.HasSuffix(reference, delimStr) {
-			reference += delimStr
-		}
-		if !strings.HasPrefix(name, reference) {
-			return false
-		}
-		name = strings.TrimPrefix(name, reference)
-	}
-
-	return matchList(name, delimStr, pattern)
-}
-
-func matchList(name, delim, pattern string) bool {
-	// TODO: optimize
-
-	i := strings.IndexAny(pattern, "*%")
-	if i == -1 {
-		// No more wildcards
-		return name == pattern
-	}
-
-	// Get parts before and after wildcard
-	chunk, wildcard, rest := pattern[0:i], pattern[i], pattern[i+1:]
-
-	// Check that name begins with chunk
-	if len(chunk) > 0 && !strings.HasPrefix(name, chunk) {
-		return false
-	}
-	name = strings.TrimPrefix(name, chunk)
-
-	// Expand wildcard
-	var j int
-	for j = 0; j < len(name); j++ {
-		if wildcard == '%' && string(name[j]) == delim {
-			break // Stop on delimiter if wildcard is %
-		}
-		// Try to match the rest from here
-		if matchList(name[j:], delim, rest) {
-			return true
-		}
-	}
-
-	return matchList(name[j:], delim, rest)
+	return internal.MatchList(name, delim, reference, pattern)
 }

--- a/imapserver/metadata.go
+++ b/imapserver/metadata.go
@@ -178,6 +178,27 @@ func (c *Conn) handleSetMetadata(dec *imapwire.Decoder) error {
 	return nil
 }
 
+// writeMetadataEntryList writes an untagged METADATA response in the entry-list
+// form of RFC 5464 §4.4.2: "* METADATA <mailbox> <entry> *(SP <entry>)".
+//
+// This is the form REQUIRED for unsolicited responses — RFC 5464 §4.4:
+// "Unsolicited METADATA responses MUST only contain entry names, not the
+// values." The entry-values form of writeMetadataResp answers GETMETADATA.
+func (c *Conn) writeMetadataEntryList(mailbox string, entries []string) error {
+	if len(entries) == 0 {
+		return nil
+	}
+
+	enc := newResponseEncoder(c)
+	defer enc.end()
+
+	enc.Atom("*").SP().Atom("METADATA").SP().Mailbox(mailbox)
+	for _, entry := range entries {
+		enc.SP().String(entry)
+	}
+	return enc.CRLF()
+}
+
 func (c *Conn) writeMetadataResp(mailbox string, entries map[string]*[]byte) error {
 	if len(entries) == 0 {
 		return nil

--- a/imapserver/notify.go
+++ b/imapserver/notify.go
@@ -11,6 +11,19 @@ import (
 	"github.com/emersion/go-imap/v2/internal/imapwire"
 )
 
+const (
+	// maxNotifyEventGroups bounds the number of event-groups in one NOTIFY SET
+	// command. RFC 5465 §3.1 advises clients to limit the mailboxes they watch;
+	// the server enforces a ceiling so a single command cannot hand the backend
+	// an arbitrarily large watch list (bounded otherwise only by the 50 KiB
+	// command-size cap).
+	maxNotifyEventGroups = 64
+
+	// maxNotifyMailboxesPerGroup bounds the mailbox names in one event-group's
+	// mailbox list. With maxNotifyEventGroups this bounds the total watch size.
+	maxNotifyMailboxesPerGroup = 256
+)
+
 // UnsupportedNotifyEventError is returned by SessionNotify.SetNotify when the
 // client requested an event the backend does not support. The server then
 // replies with a tagged NO carrying the BADEVENT response code, which lists
@@ -62,6 +75,13 @@ func (c *Conn) handleNotify(tag string, dec *imapwire.Decoder) error {
 		options = &imap.NotifyOptions{}
 		for dec.SP() {
 			if dec.Special('(') {
+				if len(options.Items) >= maxNotifyEventGroups {
+					return &imap.Error{
+						Type: imap.StatusResponseTypeNo,
+						Code: imap.ResponseCodeNotificationOverflow,
+						Text: "Too many NOTIFY event groups",
+					}
+				}
 				item, err := c.readNotifyEventGroup(dec)
 				if err != nil {
 					return err
@@ -184,6 +204,9 @@ func (c *Conn) readNotifyEventGroup(dec *imapwire.Decoder) (*imap.NotifyItem, er
 		}
 		// one-or-more-mailbox = mailbox / "(" mailbox *(SP mailbox) ")"
 		isList, err := dec.List(func() error {
+			if len(item.Mailboxes) >= maxNotifyMailboxesPerGroup {
+				return newClientBugError("NOTIFY: too many mailboxes in one event group")
+			}
 			var name string
 			if !dec.ExpectMailbox(&name) {
 				return dec.Err()

--- a/imapserver/notify.go
+++ b/imapserver/notify.go
@@ -187,9 +187,12 @@ func (c *Conn) handleNotify(tag string, dec *imapwire.Decoder) error {
 	// the MessageNew fetch-atts.
 	c.setNotifySelectedEvents(options, pendingFetchWriterOptions)
 
-	if options != nil {
-		c.startNotifyPump(session)
-	}
+	// The pump runs for NOTIFY NONE as well. Nothing is delivered then, but the
+	// updates of the selected mailbox keep queuing behind the suppression, and
+	// the per-command sync point that would let the backend see the queue is
+	// skipped (see poll) — so NotifyPoll is the backend's only opportunity to
+	// bound it and declare a notification overflow (SessionTracker.QueuedUpdates).
+	c.startNotifyPump(session)
 
 	// A successful NOTIFY SET implies an implicit NOOP (RFC 5465 section
 	// 3.1): flush pending updates for the selected mailbox before the tagged

--- a/imapserver/notify.go
+++ b/imapserver/notify.go
@@ -158,6 +158,11 @@ func (c *Conn) handleNotify(tag string, dec *imapwire.Decoder) error {
 		return err
 	}
 
+	// Record which message events the client wants for the selected mailbox, so
+	// that the per-command sync points stop reporting the ones it did not ask
+	// for (RFC 5465 section 3.1).
+	c.setNotifySelectedEvents(options)
+
 	if options != nil {
 		c.startNotifyPump(session)
 	}

--- a/imapserver/notify.go
+++ b/imapserver/notify.go
@@ -62,12 +62,19 @@ func canonicalNotifyEvent(name string) imap.NotifyEvent {
 }
 
 func (c *Conn) handleNotify(tag string, dec *imapwire.Decoder) error {
+	// pendingFetchWriterOptions carries the MessageNew fetch-att writer options
+	// from the parser to the point where the new watch is installed.
+	var pendingFetchWriterOptions *fetchWriterOptions
+
 	var verb string
 	if !dec.ExpectSP() || !dec.ExpectAtom(&verb) {
 		return dec.Err()
 	}
 
-	var options *imap.NotifyOptions
+	var (
+		options  *imap.NotifyOptions
+		overflow bool // a size cap was exceeded; refuse once the command is fully parsed
+	)
 	switch strings.ToUpper(verb) {
 	case "NONE":
 		// options stays nil: disable all notifications
@@ -75,16 +82,20 @@ func (c *Conn) handleNotify(tag string, dec *imapwire.Decoder) error {
 		options = &imap.NotifyOptions{}
 		for dec.SP() {
 			if dec.Special('(') {
-				if len(options.Items) >= maxNotifyEventGroups {
-					return &imap.Error{
-						Type: imap.StatusResponseTypeNo,
-						Code: imap.ResponseCodeNotificationOverflow,
-						Text: "Too many NOTIFY event groups",
-					}
-				}
-				item, err := c.readNotifyEventGroup(dec)
+				// Parse every group, even past the cap: the command is
+				// syntactically valid (RFC 5465 §8 bounds neither event-groups
+				// nor many-mailboxes), so it must be consumed in full — a
+				// literal left unread would be parsed as the next command.
+				// Groups beyond the cap are discarded rather than stored, so
+				// the watch stays bounded, and the refusal is sent once the
+				// whole command has been read.
+				item, groupOverflow, err := c.readNotifyEventGroup(dec, &pendingFetchWriterOptions)
 				if err != nil {
 					return err
+				}
+				if groupOverflow || len(options.Items) >= maxNotifyEventGroups {
+					overflow = true
+					continue
 				}
 				options.Items = append(options.Items, *item)
 				continue
@@ -100,6 +111,18 @@ func (c *Conn) handleNotify(tag string, dec *imapwire.Decoder) error {
 				continue
 			}
 			return newClientBugError("Syntax error in NOTIFY command")
+		}
+		if overflow {
+			// RFC 5465 §3.1: the server MAY refuse a watch that would be
+			// prohibitively expensive with NO [NOTIFICATIONOVERFLOW].
+			if !dec.ExpectCRLF() {
+				return dec.Err()
+			}
+			return &imap.Error{
+				Type: imap.StatusResponseTypeNo,
+				Code: imap.ResponseCodeNotificationOverflow,
+				Text: "NOTIFY watch too large",
+			}
 		}
 		if len(options.Items) == 0 {
 			return newClientBugError("NOTIFY SET requires at least one event group")
@@ -160,8 +183,9 @@ func (c *Conn) handleNotify(tag string, dec *imapwire.Decoder) error {
 
 	// Record which message events the client wants for the selected mailbox, so
 	// that the per-command sync points stop reporting the ones it did not ask
-	// for (RFC 5465 section 3.1).
-	c.setNotifySelectedEvents(options)
+	// for (RFC 5465 section 3.1), together with the response-writer options of
+	// the MessageNew fetch-atts.
+	c.setNotifySelectedEvents(options, pendingFetchWriterOptions)
 
 	if options != nil {
 		c.startNotifyPump(session)
@@ -184,139 +208,150 @@ func (c *Conn) handleNotify(tag string, dec *imapwire.Decoder) error {
 // already been consumed:
 //
 //	event-group = "(" filter-mailboxes SP events ")"
-func (c *Conn) readNotifyEventGroup(dec *imapwire.Decoder) (*imap.NotifyItem, error) {
+//
+// The returned overflow flag reports that the group named more mailboxes than
+// maxNotifyMailboxesPerGroup. The group is still parsed to its end so the
+// command stream stays in sync; the caller turns the flag into a refusal.
+func (c *Conn) readNotifyEventGroup(dec *imapwire.Decoder, pendingFetchWriterOptions **fetchWriterOptions) (item *imap.NotifyItem, overflow bool, err error) {
 	var filter string
 	if !dec.ExpectAtom(&filter) {
-		return nil, dec.Err()
+		return nil, false, dec.Err()
 	}
 
-	var item imap.NotifyItem
+	var group imap.NotifyItem
 	switch strings.ToUpper(filter) {
 	case "SELECTED":
-		item.MailboxSpec = imap.NotifyMailboxSpecSelected
+		group.MailboxSpec = imap.NotifyMailboxSpecSelected
 	case "SELECTED-DELAYED":
-		item.MailboxSpec = imap.NotifyMailboxSpecSelectedDelayed
+		group.MailboxSpec = imap.NotifyMailboxSpecSelectedDelayed
 	case "PERSONAL":
-		item.MailboxSpec = imap.NotifyMailboxSpecPersonal
+		group.MailboxSpec = imap.NotifyMailboxSpecPersonal
 	case "INBOXES":
-		item.MailboxSpec = imap.NotifyMailboxSpecInboxes
+		group.MailboxSpec = imap.NotifyMailboxSpecInboxes
 	case "SUBSCRIBED":
-		item.MailboxSpec = imap.NotifyMailboxSpecSubscribed
+		group.MailboxSpec = imap.NotifyMailboxSpecSubscribed
 	case "SUBTREE", "MAILBOXES":
-		item.Subtree = strings.EqualFold(filter, "SUBTREE")
+		group.Subtree = strings.EqualFold(filter, "SUBTREE")
 		if !dec.ExpectSP() {
-			return nil, dec.Err()
+			return nil, false, dec.Err()
 		}
 		// one-or-more-mailbox = mailbox / "(" mailbox *(SP mailbox) ")"
 		isList, err := dec.List(func() error {
-			if len(item.Mailboxes) >= maxNotifyMailboxesPerGroup {
-				return newClientBugError("NOTIFY: too many mailboxes in one event group")
-			}
 			var name string
 			if !dec.ExpectMailbox(&name) {
 				return dec.Err()
 			}
-			item.Mailboxes = append(item.Mailboxes, name)
+			if len(group.Mailboxes) >= maxNotifyMailboxesPerGroup {
+				// Keep consuming the list, but stop growing the watch.
+				overflow = true
+				return nil
+			}
+			group.Mailboxes = append(group.Mailboxes, name)
 			return nil
 		})
 		if err != nil {
-			return nil, err
+			return nil, false, err
 		}
 		if !isList {
 			var name string
 			if !dec.ExpectMailbox(&name) {
-				return nil, dec.Err()
+				return nil, false, dec.Err()
 			}
-			item.Mailboxes = []string{name}
+			group.Mailboxes = []string{name}
 		}
-		if len(item.Mailboxes) == 0 {
-			return nil, newClientBugError("NOTIFY: at least one mailbox is required")
+		if len(group.Mailboxes) == 0 {
+			return nil, false, newClientBugError("NOTIFY: at least one mailbox is required")
 		}
 	default:
-		return nil, newClientBugError("NOTIFY: unknown mailbox specifier")
+		return nil, false, newClientBugError("NOTIFY: unknown mailbox specifier")
 	}
 
 	// events = ("(" event *(SP event) ")") / "NONE"
 	if !dec.ExpectSP() {
-		return nil, dec.Err()
+		return nil, false, dec.Err()
 	}
 	if dec.Special('(') {
 		for {
 			var name string
 			if !dec.ExpectAtom(&name) {
-				return nil, dec.Err()
+				return nil, false, dec.Err()
 			}
 			event := canonicalNotifyEvent(name)
-			item.Events = append(item.Events, event)
+			group.Events = append(group.Events, event)
 			if !dec.SP() {
 				break
 			}
 			if dec.Special('(') {
 				// message-event = "MessageNew" [SP "(" fetch-att *(SP fetch-att) ")"]
 				if event != imap.NotifyEventMessageNew {
-					return nil, newClientBugError("NOTIFY: fetch attributes are only allowed after MessageNew")
+					return nil, false, newClientBugError("NOTIFY: fetch attributes are only allowed after MessageNew")
 				}
-				if item.MessageNewFetch != nil {
-					return nil, newClientBugError("NOTIFY: duplicate MessageNew fetch attributes")
+				if group.MessageNewFetch != nil {
+					return nil, false, newClientBugError("NOTIFY: duplicate MessageNew fetch attributes")
 				}
-				fetchOptions, err := readNotifyFetchAtts(c, dec)
+				fetchOptions, fetchWriterOpts, err := readNotifyFetchAtts(c, dec)
 				if err != nil {
-					return nil, err
+					return nil, false, err
 				}
-				item.MessageNewFetch = fetchOptions
+				group.MessageNewFetch = fetchOptions
+				// Remember how the client spelled the fetch-atts so the
+				// notification's FETCH response uses the same item names
+				// (RFC 5465 §5.2: "the information requested by the
+				// client"). Applied once the watch is installed.
+				*pendingFetchWriterOptions = fetchWriterOpts
 				if !dec.SP() {
 					break
 				}
 			}
 		}
 		if !dec.ExpectSpecial(')') {
-			return nil, dec.Err()
+			return nil, false, dec.Err()
 		}
 	} else {
 		var atom string
 		if !dec.ExpectAtom(&atom) {
-			return nil, dec.Err()
+			return nil, false, dec.Err()
 		}
 		if !strings.EqualFold(atom, "NONE") {
-			return nil, newClientBugError("NOTIFY: expected event list or NONE")
+			return nil, false, newClientBugError("NOTIFY: expected event list or NONE")
 		}
 	}
 
 	if !dec.ExpectSpecial(')') {
-		return nil, dec.Err()
+		return nil, false, dec.Err()
 	}
-	return &item, nil
+	return &group, overflow, nil
 }
 
 // readNotifyFetchAtts parses the fetch-att list of a MessageNew event; the
 // opening parenthesis has already been consumed.
-func readNotifyFetchAtts(c *Conn, dec *imapwire.Decoder) (*imap.FetchOptions, error) {
+func readNotifyFetchAtts(c *Conn, dec *imapwire.Decoder) (*imap.FetchOptions, *fetchWriterOptions, error) {
 	options := &imap.FetchOptions{}
-	writerOptions := fetchWriterOptions{obsolete: make(map[*imap.FetchItemBodySection]string)}
+	writerOptions := &fetchWriterOptions{obsolete: make(map[*imap.FetchItemBodySection]string)}
 	for {
 		attName, err := readFetchAttName(dec)
 		if err != nil {
-			return nil, err
+			return nil, nil, err
 		}
 		switch attName {
 		case "ALL", "FAST", "FULL":
-			return nil, newClientBugError("NOTIFY: FETCH macros are not allowed in MessageNew fetch attributes")
+			return nil, nil, newClientBugError("NOTIFY: FETCH macros are not allowed in MessageNew fetch attributes")
 		}
-		if err := handleFetchAtt(c, dec, attName, options, &writerOptions); err != nil {
+		if err := handleFetchAtt(c, dec, attName, options, writerOptions); err != nil {
 			var imapErr *imap.Error
 			if errors.As(err, &imapErr) {
-				return nil, err
+				return nil, nil, err
 			}
-			return nil, newClientBugError(fmt.Sprintf("NOTIFY: %v", err))
+			return nil, nil, newClientBugError(fmt.Sprintf("NOTIFY: %v", err))
 		}
 		if !dec.SP() {
 			break
 		}
 	}
 	if !dec.ExpectSpecial(')') {
-		return nil, dec.Err()
+		return nil, nil, dec.Err()
 	}
-	return options, nil
+	return options, writerOptions, nil
 }
 
 // validateNotifyOptions enforces the structural rules of RFC 5465 sections 5
@@ -398,6 +433,33 @@ func (c *Conn) writeBadEvent(tag string, supported []imap.NotifyEvent) error {
 	}
 	enc.Text("Unsupported NOTIFY event")
 	return enc.CRLF()
+}
+
+// fenceNotifyPump stops the NOTIFY pump and reports whether one was running,
+// so the caller can restart it with restartNotifyPump once it is done. It is
+// used around changes of the selected mailbox, which the running watch refers
+// to (RFC 5465 section 6.1).
+func (c *Conn) fenceNotifyPump() bool {
+	running := c.notifyPumpRunning()
+	c.stopNotifyPump()
+	return running
+}
+
+// restartNotifyPump restarts a pump stopped by fenceNotifyPump. It is a no-op
+// when no pump was running, when the session no longer supports NOTIFY, or
+// when the connection is no longer authenticated.
+func (c *Conn) restartNotifyPump(running bool) {
+	if !running {
+		return
+	}
+	session, ok := c.session.(SessionNotify)
+	if !ok {
+		return
+	}
+	switch c.state {
+	case imap.ConnStateAuthenticated, imap.ConnStateSelected:
+		c.startNotifyPump(session)
+	}
 }
 
 func (c *Conn) notifyPumpRunning() bool {

--- a/imapserver/notify.go
+++ b/imapserver/notify.go
@@ -1,0 +1,428 @@
+package imapserver
+
+import (
+	"errors"
+	"fmt"
+	"runtime/debug"
+	"strings"
+	"time"
+
+	"github.com/emersion/go-imap/v2"
+	"github.com/emersion/go-imap/v2/internal/imapwire"
+)
+
+// UnsupportedNotifyEventError is returned by SessionNotify.SetNotify when the
+// client requested an event the backend does not support. The server then
+// replies with a tagged NO carrying the BADEVENT response code, which lists
+// all events the backend supports (RFC 5465 section 4).
+type UnsupportedNotifyEventError struct {
+	// Supported is the full list of events supported by the backend,
+	// advertised to the client in the BADEVENT response code.
+	Supported []imap.NotifyEvent
+}
+
+// Error implements the error interface.
+func (err *UnsupportedNotifyEventError) Error() string {
+	return "imapserver: unsupported NOTIFY event"
+}
+
+var notifyEventNames = map[string]imap.NotifyEvent{
+	"MESSAGENEW":            imap.NotifyEventMessageNew,
+	"MESSAGEEXPUNGE":        imap.NotifyEventMessageExpunge,
+	"FLAGCHANGE":            imap.NotifyEventFlagChange,
+	"ANNOTATIONCHANGE":      imap.NotifyEventAnnotationChange,
+	"MAILBOXNAME":           imap.NotifyEventMailboxName,
+	"SUBSCRIPTIONCHANGE":    imap.NotifyEventSubscriptionChange,
+	"MAILBOXMETADATACHANGE": imap.NotifyEventMailboxMetadataChange,
+	"SERVERMETADATACHANGE":  imap.NotifyEventServerMetadataChange,
+}
+
+// canonicalNotifyEvent maps an event atom to its canonical NotifyEvent value.
+// Event names are case-insensitive on the wire (RFC 5465 section 8). Unknown
+// atoms (user-defined events, event-ext) are preserved verbatim so the
+// backend can reject them with UnsupportedNotifyEventError.
+func canonicalNotifyEvent(name string) imap.NotifyEvent {
+	if ev, ok := notifyEventNames[strings.ToUpper(name)]; ok {
+		return ev
+	}
+	return imap.NotifyEvent(name)
+}
+
+func (c *Conn) handleNotify(tag string, dec *imapwire.Decoder) error {
+	var verb string
+	if !dec.ExpectSP() || !dec.ExpectAtom(&verb) {
+		return dec.Err()
+	}
+
+	var options *imap.NotifyOptions
+	switch strings.ToUpper(verb) {
+	case "NONE":
+		// options stays nil: disable all notifications
+	case "SET":
+		options = &imap.NotifyOptions{}
+		for dec.SP() {
+			if dec.Special('(') {
+				item, err := c.readNotifyEventGroup(dec)
+				if err != nil {
+					return err
+				}
+				options.Items = append(options.Items, *item)
+				continue
+			}
+			// status-indicator = SP "STATUS": a bare atom before the first
+			// event group (RFC 5465 section 8).
+			var atom string
+			if !dec.ExpectAtom(&atom) {
+				return dec.Err()
+			}
+			if strings.EqualFold(atom, "STATUS") && !options.Status && len(options.Items) == 0 {
+				options.Status = true
+				continue
+			}
+			return newClientBugError("Syntax error in NOTIFY command")
+		}
+		if len(options.Items) == 0 {
+			return newClientBugError("NOTIFY SET requires at least one event group")
+		}
+	default:
+		return newClientBugError("NOTIFY argument must be SET or NONE")
+	}
+
+	if !dec.ExpectCRLF() {
+		return dec.Err()
+	}
+
+	if err := c.checkState(imap.ConnStateAuthenticated); err != nil {
+		return err
+	}
+
+	// Check if NOTIFY is supported by the session (mirrors handleIdle, so a
+	// per-session capability filter also gates NOTIFY).
+	var supportsNotify bool
+	if capSession, ok := c.session.(SessionCapabilities); ok {
+		supportsNotify = capSession.GetCapabilities().Has(imap.CapNotify)
+	} else {
+		supportsNotify = c.availableCapsSet().Has(imap.CapNotify)
+	}
+	session, ok := c.session.(SessionNotify)
+	if !supportsNotify || !ok {
+		return &imap.Error{
+			Type: imap.StatusResponseTypeNo,
+			Text: "NOTIFY not supported",
+		}
+	}
+
+	if options != nil {
+		if err := validateNotifyOptions(options); err != nil {
+			return err
+		}
+	}
+
+	// Stop the current pump before touching the backend watch: NotifyPoll
+	// must not run while SetNotify swaps the state underneath it.
+	hadPump := c.notifyPumpRunning()
+	c.stopNotifyPump()
+
+	w := &UpdateWriter{conn: c, allowExpunge: true, notify: true}
+	if err := session.SetNotify(c.ctx, options, w); err != nil {
+		// RFC 5465 section 3.1: the effect of a successful NOTIFY command
+		// lasts until the next NOTIFY command. A failed one leaves the
+		// previous watch in effect, so restart its pump.
+		if hadPump {
+			c.startNotifyPump(session)
+		}
+		var badEventErr *UnsupportedNotifyEventError
+		if errors.As(err, &badEventErr) {
+			return c.writeBadEvent(tag, badEventErr.Supported)
+		}
+		return err
+	}
+
+	if options != nil {
+		c.startNotifyPump(session)
+	}
+
+	// A successful NOTIFY SET implies an implicit NOOP (RFC 5465 section
+	// 3.1): flush pending updates for the selected mailbox before the tagged
+	// OK. NOTIFY NONE gets the same treatment (it is not one of the commands
+	// that forbid expunges).
+	if err := c.poll("NOTIFY"); err != nil {
+		return err
+	}
+	return c.writeStatusResp(tag, &imap.StatusResponse{
+		Type: imap.StatusResponseTypeOK,
+		Text: "NOTIFY completed",
+	})
+}
+
+// readNotifyEventGroup parses one event-group; the opening parenthesis has
+// already been consumed:
+//
+//	event-group = "(" filter-mailboxes SP events ")"
+func (c *Conn) readNotifyEventGroup(dec *imapwire.Decoder) (*imap.NotifyItem, error) {
+	var filter string
+	if !dec.ExpectAtom(&filter) {
+		return nil, dec.Err()
+	}
+
+	var item imap.NotifyItem
+	switch strings.ToUpper(filter) {
+	case "SELECTED":
+		item.MailboxSpec = imap.NotifyMailboxSpecSelected
+	case "SELECTED-DELAYED":
+		item.MailboxSpec = imap.NotifyMailboxSpecSelectedDelayed
+	case "PERSONAL":
+		item.MailboxSpec = imap.NotifyMailboxSpecPersonal
+	case "INBOXES":
+		item.MailboxSpec = imap.NotifyMailboxSpecInboxes
+	case "SUBSCRIBED":
+		item.MailboxSpec = imap.NotifyMailboxSpecSubscribed
+	case "SUBTREE", "MAILBOXES":
+		item.Subtree = strings.EqualFold(filter, "SUBTREE")
+		if !dec.ExpectSP() {
+			return nil, dec.Err()
+		}
+		// one-or-more-mailbox = mailbox / "(" mailbox *(SP mailbox) ")"
+		isList, err := dec.List(func() error {
+			var name string
+			if !dec.ExpectMailbox(&name) {
+				return dec.Err()
+			}
+			item.Mailboxes = append(item.Mailboxes, name)
+			return nil
+		})
+		if err != nil {
+			return nil, err
+		}
+		if !isList {
+			var name string
+			if !dec.ExpectMailbox(&name) {
+				return nil, dec.Err()
+			}
+			item.Mailboxes = []string{name}
+		}
+		if len(item.Mailboxes) == 0 {
+			return nil, newClientBugError("NOTIFY: at least one mailbox is required")
+		}
+	default:
+		return nil, newClientBugError("NOTIFY: unknown mailbox specifier")
+	}
+
+	// events = ("(" event *(SP event) ")") / "NONE"
+	if !dec.ExpectSP() {
+		return nil, dec.Err()
+	}
+	if dec.Special('(') {
+		for {
+			var name string
+			if !dec.ExpectAtom(&name) {
+				return nil, dec.Err()
+			}
+			event := canonicalNotifyEvent(name)
+			item.Events = append(item.Events, event)
+			if !dec.SP() {
+				break
+			}
+			if dec.Special('(') {
+				// message-event = "MessageNew" [SP "(" fetch-att *(SP fetch-att) ")"]
+				if event != imap.NotifyEventMessageNew {
+					return nil, newClientBugError("NOTIFY: fetch attributes are only allowed after MessageNew")
+				}
+				if item.MessageNewFetch != nil {
+					return nil, newClientBugError("NOTIFY: duplicate MessageNew fetch attributes")
+				}
+				fetchOptions, err := readNotifyFetchAtts(c, dec)
+				if err != nil {
+					return nil, err
+				}
+				item.MessageNewFetch = fetchOptions
+				if !dec.SP() {
+					break
+				}
+			}
+		}
+		if !dec.ExpectSpecial(')') {
+			return nil, dec.Err()
+		}
+	} else {
+		var atom string
+		if !dec.ExpectAtom(&atom) {
+			return nil, dec.Err()
+		}
+		if !strings.EqualFold(atom, "NONE") {
+			return nil, newClientBugError("NOTIFY: expected event list or NONE")
+		}
+	}
+
+	if !dec.ExpectSpecial(')') {
+		return nil, dec.Err()
+	}
+	return &item, nil
+}
+
+// readNotifyFetchAtts parses the fetch-att list of a MessageNew event; the
+// opening parenthesis has already been consumed.
+func readNotifyFetchAtts(c *Conn, dec *imapwire.Decoder) (*imap.FetchOptions, error) {
+	options := &imap.FetchOptions{}
+	writerOptions := fetchWriterOptions{obsolete: make(map[*imap.FetchItemBodySection]string)}
+	for {
+		attName, err := readFetchAttName(dec)
+		if err != nil {
+			return nil, err
+		}
+		switch attName {
+		case "ALL", "FAST", "FULL":
+			return nil, newClientBugError("NOTIFY: FETCH macros are not allowed in MessageNew fetch attributes")
+		}
+		if err := handleFetchAtt(c, dec, attName, options, &writerOptions); err != nil {
+			var imapErr *imap.Error
+			if errors.As(err, &imapErr) {
+				return nil, err
+			}
+			return nil, newClientBugError(fmt.Sprintf("NOTIFY: %v", err))
+		}
+		if !dec.SP() {
+			break
+		}
+	}
+	if !dec.ExpectSpecial(')') {
+		return nil, dec.Err()
+	}
+	return options, nil
+}
+
+// validateNotifyOptions enforces the structural rules of RFC 5465 sections 5
+// and 6.1. Violations yield a tagged BAD response, as required by the RFC.
+// Whether each requested event is supported is for the backend to decide (see
+// UnsupportedNotifyEventError).
+func validateNotifyOptions(options *imap.NotifyOptions) error {
+	numSelected := 0
+	for i := range options.Items {
+		item := &options.Items[i]
+		selected := item.MailboxSpec == imap.NotifyMailboxSpecSelected ||
+			item.MailboxSpec == imap.NotifyMailboxSpecSelectedDelayed
+		if selected {
+			numSelected++
+			if numSelected > 1 {
+				// RFC 5465 section 6.1: only one of the mailbox specifiers
+				// affecting the currently selected mailbox can be specified.
+				return newClientBugError("NOTIFY: only one SELECTED or SELECTED-DELAYED event group is allowed")
+			}
+		}
+
+		var hasNew, hasExpunge, hasFlag, hasAnnotation, hasMailboxEvent bool
+		for _, ev := range item.Events {
+			switch ev {
+			case imap.NotifyEventMessageNew:
+				hasNew = true
+			case imap.NotifyEventMessageExpunge:
+				hasExpunge = true
+			case imap.NotifyEventFlagChange:
+				hasFlag = true
+			case imap.NotifyEventAnnotationChange:
+				hasAnnotation = true
+			case imap.NotifyEventMailboxName, imap.NotifyEventSubscriptionChange,
+				imap.NotifyEventMailboxMetadataChange, imap.NotifyEventServerMetadataChange:
+				hasMailboxEvent = true
+			}
+		}
+
+		// RFC 5465 section 5: if one of MessageNew or MessageExpunge is
+		// specified, both events MUST be specified.
+		if hasNew != hasExpunge {
+			return newClientBugError("NOTIFY: MessageNew and MessageExpunge must be specified together")
+		}
+		// RFC 5465 section 5: FlagChange and/or AnnotationChange require
+		// MessageNew and MessageExpunge.
+		if (hasFlag || hasAnnotation) && !hasNew {
+			return newClientBugError("NOTIFY: FlagChange and AnnotationChange require MessageNew and MessageExpunge")
+		}
+		// RFC 5465 section 6.1: the SELECTED/SELECTED-DELAYED specifiers only
+		// apply to message events.
+		if selected && hasMailboxEvent {
+			return newClientBugError("NOTIFY: only message events are allowed with SELECTED or SELECTED-DELAYED")
+		}
+		// RFC 5465 section 5.2: fetch attributes describe the FETCH response
+		// sent for new messages in the selected mailbox.
+		if !selected && item.MessageNewFetch != nil {
+			return newClientBugError("NOTIFY: MessageNew fetch attributes are only allowed with SELECTED or SELECTED-DELAYED")
+		}
+	}
+	return nil
+}
+
+// writeBadEvent writes a tagged NO response with the BADEVENT response code,
+// listing the events supported by the backend (RFC 5465 section 4).
+func (c *Conn) writeBadEvent(tag string, supported []imap.NotifyEvent) error {
+	enc := newResponseEncoder(c)
+	defer enc.end()
+	if tag == "" {
+		tag = "*"
+	}
+	enc.Atom(tag).SP().Atom(string(imap.StatusResponseTypeNo)).SP()
+	// unsupported-events-code = "BADEVENT" SP "(" event-name *(SP event-name) ")"
+	if len(supported) > 0 {
+		enc.Special('[').Atom(string(imap.ResponseCodeBadEvent)).SP()
+		enc.List(len(supported), func(i int) {
+			enc.Atom(string(supported[i]))
+		})
+		enc.Special(']').SP()
+	}
+	enc.Text("Unsupported NOTIFY event")
+	return enc.CRLF()
+}
+
+func (c *Conn) notifyPumpRunning() bool {
+	c.notifyMutex.Lock()
+	defer c.notifyMutex.Unlock()
+	return c.notifyStop != nil
+}
+
+// startNotifyPump spawns the goroutine that runs SessionNotify.NotifyPoll,
+// delivering unsolicited notifications concurrently with command processing.
+func (c *Conn) startNotifyPump(session SessionNotify) {
+	stop := make(chan struct{})
+	done := make(chan error, 1)
+
+	c.notifyMutex.Lock()
+	c.notifyStop = stop
+	c.notifyDone = done
+	c.notifyMutex.Unlock()
+
+	w := &UpdateWriter{conn: c, allowExpunge: true, notify: true}
+	go func() {
+		defer func() {
+			if v := recover(); v != nil {
+				c.server.logger().Printf("panic in NOTIFY: %v\n%s", v, debug.Stack())
+				done <- fmt.Errorf("imapserver: panic in NOTIFY")
+			}
+		}()
+		done <- session.NotifyPoll(c.ctx, w, stop)
+	}()
+}
+
+// stopNotifyPump stops the notify pump, if one is running, and waits for the
+// backend to return (with a timeout guard against goroutine leaks, mirroring
+// handleIdle).
+func (c *Conn) stopNotifyPump() {
+	c.notifyMutex.Lock()
+	stop, done := c.notifyStop, c.notifyDone
+	c.notifyStop, c.notifyDone = nil, nil
+	c.notifyMutex.Unlock()
+
+	if stop == nil {
+		return
+	}
+	close(stop)
+
+	timer := time.NewTimer(30 * time.Second)
+	defer timer.Stop()
+	select {
+	case err := <-done:
+		if err != nil && !isConnectionClosedError(err) {
+			c.server.logger().Printf("NOTIFY backend error: %v", err)
+		}
+	case <-timer.C:
+		c.server.logger().Printf("NOTIFY backend did not return within 30s after stop; goroutine leaked")
+	}
+}

--- a/imapserver/notify.go
+++ b/imapserver/notify.go
@@ -391,14 +391,51 @@ func (c *Conn) startNotifyPump(session SessionNotify) {
 
 	w := &UpdateWriter{conn: c, allowExpunge: true, notify: true}
 	go func() {
+		var err error
 		defer func() {
 			if v := recover(); v != nil {
 				c.server.logger().Printf("panic in NOTIFY: %v\n%s", v, debug.Stack())
-				done <- fmt.Errorf("imapserver: panic in NOTIFY")
+				err = fmt.Errorf("imapserver: panic in NOTIFY")
+			}
+			done <- err
+
+			// A pump that ends because stop was closed is an intentional stop
+			// (NOTIFY NONE, watch replacement, teardown); stopNotifyPump owns the
+			// aftermath. A pump that ends any OTHER way — NotifyPoll returning a
+			// non-nil error, or a panic — is a broken watch on a live connection:
+			// the client still believes it is being notified, but nothing is
+			// delivered. That silent failure is exactly what NOTIFY exists to
+			// avoid, so tear the connection down. A clean nil return with stop
+			// still open (e.g. NOTIFICATIONOVERFLOW: the backend disabled the
+			// watch and returned) is deliberate and leaves the connection up.
+			select {
+			case <-stop:
+			default:
+				if err != nil {
+					c.abortFromBackground("NOTIFY pump", err)
+				}
 			}
 		}()
-		done <- session.NotifyPoll(c.ctx, w, stop)
+		err = session.NotifyPoll(c.ctx, w, stop)
 	}()
+}
+
+// abortFromBackground tears the connection down from a goroutine other than the
+// command loop (the NOTIFY pump). It cancels the context and closes the socket
+// directly rather than writing a BYE: the socket close unblocks the command
+// read loop without acquiring encMutex, so it works even if a wedged response
+// writer is still holding that mutex. serve()'s deferred teardown then runs
+// normally. Safe to call concurrently with serve exit — cancel and Close are
+// both idempotent.
+func (c *Conn) abortFromBackground(who string, err error) {
+	if err != nil && !isConnectionClosedError(err) {
+		c.server.logger().Printf("%s aborting connection (remote %v): %v", who, c.conn.RemoteAddr(), err)
+	}
+	c.cancel()
+	c.mutex.Lock()
+	conn := c.conn
+	c.mutex.Unlock()
+	conn.Close()
 }
 
 // stopNotifyPump stops the notify pump, if one is running, and waits for the
@@ -423,6 +460,13 @@ func (c *Conn) stopNotifyPump() {
 			c.server.logger().Printf("NOTIFY backend error: %v", err)
 		}
 	case <-timer.C:
-		c.server.logger().Printf("NOTIFY backend did not return within 30s after stop; goroutine leaked")
+		// The pump ignored stop (or is wedged in a slow write). We must not
+		// return and let the caller start a second pump against session state
+		// that assumes a single one. Force the socket closed: that unblocks a
+		// wedged write so the goroutine can exit, and cancels the context so a
+		// replacement pump (if the caller starts one) sees a dead connection
+		// and returns immediately.
+		c.server.logger().Printf("NOTIFY backend did not return within 30s after stop; forcing connection close")
+		c.abortFromBackground("NOTIFY stop timeout", nil)
 	}
 }

--- a/imapserver/notify_test.go
+++ b/imapserver/notify_test.go
@@ -1232,3 +1232,173 @@ func TestNotifyNoneSilencesIdle(t *testing.T) {
 	}
 	watcher.conn.Write([]byte("DONE\r\n"))
 }
+
+// TestNotifyNoneBoundsSuppressedQueue verifies that the updates a NOTIFY NONE
+// client's selected mailbox accumulates — undeliverable while the suppression
+// lasts, and never looked at by a per-command Poll — are still bounded: the
+// backend declares a notification overflow (RFC 5465 section 5.8) from the
+// pump the library keeps running for NOTIFY NONE, and delivery resumes.
+func TestNotifyNoneBoundsSuppressedQueue(t *testing.T) {
+	addr, _, closer := newNotifyTestServer(t)
+	defer closer()
+
+	watcher := dialNotifyTest(t, addr)
+	defer watcher.close()
+	watcher.login(t)
+	watcher.cmd("CREATE INBOX")
+	watcher.cmd("SELECT INBOX")
+	if resp := watcher.cmd("NOTIFY NONE"); !strings.Contains(resp, "OK") {
+		t.Fatalf("NOTIFY NONE failed: %q", resp)
+	}
+
+	other := dialNotifyTest(t, addr)
+	defer other.close()
+	other.login(t)
+
+	var overflowed bool
+	for i := 0; i < 1200 && !overflowed; i++ {
+		other.appendMessage(t, "INBOX")
+		for {
+			line, err := watcher.readLine(5 * time.Millisecond)
+			if err != nil {
+				break
+			}
+			if strings.Contains(line, "NOTIFICATIONOVERFLOW") {
+				overflowed = true
+				break
+			}
+			t.Errorf("NOTIFY NONE client received %q before the overflow", line)
+		}
+	}
+	if !overflowed {
+		t.Fatal("expected an OK [NOTIFICATIONOVERFLOW] once the frozen view grew past the limit")
+	}
+
+	resp := watcher.cmd("NOOP")
+	if !strings.Contains(resp, "EXISTS") {
+		t.Errorf("expected the accumulated updates to be delivered after the overflow, got %q", resp)
+	}
+}
+
+// TestNotifyOverflowDuringIdle verifies that a notification overflow declared
+// while the client is idling puts IDLE back in charge of delivery: with the
+// watch gone the connection is under the pre-NOTIFY rules, and IDLE pushes the
+// updates that had accumulated, then the new ones, without waiting for DONE.
+func TestNotifyOverflowDuringIdle(t *testing.T) {
+	for _, tc := range []struct {
+		name   string
+		notify string
+	}{
+		{name: "NotifyNone", notify: "NOTIFY NONE"},
+		{name: "SelectedOmitted", notify: "NOTIFY SET (PERSONAL (MailboxName))"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			addr, _, closer := newNotifyTestServer(t)
+			defer closer()
+
+			watcher := dialNotifyTest(t, addr)
+			defer watcher.close()
+			watcher.login(t)
+			watcher.cmd("CREATE INBOX")
+			watcher.cmd("SELECT INBOX")
+			if resp := watcher.cmd("%s", tc.notify); !strings.Contains(resp, "OK") {
+				t.Fatalf("%s failed: %q", tc.notify, resp)
+			}
+
+			if _, err := watcher.conn.Write([]byte("T90 IDLE\r\n")); err != nil {
+				t.Fatalf("write IDLE: %v", err)
+			}
+			if line, err := watcher.readLine(5 * time.Second); err != nil || !strings.HasPrefix(line, "+") {
+				t.Fatalf("expected a continuation request for IDLE, got %q (%v)", line, err)
+			}
+
+			other := dialNotifyTest(t, addr)
+			defer other.close()
+			other.login(t)
+			for i := 0; i < 1100; i++ {
+				other.appendMessage(t, "INBOX")
+			}
+
+			// The overflow comes first, then IDLE flushes the frozen updates.
+			var sawOverflow, sawExists bool
+			for !sawExists {
+				line, err := watcher.readLine(5 * time.Second)
+				if err != nil {
+					t.Fatalf("waiting for IDLE to resume delivery (overflow seen: %v): %v", sawOverflow, err)
+				}
+				switch {
+				case strings.Contains(line, "NOTIFICATIONOVERFLOW"):
+					sawOverflow = true
+				case strings.Contains(line, "EXISTS"):
+					if !sawOverflow {
+						t.Fatalf("EXISTS pushed before the overflow: %q", line)
+					}
+					sawExists = true
+				}
+			}
+
+			// And it keeps delivering: a new message is pushed at once.
+			other.appendMessage(t, "INBOX")
+			for {
+				line, err := watcher.readLine(5 * time.Second)
+				if err != nil {
+					t.Fatalf("expected IDLE to push the next EXISTS: %v", err)
+				}
+				if strings.Contains(line, "1101 EXISTS") {
+					break
+				}
+			}
+
+			watcher.conn.Write([]byte("DONE\r\n"))
+			for {
+				line, err := watcher.readLine(5 * time.Second)
+				if err != nil {
+					t.Fatalf("waiting for IDLE completion: %v", err)
+				}
+				if strings.HasPrefix(line, "T90 ") {
+					if !strings.Contains(line, "OK") {
+						t.Fatalf("IDLE failed: %q", line)
+					}
+					break
+				}
+			}
+		})
+	}
+}
+
+// TestNotifyRejectedFirstWatchLeavesDefaultDelivery verifies that a NOTIFY SET
+// refused with BADEVENT changes nothing (RFC 5465 section 3.1: the effect of a
+// NOTIFY command lasts until the next successful one): if it was the first
+// NOTIFY, the connection is still under the pre-NOTIFY rules and IDLE keeps
+// pushing the selected mailbox's updates.
+func TestNotifyRejectedFirstWatchLeavesDefaultDelivery(t *testing.T) {
+	addr, _, closer := newNotifyTestServer(t)
+	defer closer()
+
+	watcher := dialNotifyTest(t, addr)
+	defer watcher.close()
+	watcher.login(t)
+	watcher.cmd("CREATE INBOX")
+	watcher.cmd("SELECT INBOX")
+	if resp := watcher.cmd("NOTIFY SET (SELECTED (MessageNew MessageExpunge AnnotationChange))"); !strings.Contains(resp, "NO [BADEVENT") {
+		t.Fatalf("expected the watch to be refused with BADEVENT, got %q", resp)
+	}
+
+	if _, err := watcher.conn.Write([]byte("T90 IDLE\r\n")); err != nil {
+		t.Fatalf("write IDLE: %v", err)
+	}
+	if line, err := watcher.readLine(5 * time.Second); err != nil || !strings.HasPrefix(line, "+") {
+		t.Fatalf("expected a continuation request for IDLE, got %q (%v)", line, err)
+	}
+
+	other := dialNotifyTest(t, addr)
+	defer other.close()
+	other.login(t)
+	other.appendMessage(t, "INBOX")
+
+	line, err := watcher.readLine(5 * time.Second)
+	if err != nil || !strings.Contains(line, "1 EXISTS") {
+		t.Fatalf("expected IDLE to push EXISTS after a refused NOTIFY, got %q (%v)", line, err)
+	}
+	watcher.conn.Write([]byte("DONE\r\n"))
+}

--- a/imapserver/notify_test.go
+++ b/imapserver/notify_test.go
@@ -37,6 +37,7 @@ func newNotifyTestServer(t *testing.T) (addr string, user *imapmemserver.User, c
 		Caps: imap.CapSet{
 			imap.CapIMAP4rev1: {},
 			imap.CapNotify:    {},
+			imap.CapMetadata:  {},
 		},
 		InsecureAuth: true,
 	})
@@ -218,7 +219,7 @@ func TestNotifyCommandSyntax(t *testing.T) {
 		{
 			name: "UnsupportedEvent",
 			cmd:  "NOTIFY SET (SELECTED (MessageNew MessageExpunge AnnotationChange))",
-			want: "NO [BADEVENT (MessageNew MessageExpunge FlagChange MailboxName SubscriptionChange)]",
+			want: "NO [BADEVENT (MessageNew MessageExpunge FlagChange MailboxName SubscriptionChange MailboxMetadataChange ServerMetadataChange)]",
 		},
 		{
 			name: "UnknownEvent",
@@ -382,5 +383,229 @@ func TestNotifyMailboxEventsDelivery(t *testing.T) {
 	}
 	if line, err := watcher.readLine(300 * time.Millisecond); err == nil {
 		t.Errorf("expected no notification after NOTIFY NONE, got %q", line)
+	}
+}
+
+// appendMessage appends a one-line message to the given mailbox. The literal
+// is sent without waiting for the continuation request, which the server
+// accepts.
+func (c *notifyTestConn) appendMessage(t *testing.T, mailbox string) {
+	t.Helper()
+	if resp := c.cmd("APPEND %s {5}\r\nhello", mailbox); !strings.Contains(resp, "OK") {
+		t.Fatalf("APPEND %s failed: %q", mailbox, resp)
+	}
+}
+
+// TestNotifySelectedNoneSuppressesSelectedUpdates verifies RFC 5465 section
+// 3.1: "If the SELECTED/SELECTED-DELAYED mailbox selector is not specified in
+// the NOTIFY SET command, this means that the client doesn't want to receive
+// any <message-event>s for the currently selected mailbox. This is the same as
+// specifying SELECTED NONE."
+//
+// The suppression must also hold at command sync points: a NOOP must not
+// report EXISTS for the selected mailbox.
+func TestNotifySelectedNoneSuppressesSelectedUpdates(t *testing.T) {
+	for _, tc := range []struct {
+		name   string
+		notify string
+	}{
+		{name: "SelectedOmitted", notify: "NOTIFY SET (PERSONAL (MessageNew MessageExpunge))"},
+		{name: "SelectedNone", notify: "NOTIFY SET (SELECTED NONE) (PERSONAL (MailboxName))"},
+		{name: "NotifyNone", notify: "NOTIFY NONE"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			addr, _, closer := newNotifyTestServer(t)
+			defer closer()
+
+			watcher := dialNotifyTest(t, addr)
+			defer watcher.close()
+			watcher.login(t)
+			if resp := watcher.cmd("CREATE INBOX"); !strings.Contains(resp, "OK") {
+				t.Fatalf("CREATE failed: %q", resp)
+			}
+			if resp := watcher.cmd("SELECT INBOX"); !strings.Contains(resp, "OK") {
+				t.Fatalf("SELECT failed: %q", resp)
+			}
+			if resp := watcher.cmd("%s", tc.notify); !strings.Contains(resp, "OK") {
+				t.Fatalf("%s failed: %q", tc.notify, resp)
+			}
+
+			other := dialNotifyTest(t, addr)
+			defer other.close()
+			other.login(t)
+			other.appendMessage(t, "INBOX")
+
+			// No asynchronous message event for the selected mailbox.
+			if line, err := watcher.readLine(300 * time.Millisecond); err == nil {
+				t.Errorf("unexpected unsolicited response for the selected mailbox: %q", line)
+			}
+
+			// And none at the next sync point either.
+			resp := watcher.cmd("NOOP")
+			if strings.Contains(resp, "EXISTS") {
+				t.Errorf("expected no EXISTS for the selected mailbox at a sync point, got %q", resp)
+			}
+		})
+	}
+}
+
+// TestNotifySelectedEventFiltering verifies that only the message events
+// requested with the SELECTED specifier are reported for the selected mailbox
+// (RFC 5465 sections 3.1 and 5): a watch without FlagChange must not produce
+// unsolicited FETCH responses, while MessageNew must still be delivered.
+func TestNotifySelectedEventFiltering(t *testing.T) {
+	addr, _, closer := newNotifyTestServer(t)
+	defer closer()
+
+	watcher := dialNotifyTest(t, addr)
+	defer watcher.close()
+	watcher.login(t)
+	if resp := watcher.cmd("CREATE INBOX"); !strings.Contains(resp, "OK") {
+		t.Fatalf("CREATE failed: %q", resp)
+	}
+	watcher.appendMessage(t, "INBOX")
+	if resp := watcher.cmd("SELECT INBOX"); !strings.Contains(resp, "OK") {
+		t.Fatalf("SELECT failed: %q", resp)
+	}
+	if resp := watcher.cmd("NOTIFY SET (SELECTED (MessageNew MessageExpunge))"); !strings.Contains(resp, "OK") {
+		t.Fatalf("NOTIFY SET failed: %q", resp)
+	}
+
+	other := dialNotifyTest(t, addr)
+	defer other.close()
+	other.login(t)
+	if resp := other.cmd("SELECT INBOX"); !strings.Contains(resp, "OK") {
+		t.Fatalf("SELECT failed: %q", resp)
+	}
+	if resp := other.cmd(`STORE 1 +FLAGS (\Seen)`); !strings.Contains(resp, "OK") {
+		t.Fatalf("STORE failed: %q", resp)
+	}
+
+	// FlagChange was not requested: neither asynchronously...
+	if line, err := watcher.readLine(300 * time.Millisecond); err == nil {
+		t.Errorf("unexpected unsolicited response for an unrequested FlagChange: %q", line)
+	}
+	// ...nor at a sync point.
+	if resp := watcher.cmd("NOOP"); strings.Contains(resp, "FETCH") {
+		t.Errorf("expected no FETCH for an unrequested FlagChange, got %q", resp)
+	}
+
+	// MessageNew was requested, so it must still be delivered.
+	other.appendMessage(t, "INBOX")
+	line, err := watcher.readLine(5 * time.Second)
+	if err != nil {
+		t.Fatalf("waiting for EXISTS after append: %v", err)
+	}
+	if !strings.Contains(line, "EXISTS") {
+		t.Errorf("expected an unsolicited EXISTS, got %q", line)
+	}
+	if strings.Contains(line, "FETCH") {
+		t.Errorf("expected no FETCH for an unrequested FlagChange, got %q", line)
+	}
+}
+
+// TestNotifySelfCausedEvents verifies RFC 5465 section 5: "The server SHOULD
+// omit notifying the client if the event is caused by this client."
+func TestNotifySelfCausedEvents(t *testing.T) {
+	addr, _, closer := newNotifyTestServer(t)
+	defer closer()
+
+	watcher := dialNotifyTest(t, addr)
+	defer watcher.close()
+	watcher.login(t)
+	if resp := watcher.cmd("NOTIFY SET (PERSONAL (MailboxName SubscriptionChange))"); !strings.Contains(resp, "OK") {
+		t.Fatalf("NOTIFY SET failed: %q", resp)
+	}
+
+	// Caused by this client: no notification.
+	if resp := watcher.cmd("CREATE SelfMade"); !strings.Contains(resp, "OK") {
+		t.Fatalf("CREATE failed: %q", resp)
+	}
+	if line, err := watcher.readLine(300 * time.Millisecond); err == nil {
+		t.Errorf("unexpected notification for a self-caused event: %q", line)
+	}
+	if resp := watcher.cmd("SUBSCRIBE SelfMade"); !strings.Contains(resp, "OK") {
+		t.Fatalf("SUBSCRIBE failed: %q", resp)
+	}
+	if line, err := watcher.readLine(300 * time.Millisecond); err == nil {
+		t.Errorf("unexpected notification for a self-caused event: %q", line)
+	}
+
+	// Caused by another client: notification as usual.
+	other := dialNotifyTest(t, addr)
+	defer other.close()
+	other.login(t)
+	if resp := other.cmd("CREATE OtherMade"); !strings.Contains(resp, "OK") {
+		t.Fatalf("CREATE failed: %q", resp)
+	}
+	line, err := watcher.readLine(5 * time.Second)
+	if err != nil {
+		t.Fatalf("waiting for LIST after foreign CREATE: %v", err)
+	}
+	if !strings.HasPrefix(line, "* LIST") || !strings.Contains(line, "OtherMade") {
+		t.Errorf("expected an unsolicited LIST for OtherMade, got %q", line)
+	}
+}
+
+// TestNotifyMetadataChangeDelivery verifies RFC 5465 sections 5.6 and 5.7:
+// MailboxMetadataChange and ServerMetadataChange are reported with unsolicited
+// METADATA responses. Support is REQUIRED when the server implements METADATA
+// (RFC 5464).
+func TestNotifyMetadataChangeDelivery(t *testing.T) {
+	addr, _, closer := newNotifyTestServer(t)
+	defer closer()
+
+	watcher := dialNotifyTest(t, addr)
+	defer watcher.close()
+	watcher.login(t)
+	if resp := watcher.cmd("CREATE INBOX"); !strings.Contains(resp, "OK") {
+		t.Fatalf("CREATE failed: %q", resp)
+	}
+	if resp := watcher.cmd("NOTIFY SET (PERSONAL (MailboxMetadataChange ServerMetadataChange))"); !strings.Contains(resp, "OK") {
+		t.Fatalf("NOTIFY SET failed: %q", resp)
+	}
+
+	other := dialNotifyTest(t, addr)
+	defer other.close()
+	other.login(t)
+
+	if resp := other.cmd(`SETMETADATA INBOX (/private/comment "hi")`); !strings.Contains(resp, "OK") {
+		t.Fatalf("SETMETADATA failed: %q", resp)
+	}
+	line, err := watcher.readLine(5 * time.Second)
+	if err != nil {
+		t.Fatalf("waiting for METADATA after SETMETADATA: %v", err)
+	}
+	for _, want := range []string{"* METADATA", "INBOX", "/private/comment", "hi"} {
+		if !strings.Contains(line, want) {
+			t.Errorf("METADATA response %q is missing %q", line, want)
+		}
+	}
+
+	if resp := other.cmd(`SETMETADATA "" (/private/vendor/test "v")`); !strings.Contains(resp, "OK") {
+		t.Fatalf("SETMETADATA failed: %q", resp)
+	}
+	line, err = watcher.readLine(5 * time.Second)
+	if err != nil {
+		t.Fatalf("waiting for METADATA after server SETMETADATA: %v", err)
+	}
+	for _, want := range []string{"* METADATA", "/private/vendor/test"} {
+		if !strings.Contains(line, want) {
+			t.Errorf("METADATA response %q is missing %q", line, want)
+		}
+	}
+
+	// A deleted entry must still be reported (RFC 5465 section 5.6).
+	if resp := other.cmd(`SETMETADATA INBOX (/private/comment NIL)`); !strings.Contains(resp, "OK") {
+		t.Fatalf("SETMETADATA failed: %q", resp)
+	}
+	line, err = watcher.readLine(5 * time.Second)
+	if err != nil {
+		t.Fatalf("waiting for METADATA after deletion: %v", err)
+	}
+	for _, want := range []string{"* METADATA", "/private/comment", "NIL"} {
+		if !strings.Contains(line, want) {
+			t.Errorf("METADATA response %q is missing %q", line, want)
+		}
 	}
 }

--- a/imapserver/notify_test.go
+++ b/imapserver/notify_test.go
@@ -38,6 +38,7 @@ func newNotifyTestServer(t *testing.T) (addr string, user *imapmemserver.User, c
 			imap.CapIMAP4rev1: {},
 			imap.CapNotify:    {},
 			imap.CapMetadata:  {},
+			imap.CapIdle:      {},
 		},
 		InsecureAuth: true,
 	})
@@ -550,7 +551,9 @@ func TestNotifySelfCausedEvents(t *testing.T) {
 // TestNotifyMetadataChangeDelivery verifies RFC 5465 sections 5.6 and 5.7:
 // MailboxMetadataChange and ServerMetadataChange are reported with unsolicited
 // METADATA responses. Support is REQUIRED when the server implements METADATA
-// (RFC 5464).
+// (RFC 5464). The responses carry entry names only — RFC 5464 section 4.4:
+// "Unsolicited METADATA responses MUST only contain entry names, not the
+// values."
 func TestNotifyMetadataChangeDelivery(t *testing.T) {
 	addr, _, closer := newNotifyTestServer(t)
 	defer closer()
@@ -576,10 +579,13 @@ func TestNotifyMetadataChangeDelivery(t *testing.T) {
 	if err != nil {
 		t.Fatalf("waiting for METADATA after SETMETADATA: %v", err)
 	}
-	for _, want := range []string{"* METADATA", "INBOX", "/private/comment", "hi"} {
+	for _, want := range []string{"* METADATA", "INBOX", "/private/comment"} {
 		if !strings.Contains(line, want) {
 			t.Errorf("METADATA response %q is missing %q", line, want)
 		}
+	}
+	if strings.Contains(line, "hi") {
+		t.Errorf("unsolicited METADATA must not carry values: %q", line)
 	}
 
 	if resp := other.cmd(`SETMETADATA "" (/private/vendor/test "v")`); !strings.Contains(resp, "OK") {
@@ -603,9 +609,626 @@ func TestNotifyMetadataChangeDelivery(t *testing.T) {
 	if err != nil {
 		t.Fatalf("waiting for METADATA after deletion: %v", err)
 	}
-	for _, want := range []string{"* METADATA", "/private/comment", "NIL"} {
+	for _, want := range []string{"* METADATA", "/private/comment"} {
 		if !strings.Contains(line, want) {
 			t.Errorf("METADATA response %q is missing %q", line, want)
 		}
 	}
+	if strings.Contains(line, "NIL") {
+		t.Errorf("unsolicited METADATA must not carry values, not even NIL: %q", line)
+	}
+}
+
+// mustListen opens a loopback listener for a test server.
+func mustListen(t *testing.T) net.Listener {
+	t.Helper()
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("Listen: %v", err)
+	}
+	return ln
+}
+
+// TestNotifyExpungeCommandResponses verifies that the NOTIFY filter only
+// suppresses notifications, not command response data: RFC 9051 section 6.4.3
+// and RFC 4315 section 2.1 require an untagged EXPUNGE for each removed message
+// before the tagged OK of EXPUNGE / UID EXPUNGE, whatever the watch says.
+func TestNotifyExpungeCommandResponses(t *testing.T) {
+	for _, tc := range []struct {
+		name    string
+		notify  string
+		expunge string
+	}{
+		{name: "NotifyNone", notify: "NOTIFY NONE", expunge: "EXPUNGE"},
+		{name: "NoSelectedGroup", notify: "NOTIFY SET (PERSONAL (MessageNew MessageExpunge))", expunge: "EXPUNGE"},
+		{name: "UidExpunge", notify: "NOTIFY NONE", expunge: "UID EXPUNGE 1"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			addr, _, closer := newNotifyTestServer(t)
+			defer closer()
+
+			c := dialNotifyTest(t, addr)
+			defer c.close()
+			c.login(t)
+			c.cmd("CREATE INBOX")
+			c.appendMessage(t, "INBOX")
+			c.appendMessage(t, "INBOX")
+			if resp := c.cmd("SELECT INBOX"); !strings.Contains(resp, "OK") {
+				t.Fatalf("SELECT failed: %q", resp)
+			}
+			if resp := c.cmd("%s", tc.notify); !strings.Contains(resp, "OK") {
+				t.Fatalf("%s failed: %q", tc.notify, resp)
+			}
+			if resp := c.cmd(`STORE 1 +FLAGS (\Deleted)`); !strings.Contains(resp, "OK") {
+				t.Fatalf("STORE failed: %q", resp)
+			}
+
+			resp := c.cmd("%s", tc.expunge)
+			if !strings.Contains(resp, "* 1 EXPUNGE") {
+				t.Fatalf("%s must report the removed message: %q", tc.expunge, resp)
+			}
+
+			// The client's sequence-number view must now match the server's.
+			if resp := c.cmd("FETCH 1 (UID)"); !strings.Contains(resp, "UID 2") {
+				t.Errorf("sequence numbers diverged after expunge: %q", resp)
+			}
+		})
+	}
+}
+
+// TestNotifyOversizedWatchKeepsStreamInSync verifies that refusing an
+// oversized NOTIFY SET does not desynchronise the command stream. The command
+// is valid per RFC 5465 section 8 (neither event-groups nor many-mailboxes is
+// length-bounded), so the server must consume all of it — literals included —
+// before answering, and the next command must be parsed as a command.
+func TestNotifyOversizedWatchKeepsStreamInSync(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		cmd  string
+	}{
+		{
+			name: "TooManyGroups",
+			cmd: strings.Repeat("(MAILBOXES box (MessageNew MessageExpunge)) ", 64) +
+				"(MAILBOXES {5+}\r\nSNEAK (MessageNew MessageExpunge))",
+		},
+		{
+			name: "TooManyMailboxesPerGroup",
+			cmd: "(MAILBOXES (" + strings.Repeat("box ", 256) +
+				"{5+}\r\nSNEAK) (MessageNew MessageExpunge))",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			addr, _, closer := newNotifyTestServer(t)
+			defer closer()
+
+			c := dialNotifyTest(t, addr)
+			defer c.close()
+			c.login(t)
+
+			resp := c.cmd("NOTIFY SET %s", tc.cmd)
+			lines := strings.Split(strings.TrimRight(resp, "\r\n"), "\r\n")
+			if len(lines) != 1 {
+				t.Errorf("expected a single tagged response, got %q", resp)
+			}
+			if !strings.Contains(lines[len(lines)-1], "NO [NOTIFICATIONOVERFLOW]") {
+				t.Errorf("expected NO [NOTIFICATIONOVERFLOW], got %q", resp)
+			}
+
+			// The connection must still be usable, and the literal's octets
+			// must not have been parsed as a command.
+			if resp := c.cmd("NOOP"); !strings.Contains(resp, "OK NOOP completed") {
+				t.Errorf("connection desynchronised after the refusal: %q", resp)
+			}
+		})
+	}
+}
+
+// TestNotifyMessageNewFetchAttNames verifies that the FETCH response of a
+// MessageNew notification carries the data items the client asked for, spelled
+// the way it asked for them (RFC 5465 section 5.2).
+func TestNotifyMessageNewFetchAttNames(t *testing.T) {
+	for _, tc := range []struct {
+		name      string
+		fetchAtts string
+		want      string
+	}{
+		{name: "BodyStructure", fetchAtts: "UID BODYSTRUCTURE", want: "BODYSTRUCTURE"},
+		{name: "Body", fetchAtts: "UID BODY", want: "BODY "},
+		{name: "ObsoleteRFC822Text", fetchAtts: "UID RFC822.TEXT", want: "RFC822.TEXT"},
+		{name: "ObsoleteRFC822Header", fetchAtts: "UID RFC822.HEADER", want: "RFC822.HEADER"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			addr, _, closer := newNotifyTestServer(t)
+			defer closer()
+
+			watcher := dialNotifyTest(t, addr)
+			defer watcher.close()
+			watcher.login(t)
+			watcher.cmd("CREATE INBOX")
+			watcher.cmd("SELECT INBOX")
+			if resp := watcher.cmd("NOTIFY SET (SELECTED (MessageNew (%s) MessageExpunge))", tc.fetchAtts); !strings.Contains(resp, "OK") {
+				t.Fatalf("NOTIFY SET failed: %q", resp)
+			}
+
+			other := dialNotifyTest(t, addr)
+			defer other.close()
+			other.login(t)
+			other.appendMessage(t, "INBOX")
+
+			var fetch string
+			for i := 0; i < 4 && fetch == ""; i++ {
+				line, err := watcher.readLine(5 * time.Second)
+				if err != nil {
+					t.Fatalf("waiting for the FETCH notification: %v (last %q)", err, line)
+				}
+				if strings.Contains(line, "FETCH") {
+					fetch = line
+				}
+			}
+			if fetch == "" {
+				t.Fatal("no FETCH notification arrived")
+			}
+			if !strings.Contains(fetch, tc.want) {
+				t.Errorf("FETCH notification %q is missing %q", fetch, tc.want)
+			}
+		})
+	}
+}
+
+// TestNotifyPumpFencedAcrossSelect verifies that no update queued for the
+// previously selected mailbox is delivered once another mailbox is selected
+// (RFC 5465 section 6.1: the SELECTED specifier follows the currently selected
+// mailbox). The pump must be fenced across the switch.
+func TestNotifyPumpFencedAcrossSelect(t *testing.T) {
+	addr, _, closer := newNotifyTestServer(t)
+	defer closer()
+
+	watcher := dialNotifyTest(t, addr)
+	defer watcher.close()
+	watcher.login(t)
+	watcher.cmd("CREATE INBOX")
+	watcher.cmd("CREATE Other")
+	watcher.cmd("SELECT INBOX")
+	if resp := watcher.cmd("NOTIFY SET (SELECTED (MessageNew MessageExpunge))"); !strings.Contains(resp, "OK") {
+		t.Fatalf("NOTIFY SET failed: %q", resp)
+	}
+
+	other := dialNotifyTest(t, addr)
+	defer other.close()
+	other.login(t)
+
+	for i := 0; i < 50; i++ {
+		// Queue an event for INBOX and switch mailboxes concurrently with its
+		// delivery.
+		other.appendMessage(t, "INBOX")
+		resp := watcher.cmd("SELECT Other")
+		if !strings.Contains(resp, "OK") {
+			t.Fatalf("SELECT Other failed: %q", resp)
+		}
+
+		// An update delivered before the switch took effect is legitimate — the
+		// client sees it ahead of the SELECT response, while INBOX is still its
+		// selected mailbox. What must never happen is delivery once the switch
+		// has completed: Other is empty, so any EXISTS arriving now describes
+		// INBOX and would corrupt the client's view of Other.
+		if line, err := watcher.readLine(20 * time.Millisecond); err == nil {
+			t.Fatalf("iteration %d: stray %q after Other became the selected mailbox", i, line)
+		}
+		if resp := watcher.cmd("NOOP"); strings.Contains(resp, "EXISTS") {
+			t.Fatalf("iteration %d: stray %q at the next sync point", i, resp)
+		}
+		if resp := watcher.cmd("SELECT INBOX"); !strings.Contains(resp, "OK") {
+			t.Fatalf("SELECT INBOX failed: %q", resp)
+		}
+	}
+}
+
+// TestNotifyOverflowResumesDelivery verifies the RFC 5465 section 5.8 flow: a
+// frozen view that grows past the backend's limit produces an untagged
+// OK [NOTIFICATIONOVERFLOW], after which the accumulated updates are delivered
+// again instead of being held forever.
+func TestNotifyOverflowResumesDelivery(t *testing.T) {
+	addr, _, closer := newNotifyTestServer(t)
+	defer closer()
+
+	watcher := dialNotifyTest(t, addr)
+	defer watcher.close()
+	watcher.login(t)
+	watcher.cmd("CREATE INBOX")
+	watcher.cmd("SELECT INBOX")
+	// No SELECTED specifier: message events for INBOX are suppressed and their
+	// updates accumulate.
+	if resp := watcher.cmd("NOTIFY SET (PERSONAL (MailboxName))"); !strings.Contains(resp, "OK") {
+		t.Fatalf("NOTIFY SET failed: %q", resp)
+	}
+
+	other := dialNotifyTest(t, addr)
+	defer other.close()
+	other.login(t)
+
+	var overflowed bool
+	for i := 0; i < 1200 && !overflowed; i++ {
+		other.appendMessage(t, "INBOX")
+		for {
+			line, err := watcher.readLine(5 * time.Millisecond)
+			if err != nil {
+				break
+			}
+			if strings.Contains(line, "NOTIFICATIONOVERFLOW") {
+				overflowed = true
+				break
+			}
+		}
+	}
+	if !overflowed {
+		t.Fatal("expected an OK [NOTIFICATIONOVERFLOW] once the frozen view grew past the limit")
+	}
+
+	// Notifications are off, but the client must not be left with a stale view:
+	// the accumulated updates are delivered at the next sync point.
+	resp := watcher.cmd("NOOP")
+	if !strings.Contains(resp, "EXISTS") {
+		t.Errorf("expected the accumulated updates to be delivered after the overflow, got %q", resp)
+	}
+}
+
+// TestNotifyMailboxNameAffectedNames verifies RFC 5465 section 5.4: creating or
+// deleting a mailbox affects the mailbox itself and its direct parent, and the
+// LIST responses report child status.
+func TestNotifyMailboxNameAffectedNames(t *testing.T) {
+	addr, _, closer := newNotifyTestServer(t)
+	defer closer()
+
+	watcher := dialNotifyTest(t, addr)
+	defer watcher.close()
+	watcher.login(t)
+	if resp := watcher.cmd("NOTIFY SET (PERSONAL (MailboxName))"); !strings.Contains(resp, "OK") {
+		t.Fatalf("NOTIFY SET failed: %q", resp)
+	}
+
+	other := dialNotifyTest(t, addr)
+	defer other.close()
+	other.login(t)
+	if resp := other.cmd("CREATE Parent/Child"); !strings.Contains(resp, "OK") {
+		t.Fatalf("CREATE failed: %q", resp)
+	}
+
+	var sawChild, sawParent bool
+	for i := 0; i < 2; i++ {
+		line, err := watcher.readLine(5 * time.Second)
+		if err != nil {
+			t.Fatalf("waiting for LIST responses: %v", err)
+		}
+		switch {
+		case strings.Contains(line, "Parent/Child"):
+			sawChild = true
+			if !strings.Contains(line, "\\HasNoChildren") {
+				t.Errorf("expected \\HasNoChildren for the new mailbox: %q", line)
+			}
+		case strings.Contains(line, "Parent"):
+			sawParent = true
+			// Parent itself was never created, but it now has a child.
+			if !strings.Contains(line, "\\NonExistent") || !strings.Contains(line, "\\HasChildren") {
+				t.Errorf("expected the affected parent as \\NonExistent \\HasChildren: %q", line)
+			}
+		}
+	}
+	if !sawChild || !sawParent {
+		t.Errorf("expected LIST responses for the mailbox and its parent (child=%v parent=%v)", sawChild, sawParent)
+	}
+}
+
+// TestNotifyAclChangeReportsMailboxName verifies RFC 5465 section 5.4 (losing
+// the 'l' right counts as deletion) and section 5.9 (losing another required
+// right is reported with \NoAccess).
+func TestNotifyAclChangeReportsMailboxName(t *testing.T) {
+	addr, _, closer := newNotifyTestServer(t)
+	defer closer()
+
+	watcher := dialNotifyTest(t, addr)
+	defer watcher.close()
+	watcher.login(t)
+	if resp := watcher.cmd("CREATE Shared"); !strings.Contains(resp, "OK") {
+		t.Fatalf("CREATE failed: %q", resp)
+	}
+	if resp := watcher.cmd("NOTIFY SET (PERSONAL (MailboxName))"); !strings.Contains(resp, "OK") {
+		t.Fatalf("NOTIFY SET failed: %q", resp)
+	}
+
+	other := dialNotifyTest(t, addr)
+	defer other.close()
+	other.login(t)
+
+	// Losing 'r' while keeping 'l': \NoAccess.
+	if resp := other.cmd("SETACL Shared user -r"); !strings.Contains(resp, "OK") {
+		t.Fatalf("SETACL failed: %q", resp)
+	}
+	line, err := watcher.readLine(5 * time.Second)
+	if err != nil {
+		t.Fatalf("waiting for the \\NoAccess LIST: %v", err)
+	}
+	if !strings.Contains(line, "\\NoAccess") || !strings.Contains(line, "Shared") {
+		t.Errorf("expected a \\NoAccess LIST for Shared, got %q", line)
+	}
+
+	// Losing 'l': reported as a deletion.
+	if resp := other.cmd("SETACL Shared user -l"); !strings.Contains(resp, "OK") {
+		t.Fatalf("SETACL failed: %q", resp)
+	}
+	line, err = watcher.readLine(5 * time.Second)
+	if err != nil {
+		t.Fatalf("waiting for the \\NonExistent LIST: %v", err)
+	}
+	if !strings.Contains(line, "\\NonExistent") || !strings.Contains(line, "Shared") {
+		t.Errorf("expected a \\NonExistent LIST for Shared, got %q", line)
+	}
+}
+
+// TestNotifySelfCreatedMessageNoFetch verifies RFC 5465 section 5.2: "A FETCH
+// response SHOULD NOT be generated for a new message created by the client on
+// this particular connection".
+func TestNotifySelfCreatedMessageNoFetch(t *testing.T) {
+	addr, _, closer := newNotifyTestServer(t)
+	defer closer()
+
+	c := dialNotifyTest(t, addr)
+	defer c.close()
+	c.login(t)
+	c.cmd("CREATE INBOX")
+	c.cmd("SELECT INBOX")
+	if resp := c.cmd("NOTIFY SET (SELECTED (MessageNew (UID) MessageExpunge))"); !strings.Contains(resp, "OK") {
+		t.Fatalf("NOTIFY SET failed: %q", resp)
+	}
+
+	// This connection's own APPEND: EXISTS is still required, a FETCH is not.
+	c.appendMessage(t, "INBOX")
+	deadline := time.Now().Add(500 * time.Millisecond)
+	for time.Now().Before(deadline) {
+		line, err := c.readLine(100 * time.Millisecond)
+		if err != nil {
+			continue
+		}
+		if strings.Contains(line, "FETCH") {
+			t.Fatalf("unexpected FETCH for a message created by this connection: %q", line)
+		}
+	}
+
+	// A message from another connection still gets one.
+	other := dialNotifyTest(t, addr)
+	defer other.close()
+	other.login(t)
+	other.appendMessage(t, "INBOX")
+
+	var sawFetch bool
+	for i := 0; i < 4 && !sawFetch; i++ {
+		line, err := c.readLine(5 * time.Second)
+		if err != nil {
+			break
+		}
+		sawFetch = strings.Contains(line, "FETCH")
+	}
+	if !sawFetch {
+		t.Error("expected a FETCH notification for a message from another connection")
+	}
+}
+
+// TestNotifyEventsSurviveMailboxSwitch verifies that fencing the pump across a
+// mailbox switch only pauses delivery: events raised while the pump is stopped
+// must still reach the client, not be dropped.
+func TestNotifyEventsSurviveMailboxSwitch(t *testing.T) {
+	addr, _, closer := newNotifyTestServer(t)
+	defer closer()
+
+	watcher := dialNotifyTest(t, addr)
+	defer watcher.close()
+	watcher.login(t)
+	watcher.cmd("CREATE INBOX")
+	watcher.cmd("SELECT INBOX")
+	if resp := watcher.cmd("NOTIFY SET (PERSONAL (MailboxName))"); !strings.Contains(resp, "OK") {
+		t.Fatalf("NOTIFY SET failed: %q", resp)
+	}
+
+	other := dialNotifyTest(t, addr)
+	defer other.close()
+	other.login(t)
+
+	const count = 30
+	seen := make(map[string]bool)
+	for i := 0; i < count; i++ {
+		name := fmt.Sprintf("box%02d", i)
+		if resp := other.cmd("CREATE %s", name); !strings.Contains(resp, "OK") {
+			t.Fatalf("CREATE %s failed: %q", name, resp)
+		}
+		// Re-select in the middle of the notification traffic: this stops and
+		// restarts the pump.
+		resp := watcher.cmd("SELECT INBOX")
+		for _, line := range strings.Split(resp, "\r\n") {
+			if strings.HasPrefix(line, "* LIST") {
+				seen[strings.Trim(line[strings.LastIndex(line, " ")+1:], `"`)] = true
+			}
+		}
+	}
+
+	deadline := time.Now().Add(5 * time.Second)
+	for len(seen) < count && time.Now().Before(deadline) {
+		line, err := watcher.readLine(200 * time.Millisecond)
+		if err != nil {
+			continue
+		}
+		if strings.HasPrefix(line, "* LIST") {
+			seen[strings.Trim(strings.TrimRight(line, "\r\n")[strings.LastIndex(strings.TrimRight(line, "\r\n"), " ")+1:], `"`)] = true
+		}
+	}
+
+	var missing []string
+	for i := 0; i < count; i++ {
+		if name := fmt.Sprintf("box%02d", i); !seen[name] {
+			missing = append(missing, name)
+		}
+	}
+	if len(missing) > 0 {
+		t.Errorf("%d of %d MailboxName notifications were lost across the mailbox switches: %v", len(missing), count, missing)
+	}
+}
+
+// TestNotifySelectedDelayedReleasedInIdle verifies RFC 5465 section 6.1.2: a
+// SELECTED-DELAYED watch withholds MessageExpunge only "till a NOOP or an IDLE
+// command has been issued". Holding it for the whole IDLE would also block
+// every later update, since updates are delivered in order.
+func TestNotifySelectedDelayedReleasedInIdle(t *testing.T) {
+	addr, _, closer := newNotifyTestServer(t)
+	defer closer()
+
+	watcher := dialNotifyTest(t, addr)
+	defer watcher.close()
+	watcher.login(t)
+	watcher.cmd("CREATE INBOX")
+	watcher.appendMessage(t, "INBOX")
+	watcher.appendMessage(t, "INBOX")
+	watcher.cmd("SELECT INBOX")
+	if resp := watcher.cmd("NOTIFY SET (SELECTED-DELAYED (MessageNew MessageExpunge))"); !strings.Contains(resp, "OK") {
+		t.Fatalf("NOTIFY SET failed: %q", resp)
+	}
+
+	other := dialNotifyTest(t, addr)
+	defer other.close()
+	other.login(t)
+	other.cmd("SELECT INBOX")
+	other.cmd(`STORE 1 +FLAGS (\Deleted)`)
+	if resp := other.cmd("EXPUNGE"); !strings.Contains(resp, "OK") {
+		t.Fatalf("EXPUNGE failed: %q", resp)
+	}
+
+	// Enter IDLE: the delayed expunge, and the append queued behind it, must
+	// be delivered.
+	if _, err := watcher.conn.Write([]byte("T99 IDLE\r\n")); err != nil {
+		t.Fatalf("write IDLE: %v", err)
+	}
+	if line, err := watcher.readLine(5 * time.Second); err != nil || !strings.HasPrefix(line, "+") {
+		t.Fatalf("expected a continuation request for IDLE, got %q (%v)", line, err)
+	}
+	other.appendMessage(t, "INBOX")
+
+	var sawExpunge, sawExists bool
+	deadline := time.Now().Add(5 * time.Second)
+	for (!sawExpunge || !sawExists) && time.Now().Before(deadline) {
+		line, err := watcher.readLine(500 * time.Millisecond)
+		if err != nil {
+			continue
+		}
+		if strings.Contains(line, "EXPUNGE") {
+			sawExpunge = true
+		}
+		if strings.Contains(line, "EXISTS") {
+			sawExists = true
+		}
+	}
+	watcher.conn.Write([]byte("DONE\r\n"))
+	if !sawExpunge {
+		t.Error("the delayed EXPUNGE was not released during IDLE")
+	}
+	if !sawExists {
+		t.Error("the EXISTS queued behind the delayed EXPUNGE never arrived")
+	}
+}
+
+// TestCommandErrorLiteralRecovery covers the ways a failed command can leave
+// literal octets in the stream. Either they are skipped and the connection
+// keeps working, or the connection is closed — what must never happen is the
+// next command being parsed from inside client data (RFC 9051 section 2.2.1).
+func TestCommandErrorLiteralRecovery(t *testing.T) {
+	for _, tc := range []struct {
+		name    string
+		cmd     string
+		survive bool // connection is expected to remain usable
+	}{
+		{
+			name:    "SmallNonSyncLiteralInFailedCommand",
+			cmd:     "NOTIFY SET (BOGUSSPEC {5+}\r\nSNEAK (MessageNew MessageExpunge))",
+			survive: false, // announcement never parsed: cannot resynchronize
+		},
+		{
+			name:    "RejectedNonSyncLiteral",
+			cmd:     "LOGIN {5000+}\r\n" + strings.Repeat("A", 5000) + " pass",
+			survive: true, // size refused, octets skipped
+		},
+		{
+			name:    "RejectedSyncLiteral",
+			cmd:     "LOGIN {5000}",
+			survive: true, // never sent: nothing to skip
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			addr, _, closer := newNotifyTestServer(t)
+			defer closer()
+
+			c := dialNotifyTest(t, addr)
+			defer c.close()
+
+			// The server must answer, rather than block waiting for octets the
+			// client is not going to send.
+			c.tag++
+			line := fmt.Sprintf("T%d %s\r\n", c.tag, tc.cmd)
+			if _, err := c.conn.Write([]byte(line)); err != nil {
+				t.Fatalf("write: %v", err)
+			}
+			resp, err := c.readLine(5 * time.Second)
+			if err != nil {
+				t.Fatalf("no response to the failed command: %v", err)
+			}
+			t.Logf("response: %q", resp)
+
+			// Whatever follows must not be executed as a command.
+			if _, err := c.conn.Write([]byte("T90 NOOP\r\n")); err != nil {
+				t.Fatalf("write: %v", err)
+			}
+			next, err := c.readLine(5 * time.Second)
+			switch {
+			case tc.survive:
+				if err != nil {
+					t.Fatalf("connection unusable after recovery: %v", err)
+				}
+				if !strings.Contains(next, "T90 OK") && !strings.Contains(next, "T90 ") {
+					t.Errorf("expected a response to the next command, got %q", next)
+				}
+			default:
+				if err == nil && !strings.Contains(next, "BYE") {
+					t.Errorf("expected the connection to be closed, got %q", next)
+				}
+			}
+		})
+	}
+}
+
+// TestNotifyNoneSilencesIdle verifies that IDLE reports nothing once the client
+// has asked for no events at all with NOTIFY NONE (RFC 5465 section 3.1).
+func TestNotifyNoneSilencesIdle(t *testing.T) {
+	addr, _, closer := newNotifyTestServer(t)
+	defer closer()
+
+	watcher := dialNotifyTest(t, addr)
+	defer watcher.close()
+	watcher.login(t)
+	watcher.cmd("CREATE INBOX")
+	watcher.cmd("SELECT INBOX")
+	if resp := watcher.cmd("NOTIFY NONE"); !strings.Contains(resp, "OK") {
+		t.Fatalf("NOTIFY NONE failed: %q", resp)
+	}
+
+	if _, err := watcher.conn.Write([]byte("T90 IDLE\r\n")); err != nil {
+		t.Fatalf("write IDLE: %v", err)
+	}
+	if line, err := watcher.readLine(5 * time.Second); err != nil || !strings.HasPrefix(line, "+") {
+		t.Fatalf("expected a continuation request for IDLE, got %q (%v)", line, err)
+	}
+
+	other := dialNotifyTest(t, addr)
+	defer other.close()
+	other.login(t)
+	other.appendMessage(t, "INBOX")
+
+	if line, err := watcher.readLine(500 * time.Millisecond); err == nil {
+		t.Errorf("IDLE pushed %q after NOTIFY NONE", line)
+	}
+	watcher.conn.Write([]byte("DONE\r\n"))
 }

--- a/imapserver/notify_test.go
+++ b/imapserver/notify_test.go
@@ -1,0 +1,386 @@
+package imapserver_test
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"net"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/emersion/go-imap/v2"
+	"github.com/emersion/go-imap/v2/imapserver"
+	"github.com/emersion/go-imap/v2/imapserver/imapmemserver"
+)
+
+// notifyTestConn is a raw-wire IMAP connection for exercising the NOTIFY
+// command syntax without an IMAP client library in the way.
+type notifyTestConn struct {
+	t    *testing.T
+	conn net.Conn
+	br   *bufio.Reader
+	tag  int
+}
+
+func newNotifyTestServer(t *testing.T) (addr string, user *imapmemserver.User, closer func()) {
+	t.Helper()
+
+	user = imapmemserver.NewUser("user", "pass")
+	memServer := imapmemserver.New()
+	memServer.AddUser(user)
+
+	srv := imapserver.New(&imapserver.Options{
+		NewSession: func(*imapserver.Conn) (imapserver.Session, *imapserver.GreetingData, error) {
+			return memServer.NewSession(), nil, nil
+		},
+		Caps: imap.CapSet{
+			imap.CapIMAP4rev1: {},
+			imap.CapNotify:    {},
+		},
+		InsecureAuth: true,
+	})
+
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("Listen: %v", err)
+	}
+	go srv.Serve(ln)
+
+	return ln.Addr().String(), user, func() { srv.Close() }
+}
+
+func dialNotifyTest(t *testing.T, addr string) *notifyTestConn {
+	t.Helper()
+
+	conn, err := net.Dial("tcp", addr)
+	if err != nil {
+		t.Fatalf("Dial: %v", err)
+	}
+	if err := conn.SetDeadline(time.Now().Add(10 * time.Second)); err != nil {
+		t.Fatalf("SetDeadline: %v", err)
+	}
+
+	c := &notifyTestConn{t: t, conn: conn, br: bufio.NewReader(conn)}
+	if _, err := c.br.ReadString('\n'); err != nil { // greeting
+		t.Fatalf("reading greeting: %v", err)
+	}
+	return c
+}
+
+func (c *notifyTestConn) close() {
+	c.conn.Close()
+}
+
+// cmd sends an IMAP command and returns every line up to and including the
+// tagged response.
+func (c *notifyTestConn) cmd(format string, args ...interface{}) string {
+	c.t.Helper()
+
+	c.tag++
+	tag := fmt.Sprintf("T%d", c.tag)
+	line := tag + " " + fmt.Sprintf(format, args...)
+	if _, err := c.conn.Write([]byte(line + "\r\n")); err != nil {
+		c.t.Fatalf("write %q: %v", line, err)
+	}
+
+	var buf bytes.Buffer
+	for {
+		l, err := c.br.ReadString('\n')
+		buf.WriteString(l)
+		if strings.HasPrefix(l, tag+" ") {
+			return buf.String()
+		}
+		if err != nil {
+			c.t.Fatalf("reading response for %q: %v (got %q)", line, err, buf.String())
+		}
+	}
+}
+
+// readLine reads one server line, waiting up to the given duration.
+func (c *notifyTestConn) readLine(timeout time.Duration) (string, error) {
+	c.conn.SetReadDeadline(time.Now().Add(timeout))
+	defer c.conn.SetReadDeadline(time.Now().Add(10 * time.Second))
+	return c.br.ReadString('\n')
+}
+
+func (c *notifyTestConn) login(t *testing.T) {
+	t.Helper()
+	if resp := c.cmd("LOGIN user pass"); !strings.Contains(resp, "OK") {
+		t.Fatalf("LOGIN failed: %q", resp)
+	}
+}
+
+func TestNotifyCommandSyntax(t *testing.T) {
+	addr, _, closer := newNotifyTestServer(t)
+	defer closer()
+
+	c := dialNotifyTest(t, addr)
+	defer c.close()
+	c.login(t)
+	if resp := c.cmd("CREATE INBOX"); !strings.Contains(resp, "OK") {
+		t.Fatalf("CREATE failed: %q", resp)
+	}
+	if resp := c.cmd("SELECT INBOX"); !strings.Contains(resp, "OK") {
+		t.Fatalf("SELECT failed: %q", resp)
+	}
+
+	tests := []struct {
+		name string
+		cmd  string
+		want string // substring expected in the tagged response line
+	}{
+		{
+			name: "None",
+			cmd:  "NOTIFY NONE",
+			want: "OK",
+		},
+		{
+			name: "SetSelected",
+			cmd:  "NOTIFY SET (SELECTED (MessageNew MessageExpunge))",
+			want: "OK",
+		},
+		{
+			name: "CaseInsensitive",
+			cmd:  "notify set (selected-delayed (messagenew messageexpunge flagchange))",
+			want: "OK",
+		},
+		{
+			name: "EventsNone",
+			cmd:  "NOTIFY SET (PERSONAL NONE)",
+			want: "OK",
+		},
+		{
+			name: "SubtreeBareMailbox",
+			cmd:  "NOTIFY SET (SUBTREE INBOX (MailboxName))",
+			want: "OK",
+		},
+		{
+			name: "MailboxesList",
+			cmd:  `NOTIFY SET (MAILBOXES (INBOX "Foo Bar") (MessageNew MessageExpunge))`,
+			want: "OK",
+		},
+		{
+			name: "SelectedFetchAtts",
+			cmd:  "NOTIFY SET (SELECTED (MessageNew (UID FLAGS) MessageExpunge))",
+			want: "OK",
+		},
+		{
+			name: "MessageNewWithoutExpunge",
+			cmd:  "NOTIFY SET (SELECTED (MessageNew))",
+			want: "BAD",
+		},
+		{
+			name: "MessageExpungeWithoutNew",
+			cmd:  "NOTIFY SET (SELECTED (MessageExpunge))",
+			want: "BAD",
+		},
+		{
+			name: "FlagChangeWithoutMessagePair",
+			cmd:  "NOTIFY SET (SELECTED (FlagChange))",
+			want: "BAD",
+		},
+		{
+			name: "TwoSelectedGroups",
+			cmd:  "NOTIFY SET (SELECTED (MessageNew MessageExpunge)) (SELECTED-DELAYED (MessageNew MessageExpunge))",
+			want: "BAD",
+		},
+		{
+			name: "MailboxEventOnSelected",
+			cmd:  "NOTIFY SET (SELECTED (MessageNew MessageExpunge MailboxName))",
+			want: "BAD",
+		},
+		{
+			name: "FetchAttsOnNonSelected",
+			cmd:  "NOTIFY SET (PERSONAL (MessageNew (UID) MessageExpunge))",
+			want: "BAD",
+		},
+		{
+			name: "FetchAttsAfterNonMessageNew",
+			cmd:  "NOTIFY SET (SELECTED (MessageExpunge (UID) MessageNew))",
+			want: "BAD",
+		},
+		{
+			name: "UnknownSpecifier",
+			cmd:  "NOTIFY SET (BOGUS (MessageNew MessageExpunge))",
+			want: "BAD",
+		},
+		{
+			name: "SetWithoutGroups",
+			cmd:  "NOTIFY SET",
+			want: "BAD",
+		},
+		{
+			name: "UnknownVerb",
+			cmd:  "NOTIFY BOGUS",
+			want: "BAD",
+		},
+		{
+			name: "UnsupportedEvent",
+			cmd:  "NOTIFY SET (SELECTED (MessageNew MessageExpunge AnnotationChange))",
+			want: "NO [BADEVENT (MessageNew MessageExpunge FlagChange MailboxName SubscriptionChange)]",
+		},
+		{
+			name: "UnknownEvent",
+			cmd:  "NOTIFY SET (PERSONAL (SomeVendorEvent))",
+			want: "NO [BADEVENT",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			resp := c.cmd("%s", tc.cmd)
+			lines := strings.Split(strings.TrimRight(resp, "\r\n"), "\r\n")
+			tagged := lines[len(lines)-1]
+			if !strings.Contains(tagged, tc.want) {
+				t.Errorf("%s: expected tagged response containing %q, got %q", tc.cmd, tc.want, tagged)
+			}
+		})
+	}
+
+	// The watch left over from the table runs must be cleanly removable.
+	if resp := c.cmd("NOTIFY NONE"); !strings.Contains(resp, "OK") {
+		t.Errorf("NOTIFY NONE failed: %q", resp)
+	}
+}
+
+func TestNotifyNotAuthenticated(t *testing.T) {
+	addr, _, closer := newNotifyTestServer(t)
+	defer closer()
+
+	c := dialNotifyTest(t, addr)
+	defer c.close()
+
+	resp := c.cmd("NOTIFY NONE")
+	if !strings.Contains(resp, "BAD") {
+		t.Errorf("expected BAD for NOTIFY before authentication, got %q", resp)
+	}
+}
+
+// TestNotifySetStatus verifies that NOTIFY SET STATUS sends the initial
+// STATUS responses for matching non-selected mailboxes before the tagged OK
+// (RFC 5465 section 3.1).
+func TestNotifySetStatus(t *testing.T) {
+	addr, _, closer := newNotifyTestServer(t)
+	defer closer()
+
+	c := dialNotifyTest(t, addr)
+	defer c.close()
+	c.login(t)
+	for _, name := range []string{"INBOX", "Archive"} {
+		if resp := c.cmd("CREATE %s", name); !strings.Contains(resp, "OK") {
+			t.Fatalf("CREATE %s failed: %q", name, resp)
+		}
+	}
+	if resp := c.cmd("SELECT INBOX"); !strings.Contains(resp, "OK") {
+		t.Fatalf("SELECT failed: %q", resp)
+	}
+
+	resp := c.cmd("NOTIFY SET STATUS (PERSONAL (MessageNew MessageExpunge))")
+	lines := strings.Split(strings.TrimRight(resp, "\r\n"), "\r\n")
+	tagged := lines[len(lines)-1]
+	if !strings.Contains(tagged, "OK") {
+		t.Fatalf("NOTIFY SET STATUS failed: %q", resp)
+	}
+
+	// The selected mailbox (INBOX) must not get a STATUS; Archive must, and
+	// it must appear before the tagged OK by construction (it is part of the
+	// response transcript).
+	var sawArchive bool
+	for _, line := range lines[:len(lines)-1] {
+		if strings.HasPrefix(line, "* STATUS") {
+			if strings.Contains(line, "Archive") {
+				sawArchive = true
+				for _, item := range []string{"MESSAGES", "UIDNEXT", "UIDVALIDITY"} {
+					if !strings.Contains(line, item) {
+						t.Errorf("STATUS response %q is missing %v", line, item)
+					}
+				}
+			}
+			if strings.Contains(line, "INBOX") {
+				t.Errorf("unexpected STATUS for the selected mailbox: %q", line)
+			}
+		}
+	}
+	if !sawArchive {
+		t.Errorf("expected an initial STATUS response for Archive, got %q", resp)
+	}
+}
+
+// TestNotifyMailboxEventsDelivery verifies asynchronous LIST delivery for
+// MailboxName/SubscriptionChange events triggered by another connection, and
+// that NOTIFY NONE stops delivery.
+func TestNotifyMailboxEventsDelivery(t *testing.T) {
+	addr, _, closer := newNotifyTestServer(t)
+	defer closer()
+
+	watcher := dialNotifyTest(t, addr)
+	defer watcher.close()
+	watcher.login(t)
+	if resp := watcher.cmd("NOTIFY SET (PERSONAL (MailboxName SubscriptionChange))"); !strings.Contains(resp, "OK") {
+		t.Fatalf("NOTIFY SET failed: %q", resp)
+	}
+
+	other := dialNotifyTest(t, addr)
+	defer other.close()
+	other.login(t)
+
+	// CREATE on the other connection: the watcher gets an unsolicited LIST.
+	if resp := other.cmd("CREATE Foo"); !strings.Contains(resp, "OK") {
+		t.Fatalf("CREATE failed: %q", resp)
+	}
+	line, err := watcher.readLine(5 * time.Second)
+	if err != nil {
+		t.Fatalf("waiting for LIST after CREATE: %v", err)
+	}
+	if !strings.HasPrefix(line, "* LIST") || !strings.Contains(line, "Foo") {
+		t.Errorf("expected unsolicited LIST for Foo, got %q", line)
+	}
+
+	// RENAME: LIST for the new name.
+	if resp := other.cmd("RENAME Foo Bar"); !strings.Contains(resp, "OK") {
+		t.Fatalf("RENAME failed: %q", resp)
+	}
+	line, err = watcher.readLine(5 * time.Second)
+	if err != nil {
+		t.Fatalf("waiting for LIST after RENAME: %v", err)
+	}
+	if !strings.HasPrefix(line, "* LIST") || !strings.Contains(line, "Bar") {
+		t.Errorf("expected unsolicited LIST for Bar, got %q", line)
+	}
+
+	// SUBSCRIBE: LIST with \Subscribed.
+	if resp := other.cmd("SUBSCRIBE Bar"); !strings.Contains(resp, "OK") {
+		t.Fatalf("SUBSCRIBE failed: %q", resp)
+	}
+	line, err = watcher.readLine(5 * time.Second)
+	if err != nil {
+		t.Fatalf("waiting for LIST after SUBSCRIBE: %v", err)
+	}
+	if !strings.Contains(line, "\\Subscribed") || !strings.Contains(line, "Bar") {
+		t.Errorf("expected unsolicited LIST with \\Subscribed for Bar, got %q", line)
+	}
+
+	// DELETE: LIST with \NonExistent.
+	if resp := other.cmd("DELETE Bar"); !strings.Contains(resp, "OK") {
+		t.Fatalf("DELETE failed: %q", resp)
+	}
+	line, err = watcher.readLine(5 * time.Second)
+	if err != nil {
+		t.Fatalf("waiting for LIST after DELETE: %v", err)
+	}
+	if !strings.Contains(line, "\\NonExistent") || !strings.Contains(line, "Bar") {
+		t.Errorf("expected unsolicited LIST with \\NonExistent for Bar, got %q", line)
+	}
+
+	// NOTIFY NONE: no more notifications.
+	if resp := watcher.cmd("NOTIFY NONE"); !strings.Contains(resp, "OK") {
+		t.Fatalf("NOTIFY NONE failed: %q", resp)
+	}
+	if resp := other.cmd("CREATE Baz"); !strings.Contains(resp, "OK") {
+		t.Fatalf("CREATE failed: %q", resp)
+	}
+	if line, err := watcher.readLine(300 * time.Millisecond); err == nil {
+		t.Errorf("expected no notification after NOTIFY NONE, got %q", line)
+	}
+}

--- a/imapserver/select.go
+++ b/imapserver/select.go
@@ -102,6 +102,16 @@ func (c *Conn) handleSelect(tag string, dec *imapwire.Decoder, readOnly bool) er
 		return err
 	}
 
+	// The selected mailbox is about to change: no NotifyPoll delivery may be in
+	// flight across the switch, or an update queued for the old mailbox would
+	// reach the client while the new one is selected — an EXISTS or EXPUNGE
+	// that then means something entirely different (RFC 5465 §6.1: the SELECTED
+	// specifiers refer to "the mailbox that was selected using either SELECT or
+	// EXAMINE"). The pump is restarted once the whole SELECT response has been
+	// written: this defer is registered before the response encoder is opened,
+	// so it runs after the encoder is closed.
+	defer c.restartNotifyPump(c.fenceNotifyPump())
+
 	if c.state == imap.ConnStateSelected {
 		if err := c.session.Unselect(c.ctx); err != nil {
 			return err
@@ -158,7 +168,9 @@ func (c *Conn) handleSelect(tag string, dec *imapwire.Decoder, readOnly bool) er
 	writeFlags(enc.Encoder, data.Flags)
 	writePermanentFlags(enc.Encoder, data.PermanentFlags)
 	if data.List != nil {
-		if err := c.writeList(data.List, nil); err != nil {
+		// Write into the encoder this function already holds: opening a second
+		// one would deadlock on the non-reentrant encoder mutex.
+		if err := writeListData(enc.Encoder, data.List, nil, false); err != nil {
 			return err
 		}
 	}
@@ -207,6 +219,10 @@ func (c *Conn) handleUnselect(dec *imapwire.Decoder, expunge bool) error {
 	if err := c.checkState(imap.ConnStateSelected); err != nil {
 		return err
 	}
+
+	// Same fence as SELECT: nothing may be delivered for the mailbox being
+	// closed while it is being closed.
+	defer c.restartNotifyPump(c.fenceNotifyPump())
 
 	// RFC 3501 §6.4.2: "No messages are removed, and no error is given, if the
 	// mailbox is selected by an EXAMINE command or is otherwise selected

--- a/imapserver/select_list_test.go
+++ b/imapserver/select_list_test.go
@@ -1,0 +1,66 @@
+package imapserver_test
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/emersion/go-imap/v2"
+	"github.com/emersion/go-imap/v2/imapserver"
+	"github.com/emersion/go-imap/v2/imapserver/imapmemserver"
+)
+
+// selectListSession populates SelectData.List, which RFC 9051 section 6.3.2
+// lists among the required untagged responses of SELECT.
+type selectListSession struct {
+	imapserver.Session
+}
+
+func (s *selectListSession) Select(ctx context.Context, mailbox string, options *imap.SelectOptions) (*imap.SelectData, error) {
+	data, err := s.Session.Select(ctx, mailbox, options)
+	if err != nil {
+		return nil, err
+	}
+	data.List = &imap.ListData{Mailbox: mailbox, Delim: '/'}
+	return data, nil
+}
+
+// TestSelectWithListData verifies that a backend may populate SelectData.List:
+// the LIST response must be written inside the SELECT response block and the
+// command must complete. Writing it used to re-enter the response encoder,
+// deadlocking the connection goroutine on the non-reentrant encoder mutex.
+func TestSelectWithListData(t *testing.T) {
+	user := imapmemserver.NewUser("user", "pass")
+	memServer := imapmemserver.New()
+	memServer.AddUser(user)
+
+	srv := imapserver.New(&imapserver.Options{
+		NewSession: func(*imapserver.Conn) (imapserver.Session, *imapserver.GreetingData, error) {
+			return &selectListSession{Session: memServer.NewSession()}, nil, nil
+		},
+		Caps: imap.CapSet{
+			imap.CapIMAP4rev1: {},
+			imap.CapNotify:    {},
+		},
+		InsecureAuth: true,
+	})
+
+	ln := mustListen(t)
+	defer srv.Close()
+	go srv.Serve(ln)
+
+	c := dialNotifyTest(t, ln.Addr().String())
+	defer c.close()
+	c.login(t)
+	if resp := c.cmd("CREATE INBOX"); !strings.Contains(resp, "OK") {
+		t.Fatalf("CREATE failed: %q", resp)
+	}
+
+	resp := c.cmd("SELECT INBOX")
+	if !strings.Contains(resp, "OK") {
+		t.Fatalf("SELECT did not complete: %q", resp)
+	}
+	if !strings.Contains(resp, "* LIST") || !strings.Contains(resp, "INBOX") {
+		t.Errorf("expected a LIST response in the SELECT response block, got %q", resp)
+	}
+}

--- a/imapserver/session.go
+++ b/imapserver/session.go
@@ -161,6 +161,52 @@ type SessionAdditionalCaps interface {
 	AdditionalCapabilities() []imap.Cap
 }
 
+// SessionNotify is an IMAP session which supports the NOTIFY extension
+// (RFC 5465).
+//
+// The connection advertises the NOTIFY capability only when the session
+// implements this interface (and the server is configured with
+// imap.CapNotify).
+type SessionNotify interface {
+	Session
+
+	// SetNotify installs, replaces or clears the connection's notification
+	// watch. It is invoked synchronously on the connection's command
+	// goroutine while no NotifyPoll call is running.
+	//
+	// options is nil for NOTIFY NONE, otherwise it describes the requested
+	// watch. The options have already been checked against the structural
+	// rules of RFC 5465 (event pairing, single SELECTED group, fetch-atts
+	// placement); the backend is responsible for rejecting events it does
+	// not support by returning *UnsupportedNotifyEventError, which the
+	// server translates into a tagged NO with the BADEVENT response code.
+	//
+	// If options.Status is set, the implementation must write the initial
+	// STATUS responses for matching non-selected mailboxes to w before
+	// returning, so that they precede NOTIFY's tagged OK (RFC 5465
+	// section 3.1).
+	//
+	// On error, the previously installed watch (if any) must be left in
+	// effect.
+	SetNotify(ctx context.Context, options *imap.NotifyOptions, w *UpdateWriter) error
+
+	// NotifyPoll delivers notifications for the watch installed by
+	// SetNotify, writing to w until stop is closed or ctx is cancelled. It
+	// runs on a dedicated goroutine, concurrently with command processing on
+	// the connection; individual responses are serialized with command
+	// output by the library.
+	//
+	// EXPUNGE/VANISHED updates for the selected mailbox must only be
+	// delivered while w.ExpungeAllowed() reports true (and, with
+	// SELECTED-DELAYED, only at the sync points of RFC 5465 section 6.1.2 —
+	// most backends simply leave delayed expunges queued for the regular
+	// per-command Poll).
+	//
+	// If no watch is currently installed (e.g. it was dropped after a
+	// notification overflow), NotifyPoll returns nil promptly.
+	NotifyPoll(ctx context.Context, w *UpdateWriter, stop <-chan struct{}) error
+}
+
 // SessionMetadata is an IMAP session which supports the METADATA extension (RFC 5464).
 type SessionMetadata interface {
 	Session

--- a/imapserver/session.go
+++ b/imapserver/session.go
@@ -71,7 +71,24 @@ type Session interface {
 	List(ctx context.Context, w *ListWriter, ref string, patterns []string, options *imap.ListOptions) error
 	Status(ctx context.Context, mailbox string, options *imap.StatusOptions) (*imap.StatusData, error)
 	Append(ctx context.Context, mailbox string, r imap.LiteralReader, options *imap.AppendOptions) (*imap.AppendData, error)
+
+	// Poll delivers pending updates for the selected mailbox at a command sync
+	// point. Pending updates must stay queued when they cannot be delivered, so
+	// that the client's sequence-number view stays consistent.
+	//
+	// With the NOTIFY extension (RFC 5465) in use, the library does not call
+	// Poll at all when the client's watch disables message events for the
+	// selected mailbox; see SessionNotify for the events the backend itself
+	// must filter.
 	Poll(ctx context.Context, w *UpdateWriter, allowExpunge bool) error
+
+	// Idle continuously delivers updates until stop is closed.
+	//
+	// A backend implementing SessionNotify must honor the installed watch here
+	// as well: RFC 5465 section 4 requires IDLE to deliver exactly the events
+	// the client requested with NOTIFY. The usual implementation lets the
+	// NotifyPoll pump be the only source of updates while a watch is installed,
+	// and simply waits for stop.
 	Idle(ctx context.Context, w *UpdateWriter, stop <-chan struct{}) error
 
 	// Selected state
@@ -195,6 +212,13 @@ type SessionNotify interface {
 	// runs on a dedicated goroutine, concurrently with command processing on
 	// the connection; individual responses are serialized with command
 	// output by the library.
+	//
+	// Only the message events requested with the SELECTED/SELECTED-DELAYED
+	// specifier may be reported for the selected mailbox; omitting that
+	// specifier "is the same as specifying SELECTED NONE" (RFC 5465 section
+	// 3.1). The library enforces this for the per-command sync points (it
+	// skips Session.Poll, and drops unrequested flag updates), but the
+	// backend must not push such updates from NotifyPoll or Idle either.
 	//
 	// EXPUNGE/VANISHED updates for the selected mailbox must only be
 	// delivered while w.ExpungeAllowed() reports true (and, with

--- a/imapserver/session.go
+++ b/imapserver/session.go
@@ -78,8 +78,10 @@ type Session interface {
 	//
 	// With the NOTIFY extension (RFC 5465) in use, the library does not call
 	// Poll at all when the client's watch disables message events for the
-	// selected mailbox; see SessionNotify for the events the backend itself
-	// must filter.
+	// selected mailbox (a watch without a SELECTED specifier, or NOTIFY NONE);
+	// see SessionNotify for the events the backend itself must filter, and
+	// SessionNotify.NotifyPoll for how the backend keeps the queue that builds
+	// up behind such a watch bounded.
 	Poll(ctx context.Context, w *UpdateWriter, allowExpunge bool) error
 
 	// Idle continuously delivers updates until stop is closed.
@@ -242,8 +244,19 @@ type SessionNotify interface {
 	// most backends simply leave delayed expunges queued for the regular
 	// per-command Poll).
 	//
-	// If no watch is currently installed (e.g. it was dropped after a
-	// notification overflow), NotifyPoll returns nil promptly.
+	// NotifyPoll is started after every successful NOTIFY command, NOTIFY NONE
+	// included. While message events for the selected mailbox are suppressed
+	// — by NOTIFY NONE or by a watch without a SELECTED specifier — its
+	// updates cannot be delivered and stay queued (SessionTracker.QueuedUpdates
+	// for a tracker-based backend), and no per-command Poll gives the backend
+	// a look at that queue; NotifyPoll is where a backend bounds it, by
+	// declaring a notification overflow with w.WriteNotificationOverflow once
+	// the queue grows past a limit of its choosing, and returning nil. A
+	// backend with nothing left to do — e.g. after that overflow — may return
+	// nil promptly: the connection stays up. The library may still invoke
+	// NotifyPoll again (it restarts the pump around every change of the
+	// selected mailbox), so the backend must keep returning promptly until a
+	// new watch is installed with SetNotify.
 	NotifyPoll(ctx context.Context, w *UpdateWriter, stop <-chan struct{}) error
 }
 

--- a/imapserver/session.go
+++ b/imapserver/session.go
@@ -198,6 +198,14 @@ type SessionNotify interface {
 	// not support by returning *UnsupportedNotifyEventError, which the
 	// server translates into a tagged NO with the BADEVENT response code.
 	//
+	// The per-mailbox access checks of RFC 5465 section 3.1 are also the
+	// backend's: a named mailbox that does not exist, or that the user cannot
+	// LIST, must be ignored silently, and one the user can LIST but lacks the
+	// rights to monitor must be reported with an untagged LIST carrying
+	// imap.MailboxAttrNoAccess (written with UpdateWriter.WriteList). Section
+	// 5.9 extends this to later changes: monitoring stops when access is lost
+	// and resumes when it is granted again.
+	//
 	// If options.Status is set, the implementation must write the initial
 	// STATUS responses for matching non-selected mailboxes to w before
 	// returning, so that they precede NOTIFY's tagged OK (RFC 5465

--- a/imapserver/tracker.go
+++ b/imapserver/tracker.go
@@ -144,17 +144,40 @@ type trackerUpdateFetch struct {
 type SessionTracker struct {
 	mailbox *MailboxTracker
 
+	// deliverMutex serializes Poll calls end-to-end (dequeue + network
+	// write), so a batch dequeued by one goroutine is fully written before
+	// another goroutine dequeues and writes the next. Without it, two
+	// concurrent flushers — e.g. the command loop and a NOTIFY pump — can
+	// dequeue batches under `mutex`, release it, and then interleave their
+	// writes, delivering EXPUNGE/EXISTS out of order and corrupting the
+	// client's sequence-number view. It is a separate lock from `mutex`
+	// (which only guards `queue`/`updates`) so queueUpdate never blocks on a
+	// slow network write.
+	deliverMutex sync.Mutex
+
 	mutex   sync.Mutex
 	queue   []trackerUpdate
 	updates chan<- struct{}
 }
 
 // Close unregisters the session.
+//
+// After Close, DecodeSeqNum/EncodeSeqNum return 0 rather than dereferencing the
+// released mailbox: a NOTIFY pump goroutine may still hold a reference to this
+// tracker and call them after a concurrent UNSELECT/SELECT closed it. The
+// t.mailbox field is cleared under t.mutex so those readers observe the change
+// race-free.
 func (t *SessionTracker) Close() {
-	t.mailbox.mutex.Lock()
-	delete(t.mailbox.sessions, t)
-	t.mailbox.mutex.Unlock()
+	t.mutex.Lock()
+	mailbox := t.mailbox
 	t.mailbox = nil
+	t.mutex.Unlock()
+
+	if mailbox != nil {
+		mailbox.mutex.Lock()
+		delete(mailbox.sessions, t)
+		mailbox.mutex.Unlock()
+	}
 }
 
 func (t *SessionTracker) queueUpdate(update *trackerUpdate) {
@@ -175,7 +198,14 @@ func (t *SessionTracker) queueUpdate(update *trackerUpdate) {
 }
 
 // Poll dequeues pending mailbox updates for this session.
+//
+// Poll is safe to call from multiple goroutines: calls are serialized so each
+// dequeued batch is written to the client atomically, preserving update
+// ordering (a NOTIFY pump and the command loop may both flush this tracker).
 func (t *SessionTracker) Poll(w *UpdateWriter, allowExpunge bool) error {
+	t.deliverMutex.Lock()
+	defer t.deliverMutex.Unlock()
+
 	var updates []trackerUpdate
 	t.mutex.Lock()
 	if allowExpunge {
@@ -299,6 +329,10 @@ func (t *SessionTracker) DecodeSeqNum(seqNum uint32) uint32 {
 	t.mutex.Lock()
 	defer t.mutex.Unlock()
 
+	if t.mailbox == nil {
+		return 0 // tracker closed (see Close)
+	}
+
 	for _, update := range t.queue {
 		if update.expunge == 0 {
 			continue
@@ -328,6 +362,10 @@ func (t *SessionTracker) EncodeSeqNum(seqNum uint32) uint32 {
 
 	t.mutex.Lock()
 	defer t.mutex.Unlock()
+
+	if t.mailbox == nil {
+		return 0 // tracker closed (see Close)
+	}
 
 	if seqNum > t.mailbox.numMessages {
 		return 0

--- a/imapserver/tracker.go
+++ b/imapserver/tracker.go
@@ -317,11 +317,13 @@ func (t *SessionTracker) poll(w *UpdateWriter, allowExpunge bool) error {
 // session.
 //
 // It grows without bound while the client's NOTIFY watch disables message
-// events for the selected mailbox (RFC 5465 section 3.1): the updates cannot be
-// delivered, and dropping them would desynchronise the client's sequence
-// numbers. A backend watching a large mailbox should therefore check it and,
-// past a limit of its choosing, declare a notification overflow with
-// UpdateWriter.WriteNotificationOverflow — which tells the client its
+// events for the selected mailbox (RFC 5465 section 3.1: NOTIFY NONE, or a
+// watch without a SELECTED specifier): the updates cannot be delivered, and
+// dropping them would desynchronise the client's sequence numbers. A backend
+// should therefore check it from SessionNotify.NotifyPoll — the per-command
+// Poll is not called while the suppression is in effect — and, past a limit
+// of its choosing, declare a notification overflow with
+// UpdateWriter.WriteNotificationOverflow, which tells the client its
 // notifications are off (RFC 5465 section 5.8) and lets the server resume
 // ordinary delivery, draining the queue.
 func (t *SessionTracker) QueuedUpdates() int {
@@ -352,6 +354,14 @@ func (t *SessionTracker) Idle(w *UpdateWriter, stop <-chan struct{}) error {
 		t.updates = nil
 		t.mutex.Unlock()
 	}()
+
+	// Drain once now that the channel is registered. queueUpdate signals it
+	// with a non-blocking send, so an update queued before registration left
+	// no signal behind; without this poll it would wait for the next update to
+	// wake the loop. It also delivers whatever accumulated before IDLE began.
+	if err := t.Poll(w, true); err != nil {
+		return err
+	}
 
 	for {
 		select {

--- a/imapserver/tracker.go
+++ b/imapserver/tracker.go
@@ -203,9 +203,34 @@ func (t *SessionTracker) queueUpdate(update *trackerUpdate) {
 // dequeued batch is written to the client atomically, preserving update
 // ordering (a NOTIFY pump and the command loop may both flush this tracker).
 func (t *SessionTracker) Poll(w *UpdateWriter, allowExpunge bool) error {
+	return t.PollWith(w, allowExpunge, nil)
+}
+
+// PollWith is Poll with a follow-up write that must not be interleaved with
+// another flush.
+//
+// after runs once the pending updates have been written, while the delivery
+// lock is still held. A NOTIFY backend uses it for the FETCH responses of the
+// MessageNew fetch-atts (RFC 5465 §5.2): their sequence numbers are computed
+// from the state Poll just delivered, so another goroutine flushing an EXPUNGE
+// in between would renumber the client's view and make those responses point
+// at the wrong messages. Encode the sequence numbers inside after, not before
+// the call.
+func (t *SessionTracker) PollWith(w *UpdateWriter, allowExpunge bool, after func() error) error {
 	t.deliverMutex.Lock()
 	defer t.deliverMutex.Unlock()
 
+	if err := t.poll(w, allowExpunge); err != nil {
+		return err
+	}
+	if after != nil {
+		return after()
+	}
+	return nil
+}
+
+// poll delivers pending updates. The delivery lock must be held.
+func (t *SessionTracker) poll(w *UpdateWriter, allowExpunge bool) error {
 	var updates []trackerUpdate
 	t.mutex.Lock()
 	if allowExpunge {
@@ -280,6 +305,23 @@ func (t *SessionTracker) Poll(w *UpdateWriter, allowExpunge bool) error {
 		}
 	}
 	return flushVanished()
+}
+
+// QueuedUpdates returns the number of updates waiting to be delivered to this
+// session.
+//
+// It grows without bound while the client's NOTIFY watch disables message
+// events for the selected mailbox (RFC 5465 section 3.1): the updates cannot be
+// delivered, and dropping them would desynchronise the client's sequence
+// numbers. A backend watching a large mailbox should therefore check it and,
+// past a limit of its choosing, declare a notification overflow with
+// UpdateWriter.WriteNotificationOverflow — which tells the client its
+// notifications are off (RFC 5465 section 5.8) and lets the server resume
+// ordinary delivery, draining the queue.
+func (t *SessionTracker) QueuedUpdates() int {
+	t.mutex.Lock()
+	defer t.mutex.Unlock()
+	return len(t.queue)
 }
 
 // Idle continuously writes mailbox updates.

--- a/internal/imapwire/decoder.go
+++ b/internal/imapwire/decoder.go
@@ -59,10 +59,35 @@ type Decoder struct {
 	// to be available, or UTF8=ACCEPT to be enabled.
 	QuotedUTF8 bool
 
-	r         *bufio.Reader
-	side      ConnSide
-	err       error
-	literal   bool
+	r    *bufio.Reader
+	side ConnSide
+	err  error
+
+	// literal is set while a LiteralReader is open.
+	//
+	// pendingLiteral holds the still-unread octets of a NON-SYNCHRONIZING
+	// literal that was announced but abandoned — one whose size the caller
+	// refused, or one left behind by a failing command. Those octets are on the
+	// wire already and are part of the command being read (RFC 9051 §2.2.1), so
+	// DiscardLine skips them rather than letting the next command start inside
+	// them. Synchronizing literals are never recorded: the client is waiting
+	// for a continuation request that the failing command never sends, so
+	// nothing was transmitted and there is nothing to skip.
+	//
+	// The count is only trustworthy because abandoning a literal also sets the
+	// decoder error, which stops the parser from consuming any more of the
+	// payload behind DiscardLine's back.
+	literal        bool
+	pendingLiteral int64
+
+	// discarding is set while DiscardLine is skipping the rest of a failed
+	// command: it is the one reader allowed to run after an error.
+	discarding bool
+
+	// desynced records that the command stream could not be resynchronised:
+	// octets of the current command remain in the stream and cannot safely be
+	// skipped. The connection has to be torn down; see Desynchronized.
+	desynced  bool
 	crlf      bool
 	listDepth int
 	readBytes int64
@@ -107,6 +132,14 @@ func (dec *Decoder) returnErr(err error) bool {
 }
 
 func (dec *Decoder) readByte() (byte, bool) {
+	// Once the decode has failed, stop consuming input. Parsers routinely try
+	// one syntactic form after another, and without this a failed literal would
+	// send the next attempt straight into the literal's payload — reading data
+	// as syntax, or blocking on octets a client is waiting for a continuation
+	// request to send. Only DiscardLine reads past an error, to resynchronise.
+	if dec.err != nil && !dec.discarding {
+		return 0, false
+	}
 	if dec.MaxSize > 0 && dec.readBytes > dec.MaxSize {
 		return 0, dec.returnErr(fmt.Errorf("imapwire: max size exceeded"))
 	}
@@ -277,13 +310,76 @@ func (dec *Decoder) DiscardUntilByte(untilCh byte) {
 	}
 }
 
+// maxDiscardLiteralSize bounds how many octets of a non-synchronizing literal
+// DiscardLine drains while recovering from a command error. It is well above
+// the 4096-octet cap LITERAL- puts on non-synchronizing literals; a larger one
+// is refused rather than read, so recovery can never be turned into an
+// unbounded read.
+const maxDiscardLiteralSize = 64 << 10
+
+// DiscardLine skips the remainder of the current line, so that the next
+// command can be read from a clean position.
+//
+// The still-unread octets of a non-synchronizing literal announced by this line
+// are skipped too: they are part of the command being read (RFC 9051 §2.2.1),
+// and leaving them in the stream would make the next command start inside
+// client-supplied data. When they cannot be skipped — too many to read, or a
+// literal whose announcement was never parsed — the stream is marked
+// desynchronised instead of guessing; see Desynchronized.
 func (dec *Decoder) DiscardLine() {
+	dec.discarding = true
+	defer func() { dec.discarding = false }()
+
+	if n := dec.pendingLiteral; n > 0 {
+		dec.pendingLiteral = 0
+		if n > maxDiscardLiteralSize {
+			dec.desynced = true
+			return
+		}
+		if _, err := io.CopyN(io.Discard, dec.r, n); err != nil {
+			dec.returnErr(err)
+			dec.desynced = true
+			return
+		}
+		// The rest of the command follows the literal octets.
+		dec.crlf = false
+	}
+
 	if dec.crlf {
 		return
 	}
+
 	var text string
 	dec.Text(&text)
 	dec.CRLF()
+
+	// A line ending in a non-synchronizing literal announcement that the parser
+	// never reached: its octets follow, but their count was never validated by
+	// this decoder, so skipping them would be a guess. Refuse to resynchronise.
+	if dec.side == ConnSideServer && endsWithNonSyncLiteral(text) {
+		dec.desynced = true
+	}
+}
+
+// Desynchronized reports whether the decoder had to give up on resynchronising
+// the stream. The remaining input cannot be trusted to start at a command
+// boundary, so the connection must be terminated rather than kept in service.
+func (dec *Decoder) Desynchronized() bool {
+	return dec.desynced
+}
+
+// endsWithNonSyncLiteral reports whether text ends with a non-synchronizing
+// literal announcement such as "{42+}".
+func endsWithNonSyncLiteral(text string) bool {
+	if !strings.HasSuffix(text, "+}") {
+		return false
+	}
+	start := strings.LastIndexByte(text, '{')
+	if start < 0 {
+		return false
+	}
+	_, err := strconv.ParseInt(text[start+1:len(text)-2], 10, 64)
+	return err == nil
 }
 
 func (dec *Decoder) DiscardValue() bool {
@@ -602,7 +698,12 @@ func (dec *Decoder) Literal(ptr *string) bool {
 	if dec.CheckBufferedLiteralFunc != nil {
 		if err := dec.CheckBufferedLiteralFunc(lit.Size(), nonSync); err != nil {
 			lit.cancel()
-			return false
+			// Fail the whole decode rather than returning a plain false: callers
+			// such as ExpectAString would otherwise fall through to another
+			// read and start consuming the literal's payload as IMAP syntax —
+			// which both corrupts the command and makes the pending-octet count
+			// DiscardLine relies on wrong.
+			return dec.returnErr(err)
 		}
 	} else if lit.Size() > absoluteMaxBufferedLiteral {
 		lit.cancel()
@@ -641,9 +742,10 @@ func (dec *Decoder) LiteralReader() (lit *LiteralReader, nonSync, ok bool) {
 	}
 	dec.literal = true
 	lit = &LiteralReader{
-		dec:  dec,
-		size: size,
-		r:    io.LimitReader(dec.r, size),
+		dec:     dec,
+		size:    size,
+		nonSync: nonSync,
+		r:       io.LimitReader(dec.r, size),
 	}
 	return lit, nonSync, true
 }
@@ -657,9 +759,10 @@ func (dec *Decoder) ExpectLiteralReader() (lit *LiteralReader, nonSync bool, err
 }
 
 type LiteralReader struct {
-	dec  *Decoder
-	size int64
-	r    io.Reader
+	nonSync bool
+	dec     *Decoder
+	size    int64
+	r       io.Reader
 }
 
 func newLiteralReaderFromString(s string) *LiteralReader {
@@ -686,5 +789,21 @@ func (lit *LiteralReader) cancel() {
 		return
 	}
 	lit.dec.literal = false
+	// A non-synchronizing literal's octets are already on the wire: remember
+	// what is left so DiscardLine can skip it instead of parsing it as the next
+	// command. A synchronizing literal was never sent — the continuation
+	// request that would have asked for it is not coming — so there is nothing
+	// to skip.
+	if n := lit.remaining(); n > 0 && lit.nonSync {
+		lit.dec.pendingLiteral += n
+	}
 	lit.dec = nil
+}
+
+// remaining reports how many octets of the literal have not been read yet.
+func (lit *LiteralReader) remaining() int64 {
+	if r, ok := lit.r.(*io.LimitedReader); ok {
+		return r.N
+	}
+	return 0
 }

--- a/internal/internal.go
+++ b/internal/internal.go
@@ -140,6 +140,7 @@ func canonInit() {
 		imap.MailboxAttrUnmarked,
 		imap.MailboxAttrSubscribed,
 		imap.MailboxAttrRemote,
+		imap.MailboxAttrNoAccess,
 		imap.MailboxAttrAll,
 		imap.MailboxAttrArchive,
 		imap.MailboxAttrDrafts,

--- a/internal/listmatch.go
+++ b/internal/listmatch.go
@@ -30,35 +30,88 @@ func MatchList(name string, delim rune, reference, pattern string) bool {
 	return matchList(name, delimStr, pattern)
 }
 
+// matchList reports whether pattern matches name (RFC 9051 section 6.3.9): "*"
+// matches any sequence of bytes, "%" any sequence of bytes not containing the
+// hierarchy delimiter, and everything else matches itself. With an empty delim,
+// "%" is the same as "*".
+//
+// The pattern comes from the client, so the running time must not depend on
+// how it is written. A backtracking matcher takes exponential time on
+// "*a*a*a*a*b" against a name of a's — enough for one LIST to hold a CPU core
+// (and, in a backend that matches under a lock, every other session of the
+// user) for hours. This one is a dynamic programme over the name that runs in
+// O(len(name)²) time and O(len(name)) space whatever the pattern: a run of
+// wildcards collapses to one, and a pattern with more literal bytes than the
+// name cannot match, which bounds the number of pattern steps by the name.
 func matchList(name, delim, pattern string) bool {
-	// TODO: optimize
-
-	i := strings.IndexAny(pattern, "*%")
-	if i == -1 {
-		// No more wildcards
+	literals := 0
+	for i := 0; i < len(pattern); i++ {
+		if c := pattern[i]; c != '*' && c != '%' {
+			literals++
+		}
+	}
+	if literals > len(name) {
+		return false
+	}
+	if literals == len(pattern) {
 		return name == pattern
 	}
 
-	// Get parts before and after wildcard
-	chunk, wildcard, rest := pattern[0:i], pattern[i], pattern[i+1:]
+	// reach[j] reports whether the part of the pattern consumed so far matches
+	// name[:j]; next receives the same for the part including the current step.
+	n := len(name)
+	buf := make([]bool, 2*(n+1))
+	reach, next := buf[:n+1], buf[n+1:]
+	reach[0] = true
 
-	// Check that name begins with chunk
-	if len(chunk) > 0 && !strings.HasPrefix(name, chunk) {
-		return false
-	}
-	name = strings.TrimPrefix(name, chunk)
+	for i := 0; i < len(pattern); i++ {
+		c := pattern[i]
+		if c != '*' && c != '%' {
+			// A literal byte consumes exactly one byte of the name.
+			next[0] = false
+			for j := 1; j <= n; j++ {
+				next[j] = reach[j-1] && name[j-1] == c
+			}
+		} else {
+			// A run of wildcards is one wildcard: any "*" in it lets the run
+			// match anything, "%" alone still cannot span a delimiter.
+			star := c == '*'
+			for i+1 < len(pattern) && (pattern[i+1] == '*' || pattern[i+1] == '%') {
+				i++
+				star = star || pattern[i] == '*'
+			}
 
-	// Expand wildcard
-	var j int
-	for j = 0; j < len(name); j++ {
-		if wildcard == '%' && string(name[j]) == delim {
-			break // Stop on delimiter if wildcard is %
+			// The wildcard extends every reachable position to the right:
+			// next[j] is set if reach[k] is, for some k <= j whose gap
+			// name[k:j] the wildcard may absorb. acc carries that OR along j;
+			// for "%" it starts over each time a delimiter completes at j, since
+			// no earlier k can then reach past it.
+			acc := false
+			for j := 0; j <= n; j++ {
+				if !star && j >= len(delim) && len(delim) > 0 && name[j-len(delim):j] == delim {
+					acc = false
+					for k := j - len(delim) + 1; k < j; k++ {
+						acc = acc || reach[k]
+					}
+				}
+				acc = acc || reach[j]
+				next[j] = acc
+			}
 		}
-		// Try to match the rest from here
-		if matchList(name[j:], delim, rest) {
+
+		reach, next = next, reach
+		if !anyTrue(reach) {
+			return false
+		}
+	}
+	return reach[n]
+}
+
+func anyTrue(s []bool) bool {
+	for _, b := range s {
+		if b {
 			return true
 		}
 	}
-
-	return matchList(name[j:], delim, rest)
+	return false
 }

--- a/internal/listmatch.go
+++ b/internal/listmatch.go
@@ -1,0 +1,64 @@
+package internal
+
+import "strings"
+
+// MatchList checks whether a reference and a pattern matches a mailbox.
+//
+// It is used by the server to answer LIST commands, and by the client to tell
+// the LIST responses of its own command apart from unsolicited ones (which
+// NOTIFY delivers for MailboxName and SubscriptionChange events).
+func MatchList(name string, delim rune, reference, pattern string) bool {
+	var delimStr string
+	if delim != 0 {
+		delimStr = string(delim)
+	}
+
+	if delimStr != "" && strings.HasPrefix(pattern, delimStr) {
+		reference = ""
+		pattern = strings.TrimPrefix(pattern, delimStr)
+	}
+	if reference != "" {
+		if delimStr != "" && !strings.HasSuffix(reference, delimStr) {
+			reference += delimStr
+		}
+		if !strings.HasPrefix(name, reference) {
+			return false
+		}
+		name = strings.TrimPrefix(name, reference)
+	}
+
+	return matchList(name, delimStr, pattern)
+}
+
+func matchList(name, delim, pattern string) bool {
+	// TODO: optimize
+
+	i := strings.IndexAny(pattern, "*%")
+	if i == -1 {
+		// No more wildcards
+		return name == pattern
+	}
+
+	// Get parts before and after wildcard
+	chunk, wildcard, rest := pattern[0:i], pattern[i], pattern[i+1:]
+
+	// Check that name begins with chunk
+	if len(chunk) > 0 && !strings.HasPrefix(name, chunk) {
+		return false
+	}
+	name = strings.TrimPrefix(name, chunk)
+
+	// Expand wildcard
+	var j int
+	for j = 0; j < len(name); j++ {
+		if wildcard == '%' && string(name[j]) == delim {
+			break // Stop on delimiter if wildcard is %
+		}
+		// Try to match the rest from here
+		if matchList(name[j:], delim, rest) {
+			return true
+		}
+	}
+
+	return matchList(name[j:], delim, rest)
+}

--- a/internal/listmatch_test.go
+++ b/internal/listmatch_test.go
@@ -1,0 +1,151 @@
+package internal
+
+import (
+	"math/rand"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestMatchList(t *testing.T) {
+	tests := []struct {
+		name, pattern string
+		delim         rune
+		want          bool
+	}{
+		{"", "", '/', true},
+		{"", "*", '/', true},
+		{"", "%", '/', true},
+		{"", "a", '/', false},
+		{"a", "", '/', false},
+		{"INBOX", "INBOX", '/', true},
+		{"INBOX", "inbox", '/', false},
+		{"a/b/c", "*", '/', true},
+		{"a/b/c", "%", '/', false},
+		{"a/b/c", "%/%/%", '/', true},
+		{"a/b/c", "%/%", '/', false},
+		{"a/b/c", "a/%", '/', false},
+		{"a/b/c", "a/*", '/', true},
+		{"a/b/c", "*/c", '/', true},
+		{"a/b/c", "%/c", '/', false},
+		{"a/b/c", "a%/b/c", '/', true},
+		{"a/b/c", "a%b/c", '/', false},
+		{"a/b/c", "a*b/c", '/', true},
+		{"a/b/c", "*c", '/', true},
+		{"a/b/c", "%c", '/', false},
+		{"a/b/c", "***", '/', true},
+		{"a/b/c", "%%%", '/', false},
+		{"a/b/c", "%*%", '/', true},
+		{"a/b/c", "*%*", '/', true},
+		{"a/", "%/", '/', true},
+		{"a/", "%", '/', false},
+		{"/", "%", '/', false},
+		{"/", "%/%", '/', true},
+		{"//", "%/%", '/', false},
+		{"//", "%/%/%", '/', true},
+		{"abc", "a%c", '/', true},
+		{"abc", "a%b", '/', false},
+		{"abc", "%b%", '/', true},
+		{"aXbXc", "a*c", '/', true},
+		{"aXbXc", "a*b*c*", '/', true},
+		{"aXbXc", "a*d*c", '/', false},
+
+		// Without a hierarchy delimiter, "%" is "*".
+		{"a/b", "%", 0, true},
+		{"a/b", "a%b", 0, true},
+
+		// A multi-byte delimiter is a delimiter too: "%" stops at it, and a
+		// byte of it in the name is not a delimiter on its own.
+		{"a·b", "*", '·', true},
+		{"a·b", "%", '·', false},
+		{"a·b", "%·%", '·', true},
+		{"a·b", "a·%", '·', true},
+		{"a·b", "a%", '·', false},
+		{"a\xc2b", "%", '·', true}, // lone first byte of "·"
+	}
+	for _, test := range tests {
+		if got := MatchList(test.name, test.delim, "", test.pattern); got != test.want {
+			t.Errorf("MatchList(%q, %q, \"\", %q) = %v, want %v", test.name, test.delim, test.pattern, got, test.want)
+		}
+	}
+}
+
+// matchListReference is the definition of the matcher: the backtracking
+// implementation MatchList used to have, kept as the oracle for
+// TestMatchListEquivalence. It takes exponential time on adversarial patterns,
+// which is why it was replaced; on the short inputs used here it is fast.
+func matchListReference(name, delim, pattern string) bool {
+	i := strings.IndexAny(pattern, "*%")
+	if i == -1 {
+		return name == pattern
+	}
+	chunk, wildcard, rest := pattern[0:i], pattern[i], pattern[i+1:]
+	if len(chunk) > 0 && !strings.HasPrefix(name, chunk) {
+		return false
+	}
+	name = strings.TrimPrefix(name, chunk)
+	var j int
+	for j = 0; j < len(name); j++ {
+		if wildcard == '%' && string(name[j]) == delim {
+			break
+		}
+		if matchListReference(name[j:], delim, rest) {
+			return true
+		}
+	}
+	return matchListReference(name[j:], delim, rest)
+}
+
+// TestMatchListEquivalence checks the matcher against the reference on random
+// names and patterns over a small alphabet, where wildcards, literals and
+// delimiters collide as often as possible.
+func TestMatchListEquivalence(t *testing.T) {
+	const nameAlphabet = "ab/"
+	const patternAlphabet = "ab/*%"
+
+	rng := rand.New(rand.NewSource(1))
+	random := func(alphabet string, maxLen int) string {
+		b := make([]byte, rng.Intn(maxLen+1))
+		for i := range b {
+			b[i] = alphabet[rng.Intn(len(alphabet))]
+		}
+		return string(b)
+	}
+
+	for _, delim := range []string{"/", ""} {
+		for i := 0; i < 200000; i++ {
+			name, pattern := random(nameAlphabet, 8), random(patternAlphabet, 8)
+			want := matchListReference(name, delim, pattern)
+			if got := matchList(name, delim, pattern); got != want {
+				t.Fatalf("matchList(%q, %q, %q) = %v, reference says %v", name, delim, pattern, got, want)
+			}
+		}
+	}
+}
+
+// TestMatchListAdversarialPattern verifies that a pattern crafted to make a
+// backtracking matcher explode is matched in negligible time. The reference
+// implementation needs on the order of 10^15 steps for these inputs.
+func TestMatchListAdversarialPattern(t *testing.T) {
+	name := strings.Repeat("a", 200)
+	tests := []struct {
+		pattern string
+		want    bool
+	}{
+		{strings.Repeat("*a", 12) + "*b", false},
+		{strings.Repeat("%a", 12) + "%b", false},
+		{strings.Repeat("*a", 12) + "*", true},
+		{strings.Repeat("*a", 12) + "%b/", false},
+		{strings.Repeat("a*", 60) + "b", false},
+	}
+	for _, test := range tests {
+		start := time.Now()
+		got := MatchList(name, '/', "", test.pattern)
+		if elapsed := time.Since(start); elapsed > time.Second {
+			t.Errorf("MatchList(%d×a, %q) took %v", len(name), test.pattern, elapsed)
+		}
+		if got != test.want {
+			t.Errorf("MatchList(%d×a, %q) = %v, want %v", len(name), test.pattern, got, test.want)
+		}
+	}
+}

--- a/notify.go
+++ b/notify.go
@@ -17,6 +17,19 @@ const (
 	NotifyEventServerMetadataChange  NotifyEvent = "ServerMetadataChange"
 )
 
+// IsMessageEvent reports whether the event is a <message-event> as defined by
+// RFC 5465 section 8: MessageNew, MessageExpunge, FlagChange or
+// AnnotationChange. Only message events may be used with the SELECTED and
+// SELECTED-DELAYED mailbox specifiers (RFC 5465 section 6.1).
+func (event NotifyEvent) IsMessageEvent() bool {
+	switch event {
+	case NotifyEventMessageNew, NotifyEventMessageExpunge, NotifyEventFlagChange, NotifyEventAnnotationChange:
+		return true
+	default:
+		return false
+	}
+}
+
 // NotifyMailboxSpec represents a mailbox specifier RFC 5465 section 6 for the NOTIFY command.
 type NotifyMailboxSpec string
 
@@ -30,8 +43,9 @@ const (
 
 // NotifyOptions contains options for the NOTIFY command.
 type NotifyOptions struct {
-	// Status indicates that a STATUS response should be sent for new mailboxes.
-	// Only valid with Personal, Inboxes, or Subscribed mailbox specs.
+	// Status indicates that a STATUS response should be sent for each
+	// non-selected mailbox with message events enabled, before NOTIFY's
+	// tagged OK (RFC 5465 section 3.1).
 	Status bool
 
 	// Items represents the mailbox and events to monitor.
@@ -45,7 +59,9 @@ type NotifyItem struct {
 	MailboxSpec NotifyMailboxSpec
 
 	// Mailboxes is a list of specific mailboxes to monitor.
-	// Can include wildcards (*).
+	//
+	// Note that RFC 5465 section 6.6 forbids wildcard expansion: '*' and '%'
+	// have no special meaning in these names.
 	Mailboxes []string
 
 	// Subtree indicates that all mailboxes under the specified mailboxes
@@ -53,5 +69,17 @@ type NotifyItem struct {
 	Subtree bool
 
 	// Events is the list of events to monitor for these mailboxes.
+	//
+	// An empty list corresponds to the NONE event specifier (RFC 5465
+	// section 5): no events are requested for these mailboxes.
 	Events []NotifyEvent
+
+	// MessageNewFetch contains the optional fetch attributes of the
+	// MessageNew event (RFC 5465 section 5.2). When a new message appears in
+	// the selected mailbox, the server sends a FETCH response with these
+	// items following the EXISTS response.
+	//
+	// It is only valid when Events contains NotifyEventMessageNew and
+	// MailboxSpec is SELECTED or SELECTED-DELAYED.
+	MessageNewFetch *FetchOptions
 }

--- a/response.go
+++ b/response.go
@@ -51,6 +51,10 @@ const (
 
 	// APPENDLIMIT
 	ResponseCodeTooBig ResponseCode = "TOOBIG"
+
+	// NOTIFY (RFC 5465)
+	ResponseCodeNotificationOverflow ResponseCode = "NOTIFICATIONOVERFLOW"
+	ResponseCodeBadEvent             ResponseCode = "BADEVENT"
 )
 
 // StatusResponse is a generic status response.


### PR DESCRIPTION
Server-side implementation of the NOTIFY extension (RFC 5465), with the client-side encoding fixes, the imapmemserver reference backend, and the hardening that came out of three adversarial review rounds plus an independent audit.

## Library (`imapserver`)

- `SessionNotify` interface: `SetNotify` installs/replaces/clears the watch (structural validation of event groups, single SELECTED group, fetch-atts placement done by the library; BADEVENT via `UnsupportedNotifyEventError`), `NotifyPoll` runs on a dedicated pump goroutine, serialized with command output.
- RFC 5465 §3.1 semantics enforced at the connection level: once NOTIFY is used, message events for the selected mailbox are reported only if requested with SELECTED/SELECTED-DELAYED (omitting it == SELECTED NONE); the per-command sync point is skipped accordingly, with EXPUNGE/UID EXPUNGE exempt (their untagged EXPUNGEs are command response data, RFC 9051 §6.4.3 / RFC 4315 §2.1).
- Pump lifecycle: fenced across SELECT/EXAMINE/UNSELECT/CLOSE and UNAUTHENTICATE so no cross-mailbox delivery race exists; 30s stop guard mirroring IDLE; a pump that dies on a live connection tears the connection down instead of failing silently.
- `NOTIFY SET STATUS` initial STATUS responses; NOTIFICATIONOVERFLOW (§5.8) with a documented deviation: after the overflow the connection returns to pre-NOTIFY delivery so the queue drains, rather than staying frozen forever.
- MessageNew fetch-atts (§5.2): `SessionTracker.PollWith` holds the delivery lock across the follow-up FETCH writes so sequence numbers cannot be renumbered mid-batch; unsolicited METADATA responses carry entry names only (RFC 5464 §4.4).
- NOTIFY SET watch size bounded (64 groups × 256 mailboxes), parsed to completion and refused with NOTIFICATIONOVERFLOW so the stream stays in sync.
- Wire decoder: non-synchronizing literal recovery after command errors — abandoned literal octets are drained (≤64KiB) so the next command never starts inside client data; anything unaccountable marks the stream desynchronized and the connection ends with BYE instead of guessing.

## Audit follow-ups (last three commits)

- `internal`: the recursive LIST pattern matcher was exponential on wildcard-heavy patterns (21s for one match on a 60-char name; nothing bounds name length or patterns per LIST, and imapmemserver matches under the user mutex). Replaced with an O(n²) DP; equivalence-tested against the old matcher on ~1.3M random inputs.
- `imapserver`: under NOTIFY NONE the suppressed update queue of the selected mailbox grew without bound — no sync point flushes it and the pump never ran to check it. The pump now runs for NOTIFY NONE too, so the backend can watch `SessionTracker.QueuedUpdates` and declare an overflow; imapmemserver does, and an in-progress IDLE takes delivery back afterwards. Also fixes a pre-existing lost-wakeup in `SessionTracker.Idle`.
- `imapclient`: documented STATUS/LIST absorption by in-flight commands on `UnilateralDataHandler` (Fetch already was).

## Testing

`go test -race ./...` green across all packages. ~25 new tests: raw-wire NOTIFY tests (syntax, SELECTED filtering, self-event suppression, metadata events, expunge command responses, oversized watches, pump fencing across SELECT, overflow + resume incl. during IDLE, SELECTED-DELAYED release in IDLE, literal recovery), client/server integration tests, and the matcher suite.
