### PR TITLE
imapserver: read the virtual c right as k+x, not k alone

### DIFF
--- a/imapserver/acl_capability_test.go
+++ b/imapserver/acl_capability_test.go
@@ -107,14 +107,16 @@ func TestExpandVirtualRights(t *testing.T) {
 		want  imap.RightSet
 	}{
 		{imap.RightSet("lrswi"), imap.RightSet("lrswi")},
-		{imap.RightSet("c"), imap.RightSet("k")},
-		// `d` is `t`+`e` (Dovecot/Cyrus reading of RFC 4314 §2.1.1): mailbox
-		// deletion `x` is never implied.
+		// `c` is `k`+`x` and `d` is `t`+`e` (RFC 4314 §2.1.1 first family, as
+		// Dovecot and Cyrus' default): mailbox deletion `x` comes with `c`, and
+		// `d` never implies it.
+		{imap.RightSet("c"), imap.RightSet("kx")},
 		{imap.RightSet("d"), imap.RightSet("te")},
-		{imap.RightSet("cd"), imap.RightSet("kte")},
-		{imap.RightSet("lrswicda"), imap.RightSet("lrswiktea")},
+		{imap.RightSet("cd"), imap.RightSet("kxte")},
+		{imap.RightSet("lrswicda"), imap.RightSet("lrswikxtea")},
 		// An explicit `x` survives alongside the expansion, and is not doubled.
 		{imap.RightSet("xd"), imap.RightSet("xte")},
+		{imap.RightSet("xc"), imap.RightSet("xk")},
 		{imap.RightSet("td"), imap.RightSet("te")},
 	}
 
