### PR TITLE
imapserver: stop the NOTIFY pump before the shutdown BYE

### DIFF
--- a/imapserver/conn.go
+++ b/imapserver/conn.go
@@ -402,6 +402,15 @@ func (c *Conn) serve() {
 	}
 
 	if byeOnExit {
+		// The NOTIFY pump writes unsolicited responses from its own goroutine,
+		// independent of this loop. BYE announces that the server is done
+		// talking (RFC 9051 §7.1.5), so the pump must be gone before the BYE
+		// goes out -- not stopped in the deferred teardown, which only runs
+		// after the lingering close. Left running, a pump write during the
+		// linger would hit the half-closed socket, fail, and abort the
+		// connection hard, defeating the clean close. stopNotifyPump is
+		// idempotent, so the deferred call is then a no-op.
+		c.stopNotifyPump()
 		c.shutdownBye()
 	}
 }

--- a/imapserver/shutdown_notify_test.go
+++ b/imapserver/shutdown_notify_test.go
@@ -1,0 +1,92 @@
+package imapserver_test
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"testing"
+	"time"
+
+	"github.com/emersion/go-imap/v2"
+	"github.com/emersion/go-imap/v2/imapserver"
+	"github.com/emersion/go-imap/v2/imapserver/imapmemserver"
+)
+
+// notifyProbeSession embeds a real in-memory session and replaces the NOTIFY
+// pump with one that only records its own lifecycle: it never delivers events,
+// it just reports when it was started and when it observed stop.
+type notifyProbeSession struct {
+	*imapmemserver.UserSession
+	pumpStarted chan struct{}
+	pumpStopped chan struct{}
+}
+
+func (s *notifyProbeSession) NotifyPoll(ctx context.Context, w *imapserver.UpdateWriter, stop <-chan struct{}) error {
+	close(s.pumpStarted)
+	<-stop
+	close(s.pumpStopped)
+	return nil
+}
+
+// TestShutdownStopsNotifyPumpBeforeBye: BYE announces that the server is done
+// talking (RFC 9051 §7.1.5), so nothing may still be producing output when it
+// goes out. The NOTIFY pump writes unsolicited responses from its own
+// goroutine, independent of the command loop, and it must therefore be stopped
+// before the shutdown BYE is written -- not in the deferred teardown that runs
+// only after the lingering close.
+//
+// The observable property is ordering: at the instant the client reads the
+// BYE, the pump must already have observed stop. With the pump stopped only in
+// teardown it is still running at that instant, and it stops only after the
+// client closes its side, which the client here does not do until it has made
+// the check.
+func TestShutdownStopsNotifyPumpBeforeBye(t *testing.T) {
+	user := newTestUser(t)
+	probe := &notifyProbeSession{
+		UserSession: imapmemserver.NewUserSession(user),
+		pumpStarted: make(chan struct{}),
+		pumpStopped: make(chan struct{}),
+	}
+	srv := newShutdownTestServer(t, func() imapserver.Session { return probe }, imap.CapNotify)
+
+	wc := dialWire(t, srv.addr)
+	wc.login(t)
+	wc.mustOK(t, "SELECT INBOX")
+	wc.mustOK(t, "NOTIFY SET (SELECTED (MessageNew MessageExpunge))")
+	select {
+	case <-probe.pumpStarted:
+	case <-time.After(5 * time.Second):
+		t.Fatal("NOTIFY pump never started")
+	}
+
+	clientErr := make(chan error, 1)
+	go func() {
+		line, err := wc.readLine()
+		if err != nil {
+			clientErr <- err
+			return
+		}
+		if line != shutdownBye {
+			clientErr <- fmt.Errorf("after shutdown got %q, want %q", line, shutdownBye)
+			return
+		}
+		// The check itself: the BYE is on the wire, so the pump must be gone.
+		select {
+		case <-probe.pumpStopped:
+		default:
+			clientErr <- fmt.Errorf("NOTIFY pump was still running when the client received BYE")
+			return
+		}
+		wc.conn.SetReadDeadline(time.Now().Add(5 * time.Second))
+		if _, err := wc.br.ReadByte(); err != io.EOF {
+			clientErr <- fmt.Errorf("after BYE got %v, want a clean EOF", err)
+			return
+		}
+		clientErr <- wc.conn.Close()
+	}()
+
+	checkPrompt(t, <-shutdownAsync(srv.server, 5*time.Second), "a NOTIFY-watching but idle connection was open")
+	if err := <-clientErr; err != nil {
+		t.Error(err)
+	}
+}

--- a/imapserver/shutdown_test.go
+++ b/imapserver/shutdown_test.go
@@ -70,15 +70,19 @@ type shutdownTestServer struct {
 	addr   string
 }
 
-func newShutdownTestServer(t *testing.T, newSession func() imapserver.Session) *shutdownTestServer {
+func newShutdownTestServer(t *testing.T, newSession func() imapserver.Session, extraCaps ...imap.Cap) *shutdownTestServer {
 	t.Helper()
 
+	caps := imap.CapSet{imap.CapIMAP4rev1: {}, imap.CapIMAP4rev2: {}}
+	for _, c := range extraCaps {
+		caps[c] = struct{}{}
+	}
 	server := imapserver.New(&imapserver.Options{
 		NewSession: func(*imapserver.Conn) (imapserver.Session, *imapserver.GreetingData, error) {
 			return newSession(), nil, nil
 		},
 		InsecureAuth: true,
-		Caps:         imap.CapSet{imap.CapIMAP4rev1: {}, imap.CapIMAP4rev2: {}},
+		Caps:         caps,
 	})
 
 	ln, err := net.Listen("tcp", "localhost:0")


### PR DESCRIPTION
Follow-up to #44, prompted by #43 (NOTIFY) landing alongside it. Found while running the full suite on the merged `sora` tip and checking how the two interact.

## The interaction

The NOTIFY pump writes unsolicited responses from its own goroutine, independent of the command loop. Graceful shutdown sends BYE from the command loop and then lingers up to 500 ms so the client gets a clean EOF. Merged together, **the pump was still running while the BYE went out**: `stopNotifyPump()` was a deferred call, and deferred teardown only runs after the linger.

BYE announces that the server is done talking (RFC 9051 §7.1.5), so nothing may still be producing output when it is written. Concretely: a pump write during the linger hits the half-closed socket, fails, and — since `stop` is still open — takes the connection down hard via `abortFromBackground`, defeating the clean close the linger exists for.

## The fix

One line, plus a comment: `stopNotifyPump()` before `shutdownBye()`. It is idempotent, so the deferred call becomes a no-op. This matches what IDLE already does — its backend is stopped and awaited before `errShutdown` returns.

## Test

The property is ordering, and the test observes it directly rather than through a wire symptom (`CloseWrite` masks the wire symptom): a probe session whose `NotifyPoll` records when it saw `stop`; at the instant the client reads the BYE, `pumpStopped` must already be closed. The client deliberately does not close its side until after the check, so the linger cannot end early and rescue a late stop.

Red on merged `sora`, 3/3, deterministic:
```
NOTIFY pump was still running when the client received BYE   (0.50s)
```
Green after, 5/5 under `-race` at 0.00 s. All shutdown and NOTIFY suites green under `-race`.

`newShutdownTestServer` gains a variadic `extraCaps` so the test can advertise `NOTIFY`; no other test changes.