### PR TITLE
Handle a missing body-fld-lines on text parts

### DIFF
--- a/imapclient/bodystructure_nil_lines_test.go
+++ b/imapclient/bodystructure_nil_lines_test.go
@@ -1,0 +1,148 @@
+package imapclient
+
+import (
+	"bufio"
+	"strings"
+	"testing"
+
+	"github.com/emersion/go-imap/v2"
+	"github.com/emersion/go-imap/v2/internal/imapwire"
+)
+
+// TestReadBodyStructureNilLineCount is a regression test for a text part whose
+// line count is NIL.
+//
+// RFC 9051 body-type-text is "media-text SP body-fields SP body-fld-lines", so
+// the line count is mandatory and a server sending NIL is malformed. Servers do
+// it anyway: a synthetic body structure, built for a message the server could
+// not parse or could not load, is typically declared "text" "plain" while its
+// line count is left unset, and the serializer then writes the extension
+// section where the count belongs:
+//
+//	("text" "plain" NIL NIL NIL "7bit" 1234 NIL NIL NIL NIL)
+//
+// The count was read with ExpectNumber64, so the whole FETCH response failed
+// with
+//
+//	in body-type-1part: imapwire: expected number64, got "N"
+//
+// and one such message took down every other message in the batch with it --
+// enough to make a mailbox unopenable in a webmail client that fetches a page
+// of messages at a time.
+func TestReadBodyStructureNilLineCount(t *testing.T) {
+	const data = `("text" "plain" NIL NIL NIL "7bit" 1234 NIL NIL NIL NIL)`
+
+	dec := imapwire.NewDecoder(bufio.NewReader(strings.NewReader(data)), imapwire.ConnSideClient)
+	bs, err := readBody(dec, &Options{})
+	if err != nil {
+		t.Fatalf("readBody() = %v", err)
+	}
+
+	sp, ok := bs.(*imap.BodyStructureSinglePart)
+	if !ok {
+		t.Fatalf("readBody() = %T, want *imap.BodyStructureSinglePart", bs)
+	}
+	if sp.Type != "text" || sp.Subtype != "plain" {
+		t.Errorf("got %v/%v, want text/plain", sp.Type, sp.Subtype)
+	}
+	if sp.Size != 1234 {
+		t.Errorf("Size = %v, want 1234", sp.Size)
+	}
+	if sp.Text == nil {
+		t.Fatal("Text = nil, want a line count of 0")
+	}
+	if sp.Text.NumLines != 0 {
+		t.Errorf("Text.NumLines = %v, want 0", sp.Text.NumLines)
+	}
+}
+
+// TestReadBodyStructureNilLineCountInMultipart is what the failure actually
+// looks like in the wild: the malformed part sits next to healthy siblings, and
+// what matters is that they survive it.
+func TestReadBodyStructureNilLineCountInMultipart(t *testing.T) {
+	const data = `(("text" "plain" NIL NIL NIL "7bit" 1234 NIL NIL NIL NIL)("APPLICATION" "PDF" NIL NIL NIL "BASE64" 1476806 NIL ("ATTACHMENT" ("FILENAME" "x.pdf")) NIL) "MIXED" ("BOUNDARY" "abc") NIL NIL)`
+
+	dec := imapwire.NewDecoder(bufio.NewReader(strings.NewReader(data)), imapwire.ConnSideClient)
+	bs, err := readBody(dec, &Options{})
+	if err != nil {
+		t.Fatalf("readBody() = %v", err)
+	}
+
+	mp, ok := bs.(*imap.BodyStructureMultiPart)
+	if !ok {
+		t.Fatalf("readBody() = %T, want *imap.BodyStructureMultiPart", bs)
+	}
+	if len(mp.Children) != 2 {
+		t.Fatalf("len(Children) = %v, want 2", len(mp.Children))
+	}
+	pdf, ok := mp.Children[1].(*imap.BodyStructureSinglePart)
+	if !ok {
+		t.Fatalf("Children[1] = %T, want *imap.BodyStructureSinglePart", mp.Children[1])
+	}
+	if pdf.Size != 1476806 {
+		t.Errorf("Children[1].Size = %v, want 1476806", pdf.Size)
+	}
+	if pdf.Extended == nil || pdf.Extended.Disposition == nil {
+		t.Fatalf("Children[1].Extended.Disposition = nil, want the attachment disposition")
+	}
+	if got := pdf.Extended.Disposition.Params["filename"]; got != "x.pdf" {
+		t.Errorf("Children[1] filename = %q, want %q", got, "x.pdf")
+	}
+}
+
+// TestReadBodyStructureNilLineCountMessageRFC822 covers the other part type
+// that carries a line count.
+func TestReadBodyStructureNilLineCountMessageRFC822(t *testing.T) {
+	const data = `("MESSAGE" "RFC822" NIL NIL NIL "7BIT" 4096 (NIL NIL NIL NIL NIL NIL NIL NIL NIL NIL) ("TEXT" "PLAIN" NIL NIL NIL "7BIT" 512 10) NIL)`
+
+	dec := imapwire.NewDecoder(bufio.NewReader(strings.NewReader(data)), imapwire.ConnSideClient)
+	bs, err := readBody(dec, &Options{})
+	if err != nil {
+		t.Fatalf("readBody() = %v", err)
+	}
+
+	sp := bs.(*imap.BodyStructureSinglePart)
+	if sp.MessageRFC822 == nil {
+		t.Fatal("MessageRFC822 = nil, want the embedded message")
+	}
+	if sp.MessageRFC822.NumLines != 0 {
+		t.Errorf("MessageRFC822.NumLines = %v, want 0", sp.MessageRFC822.NumLines)
+	}
+	child, ok := sp.MessageRFC822.BodyStructure.(*imap.BodyStructureSinglePart)
+	if !ok {
+		t.Fatalf("embedded body = %T, want *imap.BodyStructureSinglePart", sp.MessageRFC822.BodyStructure)
+	}
+	if child.Text == nil || child.Text.NumLines != 10 {
+		t.Errorf("embedded Text = %+v, want 10 lines", child.Text)
+	}
+}
+
+// TestReadBodyStructureLineCountUnaffected pins the conformant cases: a real
+// line count is still read as a number, and a token that is neither a number
+// nor NIL is still an error rather than being silently taken as zero.
+func TestReadBodyStructureLineCountUnaffected(t *testing.T) {
+	t.Run("number", func(t *testing.T) {
+		const data = `("TEXT" "PLAIN" ("CHARSET" "US-ASCII") NIL NIL "7BIT" 1152 23)`
+
+		dec := imapwire.NewDecoder(bufio.NewReader(strings.NewReader(data)), imapwire.ConnSideClient)
+		bs, err := readBody(dec, &Options{})
+		if err != nil {
+			t.Fatalf("readBody() = %v", err)
+		}
+		sp := bs.(*imap.BodyStructureSinglePart)
+		if sp.Text == nil || sp.Text.NumLines != 23 {
+			t.Errorf("Text = %+v, want 23 lines", sp.Text)
+		}
+	})
+
+	t.Run("garbage", func(t *testing.T) {
+		const data = `("TEXT" "PLAIN" NIL NIL NIL "7BIT" 1152 LINES)`
+
+		dec := imapwire.NewDecoder(bufio.NewReader(strings.NewReader(data)), imapwire.ConnSideClient)
+		if _, err := readBody(dec, &Options{}); err == nil {
+			t.Fatal("readBody() = nil, want an error for a non-numeric line count")
+		} else if !strings.Contains(err.Error(), "body-fld-lines") {
+			t.Errorf("readBody() = %v, want a body-fld-lines error", err)
+		}
+	})
+}