@@ -133,8 +135,8 @@ func TestFormatRightsWithCompat(t *testing.T) {
 	}{
 		{imap.RightSet("lrswi"), "lrswi"},
 		{imap.RightSet("k"), "kc"},
-		// `x` alone is not the virtual `d`.
-		{imap.RightSet("x"), "x"},
+		// `x` alone is a member of the virtual `c`, not of `d`.
+		{imap.RightSet("x"), "xc"},
 		{imap.RightSet("t"), "td"},
 		{imap.RightSet("e"), "ed"},
 		{imap.RightSet("te"), "ted"},

--- a/imapserver/acl_virtual_create_test.go
+++ b/imapserver/acl_virtual_create_test.go
@@ -1,0 +1,142 @@
+package imapserver
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"github.com/emersion/go-imap/v2"
+)
+
+// TestSetACLVirtualCreateReachesSessionAsKX pins the server-side reading of RFC
+// 4314 §2.1.1's virtual `c`: a client naming it delegates creating and deleting
+// mailboxes (`k` `x`), the first of the two families the section describes and
+// the one Dovecot and Cyrus (deleteright=c) implement. Before the fix the
+// expansion was `k` alone while `d` had already stopped implying `x`, leaving
+// mailbox deletion in no virtual right at all: an RFC 2086 client could neither
+// grant it nor see it.
+func TestSetACLVirtualCreateReachesSessionAsKX(t *testing.T) {
+	cases := []struct {
+		args    string
+		wantMod imap.RightModification
+		want    imap.RightSet
+	}{
+		{`INBOX bob c`, imap.RightModificationReplace, imap.RightSet("kx")},
+		{`INBOX bob lrc`, imap.RightModificationReplace, imap.RightSet("lrkx")},
+		{`INBOX bob +c`, imap.RightModificationAdd, imap.RightSet("kx")},
+		{`INBOX bob -c`, imap.RightModificationRemove, imap.RightSet("kx")},
+		// Members already named by the client are not doubled.
+		{`INBOX bob kc`, imap.RightModificationReplace, imap.RightSet("kx")},
+		{`INBOX bob xc`, imap.RightModificationReplace, imap.RightSet("xk")},
+		// `c` and `d` together are the RFC's own example: `x` comes from `c`.
+		{`INBOX bob lrswicd`, imap.RightModificationReplace, imap.RightSet("lrswikxte")},
+		// `d` on its own still never confers `x`.
+		{`INBOX bob lrd`, imap.RightModificationReplace, imap.RightSet("lrte")},
+	}
+	for _, tc := range cases {
+		t.Run(tc.args, func(t *testing.T) {
+			session := &aclRecordingSession{}
+			conn := newACLTestConn(t, session, &bytes.Buffer{})
+			if err := conn.handleSetACL(argsDecoder(" " + tc.args)); err != nil {
+				t.Fatalf("handleSetACL: %v", err)
+			}
+			if session.setMod != tc.wantMod {
+				t.Errorf("modification = %v, want %v", session.setMod, tc.wantMod)
+			}
+			if !session.setRights.Equal(tc.want) {
+				t.Errorf("session received rights %q, want %q", session.setRights, tc.want)
+			}
+			// No virtual right may survive into the backend.
+			for _, virt := range []imap.Right{imap.RightCreate, imap.RightDelete} {
+				if containsRight(session.setRights, virt) {
+					t.Errorf("rights %q: virtual %c must be expanded, not passed through", session.setRights, virt)
+				}
+			}
+		})
+	}
+}
+
+// TestACLOutputAdvertisesVirtualCreateForKX is the inverse: GETACL, MYRIGHTS and
+// LISTRIGHTS append `c` whenever `k` or `x` is held (or grantable), so a bare
+// `x` is visible to an RFC 2086 client through `c` and never through `d`.
+func TestACLOutputAdvertisesVirtualCreateForKX(t *testing.T) {
+	render := func(write func(c *Conn) error) string {
+		t.Helper()
+		var out bytes.Buffer
+		conn := newACLTestConn(t, &aclRecordingSession{}, &out)
+		if err := write(conn); err != nil {
+			t.Fatalf("write: %v", err)
+		}
+		if err := conn.bw.Flush(); err != nil {
+			t.Fatalf("flush: %v", err)
+		}
+		return strings.TrimRight(out.String(), "\r\n")
+	}
+	lastQuoted := func(line string) string {
+		t.Helper()
+		j := strings.LastIndex(line, `"`)
+		i := strings.LastIndex(line[:j], `"`)
+		if i < 0 || j <= i {
+			t.Fatalf("no quoted string in %q", line)
+		}
+		return line[i+1 : j]
+	}
+
+	rightsCases := []struct {
+		held  imap.RightSet
+		wantC bool
+		wantD bool
+	}{
+		{imap.RightSet("lrk"), true, false},
+		{imap.RightSet("lrx"), true, false},
+		{imap.RightSet("lrkx"), true, false},
+		{imap.RightSet("lrte"), false, true},
+		{imap.RightSet("lrs"), false, false},
+		// The RFC's example: lrswikda -> the client sees c and d.
+		{imap.RightSet("lrswiktea"), true, true},
+	}
+	for _, tc := range rightsCases {
+		acl := render(func(c *Conn) error {
+			return c.writeGetACL(&imap.GetACLData{Mailbox: "INBOX", ACL: []imap.ACLEntry{{Identifier: "bob", Rights: tc.held}}})
+		})
+		my := render(func(c *Conn) error {
+			return c.writeMyRights(&imap.MyRightsData{Mailbox: "INBOX", Rights: tc.held})
+		})
+		for name, line := range map[string]string{"GETACL": acl, "MYRIGHTS": my} {
+			got := lastQuoted(line)
+			if strings.ContainsRune(got, 'c') != tc.wantC {
+				t.Errorf("%s for %q: %s; virtual c present = %v, want %v", name, tc.held, line, !tc.wantC, tc.wantC)
+			}
+			if strings.ContainsRune(got, 'd') != tc.wantD {
+				t.Errorf("%s for %q: %s; virtual d present = %v, want %v", name, tc.held, line, !tc.wantD, tc.wantD)
+			}
+			// The compatibility rendering only ever adds the virtual letters; a
+			// member right the identifier does not hold must not appear.
+			for _, member := range "kx" {
+				if !containsRight(tc.held, imap.Right(member)) && strings.ContainsRune(got, member) {
+					t.Errorf("%s: %c rendered although not held", line, member)
+				}
+			}
+		}
+	}
+
+	listCases := []struct {
+		optional []imap.RightSet
+		wantC    bool
+	}{
+		{[]imap.RightSet{imap.RightSet("l"), imap.RightSet("k"), imap.RightSet("x")}, true},
+		{[]imap.RightSet{imap.RightSet("l"), imap.RightSet("x")}, true},
+		{[]imap.RightSet{imap.RightSet("l"), imap.RightSet("k")}, true},
+		{[]imap.RightSet{imap.RightSet("l"), imap.RightSet("t")}, false},
+	}
+	for _, tc := range listCases {
+		line := render(func(c *Conn) error {
+			return c.writeListRights(&imap.ListRightsData{
+				Mailbox: "INBOX", Identifier: "bob", RequiredRights: imap.RightSet{}, OptionalRights: tc.optional,
+			})
+		})
+		if got := strings.Contains(line, ` "c"`); got != tc.wantC {
+			t.Errorf("LISTRIGHTS %v: %s; virtual c group present = %v, want %v", tc.optional, line, got, tc.wantC)
+		}
+	}
+}

