### PR TITLE
imapserver: make Shutdown release idle connections with BYE

### DIFF
--- a/imapserver/conn.go
+++ b/imapserver/conn.go
@@ -81,6 +81,14 @@ type Conn struct {
 	state   imap.ConnState
 	session Session
 
+	// idle is true while the connection has nothing in flight and is blocked
+	// waiting for client input: between commands, or inside IDLE waiting for
+	// DONE. shuttingDown is set by Server.Shutdown and means "send BYE and exit
+	// at the next idle point -- or now, if already idle". Both are guarded by
+	// mutex; see setIdle, setActive and requestShutdown for the protocol.
+	idle         bool
+	shuttingDown bool
+
 	// selectedReadOnly is true when the selected mailbox is read-only, either
 	// because it was opened with EXAMINE or because the session reported it
 	// read-only (RFC 4314 §5.2). Only touched from the command-loop goroutine,
@@ -158,6 +166,61 @@ func (c *Conn) enabledHas(cap imap.Cap) bool {
 // though blocking Session methods already receive it as their first argument.
 func (c *Conn) Context() context.Context {
 	return c.ctx
+}
+
+// errShutdown is returned by a command handler that was parked waiting for
+// client input when Server.Shutdown asked the connection to finish. It carries
+// no tagged response: the serve loop answers it with BYE and exits.
+var errShutdown = errors.New("imapserver: server shutting down")
+
+// setIdle records that the connection is about to block waiting for client
+// input with nothing in flight, and reports whether it may. False means
+// Shutdown has already asked this connection to finish, so the caller should
+// send BYE now instead of waiting.
+//
+// setIdle, setActive and requestShutdown together make the idle/active
+// decision atomic with the transition. That is what keeps a BYE from ever
+// landing in the middle of a response: Shutdown only wakes a connection it has
+// seen idle under the mutex, and a connection only starts processing input
+// after re-checking under the same mutex that Shutdown has not spoken.
+func (c *Conn) setIdle() bool {
+	c.mutex.Lock()
+	defer c.mutex.Unlock()
+	if c.shuttingDown {
+		return false
+	}
+	c.idle = true
+	return true
+}
+
+// setActive records that the wait for client input is over and reports
+// whether the input may be processed. False means Shutdown asked the
+// connection to finish while it was waiting; whatever arrived is dropped in
+// favour of BYE, exactly as if it had arrived after the connection closed.
+func (c *Conn) setActive() bool {
+	c.mutex.Lock()
+	defer c.mutex.Unlock()
+	c.idle = false
+	return !c.shuttingDown
+}
+
+// requestShutdown asks the connection to finish gracefully. An idle
+// connection is woken so it can send BYE right away; an active one will do so
+// once its current command completes.
+//
+// Shutdown never writes to the connection itself. The serve goroutine owns
+// every byte of output including the BYE, so response ordering needs no
+// further coordination.
+func (c *Conn) requestShutdown() {
+	c.mutex.Lock()
+	defer c.mutex.Unlock()
+	c.shuttingDown = true
+	if c.idle {
+		// Interrupt the blocked read. The serve goroutine re-arms the deadline
+		// before every read it makes after this, so a deadline in the past
+		// cannot leak into a later command.
+		c.conn.SetReadDeadline(time.Now())
+	}
 }
 
 func (c *Conn) serve() {
@@ -249,6 +312,10 @@ func (c *Conn) serve() {
 		return
 	}
 
+	// byeOnExit is set when the loop ends because Server.Shutdown asked it to,
+	// at a point where nothing is in flight. Every other way out -- LOGOUT,
+	// client EOF, a protocol error -- has already said what it needed to say.
+	byeOnExit := false
 	for {
 		var readTimeout time.Duration
 		switch c.state {
@@ -265,12 +332,32 @@ func (c *Conn) serve() {
 
 		dec.QuotedUTF8 = c.useQuotedUTF8()
 
-		if c.state == imap.ConnStateLogout || dec.EOF() {
+		if c.state == imap.ConnStateLogout {
+			break
+		}
+
+		// Between commands: nothing is in flight, so a shutdown request is
+		// honoured immediately, and one that arrives while we are blocked
+		// below wakes the read and is honoured on the way out.
+		if !c.setIdle() {
+			byeOnExit = true
+			break
+		}
+		eof := dec.EOF()
+		if !c.setActive() {
+			byeOnExit = !eof
+			break
+		}
+		if eof {
 			break
 		}
 
 		c.setReadTimeout(cmdReadTimeout)
 		if err := c.readCommand(dec); err != nil {
+			if errors.Is(err, errShutdown) {
+				byeOnExit = true
+				break
+			}
 			var imapErr *imap.Error
 			if !isConnectionClosedError(err) && !(errors.As(err, &imapErr) && imapErr.Type == imap.StatusResponseTypeBye) {
 				c.server.logger().Printf("failed to read command (remote %v): %v", c.conn.RemoteAddr(), err)
@@ -278,6 +365,55 @@ func (c *Conn) serve() {
 			break
 		}
 	}
+
+	if byeOnExit {
+		c.shutdownBye()
+	}
+}
+
+// shutdownLingerTimeout bounds how long shutdownBye waits for the client to
+// close its side after the BYE. Same idea and order of magnitude as net/http's
+// rstAvoidanceDelay.
+const shutdownLingerTimeout = 500 * time.Millisecond
+
+// shutdownBye announces the shutdown (RFC 9051 §7.1.5) and closes the
+// connection cleanly.
+//
+// Cleanly is the operative word. When a command races the shutdown it is
+// dropped unread, and closing a socket with unread input in its receive queue
+// sends RST rather than FIN. The client would then see the BYE followed by
+// "connection reset" instead of EOF -- or on some stacks not see the BYE at
+// all, since RST can discard data still in flight. So after the BYE we
+// half-close, which hands the client a clean EOF right behind the BYE, then
+// drain whatever it sent until it closes its side or the linger timeout runs
+// out. Only then does the deferred Close in serve run, with nothing left in the
+// receive queue to provoke an RST.
+//
+// Best effort throughout: the client may already be gone, every step is
+// bounded by a deadline, and Shutdown's own context force-closes anything that
+// outlives the grace period.
+func (c *Conn) shutdownBye() {
+	if err := c.writeStatusResp("", &imap.StatusResponse{
+		Type: imap.StatusResponseTypeBye,
+		Text: "Server shutting down",
+	}); err != nil {
+		if !isConnectionClosedError(err) {
+			c.server.logger().Printf("failed to write shutdown BYE (remote %v): %v", c.conn.RemoteAddr(), err)
+		}
+		return
+	}
+
+	// Read c.conn under the mutex: STARTTLS reassigns it and forceCloseConns
+	// closes it from other goroutines.
+	c.mutex.Lock()
+	conn := c.conn
+	c.mutex.Unlock()
+
+	if cw, ok := conn.(interface{ CloseWrite() error }); ok {
+		cw.CloseWrite()
+	}
+	conn.SetReadDeadline(time.Now().Add(shutdownLingerTimeout))
+	io.Copy(io.Discard, c.br)
 }
 
 func (c *Conn) readCommand(dec *imapwire.Decoder) (err error) {
@@ -423,6 +559,12 @@ func (c *Conn) readCommand(dec *imapwire.Decoder) (err error) {
 			Type: imap.StatusResponseTypeBad,
 			Text: "Unknown command",
 		}
+	}
+
+	// A handler that was parked in an idle wait when Shutdown arrived has no
+	// tagged response to give; the serve loop answers with BYE.
+	if errors.Is(err, errShutdown) {
+		return err
 	}
 
 	dec.DiscardLine()

--- a/imapserver/idle.go
+++ b/imapserver/idle.go
@@ -52,9 +52,37 @@ func (c *Conn) handleIdle(dec *imapwire.Decoder) error {
 		done <- c.session.Idle(c.ctx, w, stop)
 	}()
 
+	// awaitBackend waits for the backend's Idle to return after stop is closed,
+	// bounded so a backend that ignores stop cannot leak this goroutine.
+	awaitBackend := func() error {
+		timer := time.NewTimer(30 * time.Second)
+		defer timer.Stop()
+		select {
+		case err := <-done:
+			return err
+		case <-timer.C:
+			c.server.logger().Printf("IDLE backend did not return within 30s after stop; goroutine leaked")
+			return fmt.Errorf("imapserver: IDLE backend did not respond to stop")
+		}
+	}
+
+	// Waiting for DONE is an idle point: the client is parked and nothing is in
+	// flight, so Server.Shutdown may end the IDLE here rather than wait up to
+	// the idle timeout for a DONE that is not coming. It does so with a plain
+	// BYE and no tagged completion, which is all it has to say.
 	c.setReadTimeout(idleReadTimeout)
+	if !c.setIdle() {
+		close(stop)
+		awaitBackend()
+		return errShutdown
+	}
 	line, isPrefix, err := c.br.ReadLine()
+	active := c.setActive()
 	close(stop)
+	if !active {
+		awaitBackend()
+		return errShutdown
+	}
 	if err == io.EOF {
 		return nil
 	} else if err != nil {
@@ -63,15 +91,5 @@ func (c *Conn) handleIdle(dec *imapwire.Decoder) error {
 		return newClientBugError("Syntax error: expected DONE to end IDLE command")
 	}
 
-	// Wait for backend to return, with timeout to prevent goroutine leak.
-	// Stop the timer on the normal path so it doesn't linger until it fires.
-	timer := time.NewTimer(30 * time.Second)
-	defer timer.Stop()
-	select {
-	case err := <-done:
-		return err
-	case <-timer.C:
-		c.server.logger().Printf("IDLE backend did not return within 30s after stop; goroutine leaked")
-		return fmt.Errorf("imapserver: IDLE backend did not respond to stop")
-	}
+	return awaitBackend()
 }

--- a/imapserver/server.go
+++ b/imapserver/server.go
@@ -272,21 +272,34 @@ func (s *Server) Close() error {
 	return err
 }
 
-// Shutdown gracefully shuts down the server without interrupting any
-// active connections. Shutdown works by first closing all open listeners,
-// then waiting for all connections to close or the context to expire,
-// whichever comes first.
+// Shutdown gracefully shuts down the server without interrupting any active
+// connections. It first closes all open listeners, then sends BYE to and
+// closes every idle connection, then waits for active connections to finish
+// their current command -- after which they too are sent BYE and closed -- or
+// for the context to expire, whichever comes first.
 //
-// When Shutdown is called, Serve immediately returns. Make sure the
-// program doesn't exit and waits instead for Shutdown to return.
+// A connection is idle when it has nothing in flight: it is waiting for its
+// next command, or is parked in IDLE. Ending it costs the client nothing but a
+// reconnect, so it is not waited for. A connection is active while a command
+// is being processed; that command runs to completion and its tagged response
+// is delivered before the BYE.
+//
+// When Shutdown is called, Serve immediately returns. Make sure the program
+// doesn't exit and waits instead for Shutdown to return.
 //
 // If the provided context expires before the shutdown completes, Shutdown
 // force-closes any remaining connections and returns the context's error.
-// Otherwise it returns nil.
+// Otherwise it returns nil. Since idle connections are released immediately,
+// the context only has to cover a single command's worst case, not the
+// lifetime of an idle client.
 //
 // Once Shutdown has been called on a server, it may not be reused.
 func (s *Server) Shutdown(ctx context.Context) error {
-	// 1. Stop accepting new connections
+	// 1. Stop accepting new connections, and ask every existing connection to
+	// finish. Idle connections are woken and send BYE right away; active ones
+	// do so once their command completes. Both happen on the connection's own
+	// goroutine -- Shutdown never writes to a connection -- so a BYE can never
+	// interleave with a response.
 	s.mutex.Lock()
 	if s.closed {
 		s.mutex.Unlock()
@@ -298,6 +311,9 @@ func (s *Server) Shutdown(ctx context.Context) error {
 		if err := l.Close(); err != nil && listenerErr == nil {
 			listenerErr = err
 		}
+	}
+	for c := range s.conns {
+		c.requestShutdown()
 	}
 	s.mutex.Unlock()
 

--- a/imapserver/shutdown_test.go
+++ b/imapserver/shutdown_test.go
@@ -1,0 +1,500 @@
+package imapserver_test
+
+import (
+	"bufio"
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/emersion/go-imap/v2"
+	"github.com/emersion/go-imap/v2/imapserver"
+	"github.com/emersion/go-imap/v2/imapserver/imapmemserver"
+)
+
+// These tests speak IMAP over a raw socket rather than through imapclient, so
+// they can assert the exact lines the server writes and the order they arrive
+// in. Graceful shutdown is all about that ordering.
+//
+// Clients here behave like real ones on BYE: they read to EOF and close their
+// side. That is what lets Shutdown return promptly, and the tests assert that
+// it does.
+
+const shutdownBye = "* BYE Server shutting down"
+
+// promptly is how long Shutdown may take when nothing is genuinely in flight.
+// The real figure is milliseconds; the slack is for -race and loaded CI. It is
+// well under every grace period used below, so a Shutdown that waited out the
+// grace period cannot pass.
+const promptly = time.Second
+
+// gateSession embeds a real in-memory session and makes Select controllable:
+// it blocks until released, then delegates. Leaving it unreleased models a
+// backend that is genuinely stuck.
+type gateSession struct {
+	*imapmemserver.UserSession
+	selectStarted chan struct{} // closed when Select is entered
+	release       chan struct{} // close to let Select proceed
+	ctxErr        chan error    // receives ctx.Err() if the context ends first
+}
+
+func newGateSession(user *imapmemserver.User) *gateSession {
+	return &gateSession{
+		UserSession:   imapmemserver.NewUserSession(user),
+		selectStarted: make(chan struct{}),
+		release:       make(chan struct{}),
+		ctxErr:        make(chan error, 1),
+	}
+}
+
+func (s *gateSession) Select(ctx context.Context, mailbox string, options *imap.SelectOptions) (*imap.SelectData, error) {
+	close(s.selectStarted)
+	select {
+	case <-s.release:
+		return s.UserSession.Select(ctx, mailbox, options)
+	case <-ctx.Done():
+		s.ctxErr <- ctx.Err()
+		return nil, ctx.Err()
+	}
+}
+
+// shutdownTestServer is a server with one user, INBOX created, listening on
+// loopback.
+type shutdownTestServer struct {
+	server *imapserver.Server
+	addr   string
+}
+
+func newShutdownTestServer(t *testing.T, newSession func() imapserver.Session) *shutdownTestServer {
+	t.Helper()
+
+	server := imapserver.New(&imapserver.Options{
+		NewSession: func(*imapserver.Conn) (imapserver.Session, *imapserver.GreetingData, error) {
+			return newSession(), nil, nil
+		},
+		InsecureAuth: true,
+		Caps:         imap.CapSet{imap.CapIMAP4rev1: {}, imap.CapIMAP4rev2: {}},
+	})
+
+	ln, err := net.Listen("tcp", "localhost:0")
+	if err != nil {
+		t.Fatalf("net.Listen() = %v", err)
+	}
+	go server.Serve(ln)
+	t.Cleanup(func() { server.Close() })
+
+	return &shutdownTestServer{server: server, addr: ln.Addr().String()}
+}
+
+func newTestUser(t *testing.T) *imapmemserver.User {
+	t.Helper()
+	user := imapmemserver.NewUser("user", "pass")
+	if err := user.Create(context.Background(), "INBOX", nil); err != nil {
+		t.Fatalf("Create() = %v", err)
+	}
+	return user
+}
+
+// wireConn is a hand-driven IMAP client.
+type wireConn struct {
+	conn net.Conn
+	br   *bufio.Reader
+	tag  int
+}
+
+func dialWire(t *testing.T, addr string) *wireConn {
+	t.Helper()
+	conn, err := net.Dial("tcp", addr)
+	if err != nil {
+		t.Fatalf("net.Dial() = %v", err)
+	}
+	t.Cleanup(func() { conn.Close() })
+	wc := &wireConn{conn: conn, br: bufio.NewReader(conn)}
+	line, err := wc.readLine()
+	if err != nil {
+		t.Fatalf("reading greeting: %v", err)
+	}
+	if !strings.HasPrefix(line, "* OK") {
+		t.Fatalf("greeting = %q, want * OK", line)
+	}
+	return wc
+}
+
+// readLine returns the next line without CRLF. Every read is bounded so a
+// server that goes quiet fails the test instead of hanging it.
+func (wc *wireConn) readLine() (string, error) {
+	wc.conn.SetReadDeadline(time.Now().Add(5 * time.Second))
+	line, err := wc.br.ReadString('\n')
+	if err != nil {
+		return "", fmt.Errorf("reading from server: %w (partial %q)", err, line)
+	}
+	return strings.TrimRight(line, "\r\n"), nil
+}
+
+// send writes a tagged command and returns its tag.
+func (wc *wireConn) send(t *testing.T, cmd string) string {
+	t.Helper()
+	wc.tag++
+	tag := fmt.Sprintf("A%d", wc.tag)
+	if _, err := io.WriteString(wc.conn, tag+" "+cmd+"\r\n"); err != nil {
+		t.Fatalf("writing %q: %v", cmd, err)
+	}
+	return tag
+}
+
+// waitTagged reads lines until the tagged completion for tag, returning every
+// line read (the tagged one last).
+func (wc *wireConn) waitTagged(tag string) ([]string, error) {
+	var lines []string
+	for {
+		line, err := wc.readLine()
+		if err != nil {
+			return lines, err
+		}
+		lines = append(lines, line)
+		if strings.HasPrefix(line, tag+" ") {
+			return lines, nil
+		}
+	}
+}
+
+func (wc *wireConn) mustOK(t *testing.T, cmd string) {
+	t.Helper()
+	tag := wc.send(t, cmd)
+	lines, err := wc.waitTagged(tag)
+	if err != nil {
+		t.Fatalf("%s: %v", cmd, err)
+	}
+	if last := lines[len(lines)-1]; !strings.HasPrefix(last, tag+" OK") {
+		t.Fatalf("%s: got %q, want %s OK", cmd, last, tag)
+	}
+}
+
+func (wc *wireConn) login(t *testing.T) {
+	t.Helper()
+	wc.mustOK(t, `LOGIN "user" "pass"`)
+}
+
+// awaitBye is what a client does when the server shuts down: it expects the
+// very next line to be the BYE, then a clean EOF, and then closes its side. It
+// returns an error describing the first deviation. Safe to call from a
+// goroutine, which is how the tests use it: the client must be reading while
+// Shutdown runs, or Shutdown would be waiting on a client that never answers.
+func (wc *wireConn) awaitBye() error {
+	line, err := wc.readLine()
+	if err != nil {
+		return fmt.Errorf("waiting for BYE: %w", err)
+	}
+	if line != shutdownBye {
+		return fmt.Errorf("after shutdown got %q, want %q", line, shutdownBye)
+	}
+	wc.conn.SetReadDeadline(time.Now().Add(5 * time.Second))
+	if _, err := wc.br.ReadByte(); err != io.EOF {
+		return fmt.Errorf("after BYE got %v, want a clean EOF", err)
+	}
+	return wc.conn.Close()
+}
+
+type shutdownResult struct {
+	err     error
+	elapsed time.Duration
+}
+
+// shutdownAsync runs Shutdown with the given grace period.
+func shutdownAsync(server *imapserver.Server, grace time.Duration) <-chan shutdownResult {
+	ch := make(chan shutdownResult, 1)
+	go func() {
+		ctx, cancel := context.WithTimeout(context.Background(), grace)
+		defer cancel()
+		start := time.Now()
+		err := server.Shutdown(ctx)
+		ch <- shutdownResult{err: err, elapsed: time.Since(start)}
+	}()
+	return ch
+}
+
+func checkPrompt(t *testing.T, r shutdownResult, what string) {
+	t.Helper()
+	if r.err != nil {
+		t.Errorf("Shutdown() = %v after %v, want nil: %s", r.err, r.elapsed.Round(time.Millisecond), what)
+	}
+	if r.elapsed > promptly {
+		t.Errorf("Shutdown() took %v, want under %v: %s", r.elapsed.Round(time.Millisecond), promptly, what)
+	}
+}
+
+// TestShutdownByesIdleConnections: a connection waiting for its next command
+// has nothing in flight, so Shutdown must not wait for it. It gets BYE at once
+// and Shutdown returns nil well inside the grace period.
+//
+// Before the fix nothing woke the idle read, so Shutdown burned the whole grace
+// period and returned context.DeadlineExceeded on every routine restart.
+func TestShutdownByesIdleConnections(t *testing.T) {
+	user := newTestUser(t)
+	srv := newShutdownTestServer(t, func() imapserver.Session { return imapmemserver.NewUserSession(user) })
+
+	// One idle in every state a connection can be idle in.
+	notAuthed := dialWire(t, srv.addr)
+	authed := dialWire(t, srv.addr)
+	authed.login(t)
+	selected := dialWire(t, srv.addr)
+	selected.login(t)
+	selected.mustOK(t, "SELECT INBOX")
+
+	conns := map[string]*wireConn{"not authenticated": notAuthed, "authenticated": authed, "selected": selected}
+	byeErrs := make(chan error, len(conns))
+	for name, wc := range conns {
+		go func(name string, wc *wireConn) {
+			if err := wc.awaitBye(); err != nil {
+				byeErrs <- fmt.Errorf("%s connection: %w", name, err)
+				return
+			}
+			byeErrs <- nil
+		}(name, wc)
+	}
+
+	checkPrompt(t, <-shutdownAsync(srv.server, 5*time.Second), "only idle connections were open")
+	for range conns {
+		if err := <-byeErrs; err != nil {
+			t.Error(err)
+		}
+	}
+}
+
+// TestShutdownWaitsForActiveCommand: a connection in the middle of a command
+// is genuinely active. Shutdown must let the command finish, deliver its tagged
+// completion, and only then send BYE -- and must not wait one moment longer.
+func TestShutdownWaitsForActiveCommand(t *testing.T) {
+	user := newTestUser(t)
+	gate := newGateSession(user)
+	srv := newShutdownTestServer(t, func() imapserver.Session { return gate })
+
+	wc := dialWire(t, srv.addr)
+	wc.login(t)
+	tag := wc.send(t, "SELECT INBOX")
+	select {
+	case <-gate.selectStarted:
+	case <-time.After(5 * time.Second):
+		t.Fatal("SELECT never reached the backend")
+	}
+
+	// The client reads throughout: the command's responses, then BYE. A BYE
+	// anywhere before the tagged line means the response stream was torn.
+	clientErr := make(chan error, 1)
+	go func() {
+		lines, err := wc.waitTagged(tag)
+		if err != nil {
+			clientErr <- err
+			return
+		}
+		for _, line := range lines {
+			if strings.HasPrefix(line, "* BYE") {
+				clientErr <- fmt.Errorf("BYE arrived before the tagged completion; response stream torn:\n%s", strings.Join(lines, "\n"))
+				return
+			}
+		}
+		if last := lines[len(lines)-1]; !strings.HasPrefix(last, tag+" OK") {
+			clientErr <- fmt.Errorf("SELECT completion = %q, want %s OK", last, tag)
+			return
+		}
+		clientErr <- wc.awaitBye()
+	}()
+
+	res := shutdownAsync(srv.server, 5*time.Second)
+
+	// While the command is in flight Shutdown must be waiting, not done.
+	select {
+	case r := <-res:
+		t.Fatalf("Shutdown() returned (%v) while a command was still running", r.err)
+	case <-time.After(300 * time.Millisecond):
+	}
+
+	close(gate.release)
+
+	r := <-res
+	checkPrompt(t, r, "the command was released and finished")
+	if err := <-clientErr; err != nil {
+		t.Error(err)
+	}
+}
+
+// TestShutdownEndsIdleCommand: an RFC 2177 IDLE has no work in flight either;
+// the client is just parked. Shutdown ends it with BYE immediately rather than
+// waiting up to the idle timeout for a DONE that is not coming.
+func TestShutdownEndsIdleCommand(t *testing.T) {
+	user := newTestUser(t)
+	srv := newShutdownTestServer(t, func() imapserver.Session { return imapmemserver.NewUserSession(user) })
+
+	wc := dialWire(t, srv.addr)
+	wc.login(t)
+	wc.mustOK(t, "SELECT INBOX")
+	tag := wc.send(t, "IDLE")
+	line, err := wc.readLine()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.HasPrefix(line, "+ ") {
+		t.Fatalf("IDLE continuation = %q, want +", line)
+	}
+
+	clientErr := make(chan error, 1)
+	go func() {
+		// No tagged completion for the IDLE: the server is ending the
+		// session, and BYE is the whole of what it has to say.
+		line, err := wc.readLine()
+		if err != nil {
+			clientErr <- err
+			return
+		}
+		if strings.HasPrefix(line, tag+" ") {
+			clientErr <- fmt.Errorf("got a tagged response %q to an IDLE ended by shutdown, want only %q", line, shutdownBye)
+			return
+		}
+		if line != shutdownBye {
+			clientErr <- fmt.Errorf("after shutdown got %q, want %q", line, shutdownBye)
+			return
+		}
+		wc.conn.SetReadDeadline(time.Now().Add(5 * time.Second))
+		if _, err := wc.br.ReadByte(); err != io.EOF {
+			clientErr <- fmt.Errorf("after BYE got %v, want a clean EOF", err)
+			return
+		}
+		clientErr <- wc.conn.Close()
+	}()
+
+	checkPrompt(t, <-shutdownAsync(srv.server, 5*time.Second), "only an IDLE connection was open")
+	if err := <-clientErr; err != nil {
+		t.Error(err)
+	}
+}
+
+// TestShutdownDoesNotWaitForClientClose: a client that reads the BYE but never
+// closes its side must not hold Shutdown hostage. The lingering close is
+// bounded, so Shutdown still returns nil well inside the grace period.
+func TestShutdownDoesNotWaitForClientClose(t *testing.T) {
+	user := newTestUser(t)
+	srv := newShutdownTestServer(t, func() imapserver.Session { return imapmemserver.NewUserSession(user) })
+
+	wc := dialWire(t, srv.addr)
+	wc.login(t)
+	// Deliberately no reader and no close: the connection just sits there.
+
+	const grace = 5 * time.Second
+	r := <-shutdownAsync(srv.server, grace)
+	if r.err != nil {
+		t.Errorf("Shutdown() = %v, want nil: the client not closing is not the server's problem", r.err)
+	}
+	if r.elapsed > grace/2 {
+		t.Errorf("Shutdown() took %v, want well under the %v grace period: the linger must be bounded", r.elapsed.Round(time.Millisecond), grace)
+	}
+
+	// The BYE was still delivered, and the connection was closed cleanly.
+	if err := wc.awaitBye(); err != nil {
+		t.Error(err)
+	}
+}
+
+// TestShutdownForceClosesStuckCommand is the guard for the backstop: a backend
+// that never returns still gets force-closed when the grace period runs out,
+// and Shutdown reports it. Graceful must not mean unbounded.
+func TestShutdownForceClosesStuckCommand(t *testing.T) {
+	user := newTestUser(t)
+	gate := newGateSession(user) // never released
+	srv := newShutdownTestServer(t, func() imapserver.Session { return gate })
+
+	wc := dialWire(t, srv.addr)
+	wc.login(t)
+	wc.send(t, "SELECT INBOX")
+	select {
+	case <-gate.selectStarted:
+	case <-time.After(5 * time.Second):
+		t.Fatal("SELECT never reached the backend")
+	}
+
+	r := <-shutdownAsync(srv.server, 300*time.Millisecond)
+	if !errors.Is(r.err, context.DeadlineExceeded) {
+		t.Fatalf("Shutdown() = %v, want context.DeadlineExceeded for a stuck command", r.err)
+	}
+	select {
+	case err := <-gate.ctxErr:
+		if !errors.Is(err, context.Canceled) {
+			t.Errorf("stuck backend saw ctx.Err() = %v, want Canceled", err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("stuck backend's context was never cancelled by the force-close")
+	}
+}
+
+// TestShutdownCommandRacingBye hammers the one genuinely racy window: a client
+// sends a command at the same instant Shutdown decides its connection is idle.
+// Either outcome is legal -- the command completes and then BYE, or the command
+// is dropped and BYE is all the client sees -- but the stream must never tear:
+// exactly one BYE, always last, nothing after it, and a clean EOF rather than a
+// reset. Both outcomes occur in practice; the assertion is the invariant, not
+// the outcome.
+func TestShutdownCommandRacingBye(t *testing.T) {
+	const rounds = 40
+	for i := 0; i < rounds; i++ {
+		user := newTestUser(t)
+		srv := newShutdownTestServer(t, func() imapserver.Session { return imapmemserver.NewUserSession(user) })
+
+		wc := dialWire(t, srv.addr)
+		wc.login(t)
+
+		var wg sync.WaitGroup
+		wg.Add(2)
+		go func() {
+			defer wg.Done()
+			io.WriteString(wc.conn, "A9 NOOP\r\n")
+		}()
+		go func() {
+			defer wg.Done()
+			ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+			defer cancel()
+			if err := srv.server.Shutdown(ctx); err != nil {
+				t.Errorf("round %d: Shutdown() = %v", i, err)
+			}
+		}()
+
+		// Drain to EOF and inspect. A reset instead of EOF is a failure: it
+		// means the server closed with the racing command unread.
+		var lines []string
+		wc.conn.SetReadDeadline(time.Now().Add(5 * time.Second))
+		for {
+			line, err := wc.br.ReadString('\n')
+			if line != "" {
+				lines = append(lines, strings.TrimRight(line, "\r\n"))
+			}
+			if err != nil {
+				if err != io.EOF {
+					t.Fatalf("round %d: read error %v; lines so far %q", i, err, lines)
+				}
+				break
+			}
+		}
+		wc.conn.Close()
+		wg.Wait()
+
+		byes := 0
+		for j, line := range lines {
+			switch {
+			case line == shutdownBye:
+				byes++
+				if j != len(lines)-1 {
+					t.Fatalf("round %d: BYE was not the last line: %q", i, lines)
+				}
+			case strings.HasPrefix(line, "A9 OK"):
+			default:
+				t.Fatalf("round %d: unexpected line %q in %q", i, line, lines)
+			}
+		}
+		if byes != 1 {
+			t.Fatalf("round %d: saw %d BYE lines, want exactly 1: %q", i, byes, lines)
+		}
+	}
+}


### PR DESCRIPTION
Surfaced while reviewing [emersion/go-imap#665](https://github.com/emersion/go-imap/pull/665) (Server.Shutdown). sora already had `Shutdown(ctx)`, ahead of upstream — but with one step missing that made it return `ctx.Err()` on every routine restart.

## The gap

`Shutdown`'s doc comment is the `net/http.Server.Shutdown` contract — *close listeners, close idle connections, wait for active ones* — but the implementation skipped the middle step. It waited on `connsWaitGroup` for **every** connection, and a connection blocked in `dec.EOF()` waiting for its next command, or in IDLE waiting for `DONE`, sits there for up to the 35-minute idle timeout. Nothing woke it.

Most IMAP connections are idle at any moment and IDLE ones are long-lived by design, so the effect was: every routine restart burned the **whole** grace period, force-closed everything without a word, and returned `context.DeadlineExceeded`.

## The fix — the `net/http` model, with IMAP's definition of idle

**Idle** = nothing in flight: waiting for the next command, or parked in IDLE. **Active** = a command is being processed.

On `Shutdown(ctx)`:
- Idle connections are woken and send `* BYE Server shutting down` **at once** (RFC 9051 §7.1.5 names BYE as the shutdown announcement).
- Active connections **finish their command**, deliver the tagged completion, and only then send BYE.
- The force-close on context expiry is unchanged — and now means what it says: a command genuinely overran the grace period.

Two properties worth calling out:

**Shutdown never writes to a connection.** It flags and wakes; the serve goroutine owns every byte of output including the BYE. So a BYE cannot interleave with a response, and there are no cross-goroutine lock-ordering questions.

**The idle/active decision is atomic with the transition**, under the connection mutex the loop already holds. Shutdown only wakes a connection it has seen idle there (by expiring the read deadline), and a connection only starts processing input after re-checking there that Shutdown hasn't spoken. If a command lands in that window it is dropped and the client gets BYE — indistinguishable to the client from the command having arrived after the close.

## A second bug the stress test caught

That dropped command exposed something the design alone would not have: closing a socket with **unread input in its receive queue sends RST, not FIN**. The client saw `* BYE` and then `connection reset by peer` instead of EOF — and on some stacks an RST can discard the BYE before it is read.

This is exactly what `net/http`'s lingering close (`rstAvoidanceDelay`) exists for, so `shutdownBye` does the same: after the BYE it **half-closes** (the client reads BYE then a clean EOF), then **drains** until the client closes its side or a 500 ms linger expires. A client that never closes costs Shutdown at most that linger, never the grace period.

## What changes for clients

Strictly better, not different in kind. Idle clients get an announced BYE in milliseconds instead of an unannounced socket close after the full grace period. Every real MUA handles BYE-and-reconnect — it's what Dovecot does on every restart. Mid-command clients get their command completed, then BYE, where before they could be cut off mid-response at expiry.

**Grace period:** after this, `ctx` only needs to cover one command's worst case, not the lifetime of an idle client. 10–15 s is plenty; minutes is no longer necessary.

**Not adopting #665's approach:** a goroutine per loop iteration selecting on a shutdown channel leaks the reader goroutine when shutdown wins the select, and sends no BYE.

## Tests

Raw-socket clients so exact lines and their order can be asserted. Clients behave like real ones on BYE — read to EOF, close — which is what lets Shutdown return promptly, and the tests assert that it does.

| Test | Asserts | Time |
|---|---|---|
| `ByesIdleConnections` | idle in every state (not-auth / auth / selected) gets BYE + clean EOF; Shutdown nil | 0.00 s |
| `WaitsForActiveCommand` | Shutdown still pending at 300 ms while a Fetch is gated; tagged `OK` **before** BYE; returns nil the moment the command completes | 0.30 s |
| `EndsIdleCommand` | IDLE gets BYE and **no** tagged line | 0.00 s |
| `DoesNotWaitForClientClose` | a client that reads BYE but never closes cannot hold Shutdown past the linger | 0.50 s |
| `ForceClosesStuckCommand` | backstop intact: `DeadlineExceeded`, backend's ctx cancelled | 0.30 s |
| `CommandRacingBye` | 40 rounds of NOOP racing the shutdown decision: exactly one BYE, always last, always followed by **EOF not RST**; both outcomes occur | 0.04 s |

Red (fix reverted, tests kept):
```
FAIL: TestShutdownByesIdleConnections (5.00s)   Shutdown() = context deadline exceeded ...
FAIL: TestShutdownWaitsForActiveCommand (5.00s)
FAIL: TestShutdownEndsIdleCommand (5.00s)
FAIL: TestShutdownDoesNotWaitForClientClose (5.00s)
FAIL: TestShutdownCommandRacingBye (5.00s)
```

**Every component is independently discriminated:** with only the linger reverted, the race test fails 3/3 on the RST; with only the IDLE handling reverted, the IDLE test burns the grace period; with only the `errShutdown` passthrough removed, IDLE gets a spurious tagged response before the BYE.

`go test ./... -race` green; shutdown tests ×10 under `-race` green; `go vet` and `gofmt` clean.