--- a/imapclient/fetch.go
+++ b/imapclient/fetch.go
@@ -1174,7 +1174,7 @@ func readBodyType1part(dec *imapwire.Decoder, typ, subtype string, options *Opti
 			return nil, err
 		}
 
-		if !dec.ExpectSP() || !dec.ExpectNumber64(&msg.NumLines) {
+		if !dec.ExpectSP() || !dec.ExpectBodyFldLines(&msg.NumLines) {
 			return nil, dec.Err()
 		}
 
@@ -1183,7 +1183,7 @@ func readBodyType1part(dec *imapwire.Decoder, typ, subtype string, options *Opti
 	} else if strings.EqualFold(bs.Type, "text") {
 		var text imap.BodyStructureText
 
-		if !dec.ExpectNumber64(&text.NumLines) {
+		if !dec.ExpectBodyFldLines(&text.NumLines) {
 			return nil, dec.Err()
 		}
 

--- a/imapserver/bodystructure_lines_test.go
+++ b/imapserver/bodystructure_lines_test.go
@@ -1,0 +1,86 @@
+package imapserver
+
+import (
+	"bufio"
+	"bytes"
+	"testing"
+
+	"github.com/emersion/go-imap/v2"
+	"github.com/emersion/go-imap/v2/internal/imapwire"
+)
+
+// TestWriteBodyStructure_TextWithoutLineCount covers a backend handing us a
+// "text" part with no line count -- a synthetic structure built for a message
+// that could not be parsed or could not be loaded, where only Type and Subtype
+// were filled in.
+//
+// body-fld-lines is mandatory for a text part (RFC 9051 body-type-text). Writing
+// nothing put the extension section where the count belongs:
+//
+//	("text" "plain" NIL NIL NIL "7bit" 1234 NIL NIL NIL NIL)
+//
+// which clients reject, failing the whole FETCH response and every other message
+// in it. Zero is written instead.
+func TestWriteBodyStructure_TextWithoutLineCount(t *testing.T) {
+	synthetic := &imap.BodyStructureSinglePart{
+		Type:    "text",
+		Subtype: "plain",
+		Size:    1234,
+		// Text intentionally nil — this is what the fallback structures look like.
+		Extended: &imap.BodyStructureSinglePartExt{},
+	}
+
+	for _, tc := range []struct {
+		extended bool
+		want     string
+	}{
+		{false, `("text" "plain" NIL NIL NIL "7bit" 1234 0)`},
+		{true, `("text" "plain" NIL NIL NIL "7bit" 1234 0 NIL NIL NIL NIL)`},
+	} {
+		var buf bytes.Buffer
+		bw := bufio.NewWriter(&buf)
+		enc := imapwire.NewEncoder(bw, imapwire.ConnSideServer)
+		writeBodyStructure(enc, synthetic, tc.extended)
+		bw.Flush()
+		if got := buf.String(); got != tc.want {
+			t.Errorf("extended=%v:\n got %v\nwant %v", tc.extended, got, tc.want)
+		}
+	}
+}
+
+// TestWriteBodyStructure_LineCountUnaffected pins the normal case: a part that
+// carries a line count still reports it, and a non-text part still has none.
+func TestWriteBodyStructure_LineCountUnaffected(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		bs   *imap.BodyStructureSinglePart
+		want string
+	}{
+		{
+			name: "text with line count",
+			bs: &imap.BodyStructureSinglePart{
+				Type: "text", Subtype: "plain", Encoding: "7bit", Size: 1234,
+				Text: &imap.BodyStructureText{NumLines: 23},
+			},
+			want: `("text" "plain" NIL NIL NIL "7bit" 1234 23)`,
+		},
+		{
+			name: "non-text",
+			bs: &imap.BodyStructureSinglePart{
+				Type: "application", Subtype: "pdf", Encoding: "base64", Size: 1234,
+			},
+			want: `("application" "pdf" NIL NIL NIL "base64" 1234)`,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			var buf bytes.Buffer
+			bw := bufio.NewWriter(&buf)
+			enc := imapwire.NewEncoder(bw, imapwire.ConnSideServer)
+			writeBodyStructure(enc, tc.bs, false)
+			bw.Flush()
+			if got := buf.String(); got != tc.want {
+				t.Errorf("\n got %v\nwant %v", got, tc.want)
+			}
+		})
+	}
+}

--- a/imapserver/fetch.go
+++ b/imapserver/fetch.go
@@ -776,6 +776,15 @@ func writeBodyType1part(enc *imapwire.Encoder, bs *imap.BodyStructureSinglePart,
 		enc.SP().Number64(msg.NumLines)
 	} else if text := bs.Text; text != nil {
 		enc.SP().Number64(text.NumLines)
+	} else if strings.EqualFold(bs.Type, "text") {
+		// body-fld-lines is mandatory for a text part (RFC 9051 body-type-text).
+		// A backend that hands us a "text" part with no line count -- typically a
+		// synthetic structure built for a message it could not parse -- would
+		// otherwise put the extension section where the count belongs, and clients
+		// fail the entire FETCH response on it. Report zero: the count is a lie no
+		// client acts on, whereas malformed output costs every message in the
+		// response.
+		enc.SP().Number64(0)
 	}
 
 	if !extended {

--- a/internal/imapwire/decoder.go
+++ b/internal/imapwire/decoder.go
@@ -474,6 +474,27 @@ func (dec *Decoder) ExpectBodyFldOctets(ptr *uint32) bool {
 	return dec.ExpectNumber(ptr)
 }
 
+// ExpectBodyFldLines parses body-fld-lines, the line count of a text or
+// message/rfc822 part.
+//
+// Workaround: the field is mandatory, but some servers send NIL for it -- most
+// often when they fall back to a synthetic body structure for a message they
+// could not parse, and forget that a "text" part owes a line count. Accept NIL
+// as zero: refusing it fails the whole FETCH response, and with it every other
+// message in the batch, over one part whose line count nobody needs.
+func (dec *Decoder) ExpectBodyFldLines(ptr *int64) bool {
+	// Number64 unreads the first non-digit byte, so NIL is still intact here.
+	if dec.Number64(ptr) {
+		return true
+	}
+	var s string
+	if dec.Atom(&s) && strings.EqualFold(s, "NIL") {
+		*ptr = 0
+		return true
+	}
+	return dec.Expect(false, "body-fld-lines")
+}
+
 func (dec *Decoder) Number64(ptr *int64) bool {
 	s, ok := dec.numberStr()
 	if !ok {


### PR DESCRIPTION
## Problem

`body-fld-lines` is mandatory for a text part (RFC 9051 `body-type-text`), but servers do send `NIL` for it — most often when they fall back to a synthetic body structure for a message they could not parse, and leave the line count unset:

```
("text" "plain" NIL NIL NIL "7bit" 1234 NIL NIL NIL NIL)
```

The client read the count with `ExpectNumber64`, so one such part failed the **entire FETCH response** — and with it every other message in the batch — with:

```
in body-type-1part: imapwire: expected number64, got "N"
```

Seen in production against sora: a webmail client that fetches a page of messages at a time could not open the mailbox at all, because one message in the page had fallen back to a synthetic structure.

## Change

- **Client:** new `imapwire.ExpectBodyFldLines` accepts `NIL` as a count of zero, used for both the text and `message/rfc822` line counts. `Number64` unreads the first non-digit byte, so `NIL` is still intact when the number parse declines it. A token that is neither a number nor `NIL` is still an error rather than being silently taken as zero.
- **Server:** a `"text"` part whose `Text` is nil now reports zero lines instead of omitting the field, so the malformed shape is not produced in the first place. A count nobody acts on is not worth a failed response.

## Tests

`imapclient/bodystructure_nil_lines_test.go` — the reported shape, the same part next to a healthy PDF sibling that has to survive it, the `message/rfc822` variant, and guards for a real numeric count and for garbage.

`imapserver/bodystructure_lines_test.go` — exact serialized output for a text part with and without a line count, in both BODY and BODYSTRUCTURE modes.

Full `go test ./...` is green.