--- a/imapserver/acl_virtual_delete_wire_test.go
+++ b/imapserver/acl_virtual_delete_wire_test.go
@@ -12,11 +12,11 @@ import (
 	"github.com/emersion/go-imap/v2/imapserver/imapmemserver"
 )
 
-// TestVirtualDeleteOverMemServer runs the virtual `d` end to end against
-// imapmemserver, whose own SetACL also reads `d` as `t`+`e`: the two layers
-// must agree, and the GETACL answer must show `t`, `e` and the compatibility
-// `d` while never inventing an `x` the client did not ask for.
-func TestVirtualDeleteOverMemServer(t *testing.T) {
+// memServerACLRights runs one SETACL for bob on a fresh imapmemserver and
+// returns the rights GETACL then reports for bob, so the virtual-right tests
+// exercise the wire layer and the backend together.
+func memServerACLRights(t *testing.T, setACLArgs string) string {
+	t.Helper()
 	memServer := imapmemserver.New()
 	memServer.AddUser(imapmemserver.NewUser("owner", "pass"))
 
@@ -73,7 +73,7 @@ func TestVirtualDeleteOverMemServer(t *testing.T) {
 	readLine() // greeting
 	mustOK("a1", "LOGIN owner pass")
 	mustOK("a2", "CREATE Shared")
-	mustOK("a3", `SETACL Shared bob lrd`)
+	mustOK("a3", "SETACL Shared bob "+setACLArgs)
 
 	var row string
 	for _, l := range mustOK("a4", "GETACL Shared") {
@@ -90,13 +90,48 @@ func TestVirtualDeleteOverMemServer(t *testing.T) {
 		t.Fatalf("GETACL row has no entry for bob: %s", row)
 	}
 	rights := row[i+len(`"bob" "`):]
-	rights = rights[:strings.IndexByte(rights, '"')]
+	return rights[:strings.IndexByte(rights, '"')]
+}
+
+// TestVirtualDeleteOverMemServer runs the virtual `d` end to end against
+// imapmemserver, whose own SetACL also reads `d` as `t`+`e`: the two layers
+// must agree, and the GETACL answer must show `t`, `e` and the compatibility
+// `d` while never inventing an `x` the client did not ask for.
+func TestVirtualDeleteOverMemServer(t *testing.T) {
+	rights := memServerACLRights(t, "lrd")
 	for _, want := range "lrted" {
 		if !strings.ContainsRune(rights, want) {
-			t.Errorf("bob's rights %q lack %q (row %s)", rights, want, row)
+			t.Errorf("bob's rights %q lack %q", rights, want)
 		}
 	}
 	if strings.ContainsRune(rights, 'x') {
-		t.Errorf("bob's rights %q carry `x`, which the virtual `d` must not confer (row %s)", rights, row)
+		t.Errorf("bob's rights %q carry `x`, which the virtual `d` must not confer", rights)
+	}
+	if strings.ContainsRune(rights, 'c') {
+		t.Errorf("bob's rights %q carry `c`, although neither `k` nor `x` is held", rights)
+	}
+}
+
+// TestVirtualCreateOverMemServer is the `c` counterpart: imapmemserver reads
+// `c` as `k`+`x` like imapserver does, and GETACL reports `k`, `x` and the
+// compatibility `c` - without a `d`, since no delete member is held.
+func TestVirtualCreateOverMemServer(t *testing.T) {
+	rights := memServerACLRights(t, "lrc")
+	for _, want := range "lrkxc" {
+		if !strings.ContainsRune(rights, want) {
+			t.Errorf("bob's rights %q lack %q", rights, want)
+		}
+	}
+	if strings.ContainsRune(rights, 'd') {
+		t.Errorf("bob's rights %q carry `d`, although neither `t` nor `e` is held", rights)
+	}
+
+	// RFC 4314 §2.1.1's own example, `c` and `d` together: `x` is there, and
+	// it came from `c`.
+	rights = memServerACLRights(t, "lrswicd")
+	for _, want := range "lrswikxtecd" {
+		if !strings.ContainsRune(rights, want) {
+			t.Errorf("bob's rights %q lack %q", rights, want)
+		}
 	}
 }

--- a/imapserver/cmd_acl.go
+++ b/imapserver/cmd_acl.go
@@ -170,14 +170,14 @@ func (c *Conn) writeListRights(data *imap.ListRightsData) error {
 	// individually (each its own group, independently grantable), so the virtual
 	// right is returned by itself as its own group. §3.7 forbids listing any right
 	// more than once, so only add c/d when not already present. The members of
-	// `d` are `t` and `e` only; see expandVirtualRights for why `x` is not one.
+	// `c` are `k` and `x`, those of `d` are `t` and `e`; see expandVirtualRights.
 	var all strings.Builder
 	all.WriteString(string(data.RequiredRights))
 	for i := range data.OptionalRights {
 		all.WriteString(string(data.OptionalRights[i]))
 	}
 	allRights := all.String()
-	if strings.ContainsRune(allRights, 'k') && !strings.ContainsRune(allRights, 'c') {
+	if strings.ContainsAny(allRights, "kx") && !strings.ContainsRune(allRights, 'c') {
 		enc.SP().String("c")
 	}
 	if strings.ContainsAny(allRights, "te") && !strings.ContainsRune(allRights, 'd') {
@@ -204,22 +204,24 @@ func formatRights(rm imap.RightModification, rs imap.RightSet) string {
 }
 
 // expandVirtualRights maps the obsolete RFC 2086 rights a client may still name
-// (RFC 4314 §2.1.1) onto the rights this server actually has: `c` becomes `k`,
-// and `d` becomes `t` `e`.
+// (RFC 4314 §2.1.1) onto the rights this server actually has: `c` becomes `k`
+// `x`, and `d` becomes `t` `e`.
 //
-// §2.1.1 leaves the exact composition of `d` to the server: it is "the union"
-// of the delete-ish rights the server implements, and mailbox deletion (`x`)
-// was split out from message deletion precisely so that a server could grant
-// one without the other. Dovecot and Cyrus both read `d` as `e`+`t` and keep
-// `x` separate, so a client written against either expects "SETACL ... d" to
-// delegate deleting and expunging MESSAGES and not the mailbox itself. Folding
-// `x` in would silently hand out a right the client never asked for, and a
-// backend that cannot grant `x` would have to refuse the whole request over a
-// letter the client never typed. `x` therefore reaches the backend only when
-// the client names it.
+// §2.1.1 describes two server families and lets each define the virtual
+// rights: servers whose RFC 2086 `c` controlled DELETE read `c` as `k`+`x` and
+// `d` as `e`+`t`; servers whose `d` controlled DELETE read `c` as `k` and `d` as
+// `e`+`t`+`x`. Either way `x` is a member of exactly one virtual right, so an
+// RFC 2086 client can still grant and see mailbox deletion. This server is of
+// the first family, as are Dovecot (unconditionally) and Cyrus (its default,
+// deleteright=c): the RFC's own worked examples expand `d` to `et`, and a
+// client written against either expects "SETACL ... d" to delegate deleting and
+// expunging MESSAGES and not the mailbox itself. Leaving `x` out of `c` as well
+// would put it in no virtual right at all, which the RFC does not describe and
+// which makes `x` unreachable for RFC 2086 clients.
 //
 // formatRightsWithCompat and writeListRights are the inverse and must agree:
-// they append `d` when `t` or `e` is held (or grantable), never for `x` alone.
+// they append `c` when `k` or `x` is held (or grantable), and `d` when `t` or
+// `e` is, never `d` for `x` alone.
 func expandVirtualRights(rs imap.RightSet) imap.RightSet {
 	res := make(imap.RightSet, 0, len(rs))
 	hasC := false
@@ -234,8 +236,10 @@ func expandVirtualRights(rs imap.RightSet) imap.RightSet {
 		}
 	}
 	if hasC {
-		if !containsRight(res, imap.RightCreateChild) {
-			res = append(res, imap.RightCreateChild)
+		for _, cr := range []imap.Right{imap.RightCreateChild, imap.RightDeleteMbox} {
+			if !containsRight(res, cr) {
+				res = append(res, cr)
+			}
 		}
 	}
 	if hasD {
@@ -258,15 +262,15 @@ func containsRight(rs imap.RightSet, r imap.Right) bool {
 }
 
 // formatRightsWithCompat renders a right set for GETACL/MYRIGHTS with the
-// obsolete virtual rights appended (RFC 4314 §2.1.1): `c` when `k` is held, `d`
-// when `t` or `e` is held. `x` alone does not imply `d`; it is not a member of
-// the virtual right here (see expandVirtualRights).
+// obsolete virtual rights appended (RFC 4314 §2.1.1): `c` when `k` or `x` is
+// held, `d` when `t` or `e` is held. `x` alone implies `c`, not `d`; it is a
+// member of the virtual create right here (see expandVirtualRights).
 func formatRightsWithCompat(rs imap.RightSet) string {
-	hasK := false
+	hasKX := false
 	hasTE := false
 	for _, r := range rs {
-		if r == imap.RightCreateChild {
-			hasK = true
+		if r == imap.RightCreateChild || r == imap.RightDeleteMbox {
+			hasKX = true
 		}
 		if r == imap.RightDeleteMsg || r == imap.RightExpunge {
 			hasTE = true
@@ -274,7 +278,7 @@ func formatRightsWithCompat(rs imap.RightSet) string {
 	}
 
 	s := string(rs)
-	if hasK && !strings.ContainsRune(s, 'c') {
+	if hasKX && !strings.ContainsRune(s, 'c') {
 		s += "c"
 	}
 	if hasTE && !strings.ContainsRune(s, 'd') {

--- a/imapserver/imapmemserver/session.go
+++ b/imapserver/imapmemserver/session.go
@@ -667,9 +667,11 @@ func (sess *UserSession) SetACL(ctx context.Context, name string, identifier ima
 	// Apply modification
 	currentRights := mbox.acl[identifier]
 
-	// Handle obsolete rights for backwards compatibility
+	// Handle obsolete rights for backwards compatibility (RFC 4314 §2.1.1):
+	// `c` is `k`+`x` and `d` is `t`+`e`, the same reading as imapserver's
+	// expandVirtualRights, so the two layers agree.
 	if strings.Contains(string(rights), "c") {
-		rights = rights.Add(imap.RightSet("k"))
+		rights = rights.Add(imap.RightSet("kx"))
 	}
 	if strings.Contains(string(rights), "d") {
 		rights = rights.Add(imap.RightSet("te"))


### PR DESCRIPTION
Follow-up to #51. That change stopped the virtual `d` from implying `x`, but left `c` as `k` alone, so `x` ended up in no virtual right at all.

RFC 4314 §2.1.1 describes two server families — `c`=`k`+`x` with `d`=`e`+`t`, or `c`=`k` with `d`=`e`+`t`+`x` — and in both, `x` belongs to exactly one virtual right, so an RFC 2086 client can still grant and see mailbox deletion. With `x` orphaned it could do neither, and GETACL/MYRIGHTS reported a bare `x` where Dovecot reports `xc`.

This makes the server the first family, matching Dovecot (unconditionally), Cyrus (default `deleteright: c`), and the RFC's own examples (`lrswikda` → `lrswikcdeta`):

- `c` expands to `k` `x`
- GETACL / MYRIGHTS / LISTRIGHTS append `c` when `k` or `x` is held or grantable
- `d` is unchanged: `t` `e`, never `x`
- imapmemserver's own `SetACL` reads `c` the same way

Tests: expansion/compat tables gain the `c` cases; new handler-level tests pin `SETACL c` → `k x` and the output side; memserver wire test factored into a helper with a `c` counterpart. All new tests fail against the previous commit. Full suite and `-race` on the ACL packages green.
