### PR TITLE
feat(imapserver): let the session declare the virtual c and d rights

### DIFF
--- a/imapserver/acl.go
+++ b/imapserver/acl.go
@@ -50,3 +50,48 @@ type SessionACL interface {
 	// This command does not require any special permissions - any user can check their own rights.
 	MyRights(ctx context.Context, mailbox string) (*imap.MyRightsData, error)
 }
+
+// SessionACLVirtualRights is an optional extension of SessionACL that lets a
+// backend define the membership of the two virtual rights RFC 4314 §2.1.1 keeps
+// alive for RFC 2086 clients: `c` (create) and `d` (delete).
+//
+// The section describes two server families and leaves the choice to the
+// server: those whose RFC 2086 `c` controlled DELETE read `c` as `k`+`x` and
+// `d` as `e`+`t`, those whose `d` did read `c` as `k` and `d` as `e`+`t`+`x`.
+// A backend that implements none of this gets the first family
+// (DefaultVirtualCreate, DefaultVirtualDelete), which is Dovecot's fixed
+// reading and Cyrus' default. A backend for which `x` is not something a grant
+// can carry at all may leave it out of both, so that a client's "SETACL ... c"
+// is not expanded into a request the backend then has to refuse over a letter
+// the client never typed.
+//
+// The declaration is the ONE source for everything the server does with the
+// virtual rights: the expansion of an incoming `c`/`d` in SETACL, the `c`/`d`
+// appended to GETACL and MYRIGHTS, and the `c`/`d` groups added to LISTRIGHTS.
+// Reading all three from one place is what keeps them from disagreeing, which
+// is why this is a single method returning both sets rather than one per
+// right. The two sets are normalized before use: the virtual letters
+// themselves and duplicates are dropped, and a right named in both stays in
+// `create` only, since in both RFC families a right is a member of at most one
+// virtual right.
+//
+// The RIGHTS= capability is deliberately NOT derived from this. RFC 4314 §6's
+// formal syntax fixes it ("new-rights ... MUST include t, e, x, and k"), so it
+// names the rights the server implements, not the ones a grant may carry.
+type SessionACLVirtualRights interface {
+	SessionACL
+
+	// VirtualRights returns the members of the virtual `c` (create) and `d`
+	// (delete) rights, in that order. Either may be empty, in which case that
+	// virtual right expands to nothing and is never advertised.
+	VirtualRights() (create, delete imap.RightSet)
+}
+
+// DefaultVirtualCreate and DefaultVirtualDelete are the members of the virtual
+// `c` and `d` rights for a SessionACL that does not implement
+// SessionACLVirtualRights: RFC 4314 §2.1.1's first family, `c` = `k`+`x` and
+// `d` = `t`+`e`.
+var (
+	DefaultVirtualCreate = imap.RightSet{imap.RightCreateChild, imap.RightDeleteMbox}
+	DefaultVirtualDelete = imap.RightSet{imap.RightDeleteMsg, imap.RightExpunge}
+)

--- a/imapserver/acl_capability_test.go
+++ b/imapserver/acl_capability_test.go
@@ -41,8 +41,9 @@ func hasCap(caps []imap.Cap, want imap.Cap) bool {
 
 // TestACLCapabilityAdvertisesRights verifies RFC 4314 compliance: a server whose
 // session implements the ACL extension must advertise both "ACL" and the
-// "RIGHTS=" capability. Per Section 2.1 the RIGHTS= string must contain "t",
-// "e", "x", and "k"; per Section 2.2 it must not contain RFC 2086 rights.
+// "RIGHTS=" capability. Per the formal syntax in Section 6 ("new-rights ...
+// MUST include t, e, x, and k") the RIGHTS= string must contain those four;
+// per Section 2.2 it must not contain RFC 2086 rights.
 func TestACLCapabilityAdvertisesRights(t *testing.T) {
 	srv := &Server{options: Options{Caps: imap.CapSet{imap.CapIMAP4rev1: {}}}}
 
@@ -59,11 +60,11 @@ func TestACLCapabilityAdvertisesRights(t *testing.T) {
 			t.Errorf("state %v: %q not advertised, got %v", state, rightsCap, caps)
 		}
 
-		// Section 2.1: RIGHTS= MUST include t, e, x, k.
+		// Section 6 formal syntax: RIGHTS= MUST include t, e, x, k.
 		rights := imap.RightSetExtended.String()
 		for _, r := range []rune{'t', 'e', 'x', 'k'} {
 			if !containsRune(rights, r) {
-				t.Errorf("RIGHTS=%q missing required right %q (RFC 4314 2.1)", rights, r)
+				t.Errorf("RIGHTS=%q missing required right %q (RFC 4314 section 6)", rights, r)
 			}
 		}
 		// Section 2.2: RIGHTS= MUST NOT include RFC 2086 rights or digits.
@@ -121,7 +122,7 @@ func TestExpandVirtualRights(t *testing.T) {
 	}
 
 	for _, tc := range tests {
-		got := expandVirtualRights(tc.input)
+		got := expandVirtualRights(tc.input, defaultVirtualRights())
 		if !got.Equal(tc.want) {
 			t.Errorf("expandVirtualRights(%q) = %q, want %q", tc.input, got, tc.want)
 		}
@@ -144,7 +145,7 @@ func TestFormatRightsWithCompat(t *testing.T) {
 	}
 
 	for _, tc := range tests {
-		got := formatRightsWithCompat(tc.input)
+		got := formatRightsWithCompat(tc.input, defaultVirtualRights())
 		if len(got) != len(tc.want) {
 			t.Errorf("formatRightsWithCompat(%q) = %q, want %q", tc.input, got, tc.want)
 			continue

--- a/imapserver/acl_virtual_rights_session_test.go
+++ b/imapserver/acl_virtual_rights_session_test.go
@@ -1,0 +1,235 @@
+package imapserver
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"github.com/emersion/go-imap/v2"
+)
+
+// aclFamilySession is a SessionACL that declares its own virtual-right
+// membership through SessionACLVirtualRights.
+type aclFamilySession struct {
+	aclRecordingSession
+	create imap.RightSet
+	delete imap.RightSet
+}
+
+func (s *aclFamilySession) VirtualRights() (create, delete imap.RightSet) {
+	return s.create, s.delete
+}
+
+var _ SessionACLVirtualRights = (*aclFamilySession)(nil)
+
+// TestNewVirtualRightsNormalizes pins the normalization every consumer relies
+// on: the virtual letters are not members of anything, a right is listed once,
+// and a right named in both sets belongs to `create` only. A backend therefore
+// cannot put `x` in both, which no RFC 4314 §2.1.1 family does.
+func TestNewVirtualRightsNormalizes(t *testing.T) {
+	cases := []struct {
+		create, delete         imap.RightSet
+		wantCreate, wantDelete imap.RightSet
+	}{
+		{imap.RightSet("kx"), imap.RightSet("te"), imap.RightSet("kx"), imap.RightSet("te")},
+		// The second RFC family.
+		{imap.RightSet("k"), imap.RightSet("xte"), imap.RightSet("k"), imap.RightSet("xte")},
+		// A backend that grants `x` to nobody keeps it out of both.
+		{imap.RightSet("k"), imap.RightSet("te"), imap.RightSet("k"), imap.RightSet("te")},
+		// `x` in both: create wins.
+		{imap.RightSet("kx"), imap.RightSet("xte"), imap.RightSet("kx"), imap.RightSet("te")},
+		// The virtual letters and duplicates are dropped.
+		{imap.RightSet("kxck"), imap.RightSet("tded"), imap.RightSet("kx"), imap.RightSet("te")},
+		{nil, nil, nil, nil},
+	}
+	for _, tc := range cases {
+		got := newVirtualRights(tc.create, tc.delete)
+		if !got.create.Equal(tc.wantCreate) || len(got.create) != len(tc.wantCreate) {
+			t.Errorf("newVirtualRights(%q, %q).create = %q, want %q", tc.create, tc.delete, got.create, tc.wantCreate)
+		}
+		if !got.delete.Equal(tc.wantDelete) || len(got.delete) != len(tc.wantDelete) {
+			t.Errorf("newVirtualRights(%q, %q).delete = %q, want %q", tc.create, tc.delete, got.delete, tc.wantDelete)
+		}
+	}
+}
+
+// TestExpandVirtualRightsFollowsDeclaration checks the expansion against each
+// family a backend may declare, including the one where `x` is a member of
+// neither: there a client's `c` reaches the session as `k` alone and an
+// explicit `x` still passes through as the client's own request.
+func TestExpandVirtualRightsFollowsDeclaration(t *testing.T) {
+	noX := newVirtualRights(imap.RightSet("k"), imap.RightSet("te"))
+	second := newVirtualRights(imap.RightSet("k"), imap.RightSet("xte"))
+	none := newVirtualRights(nil, nil)
+
+	cases := []struct {
+		vr    virtualRights
+		input imap.RightSet
+		want  imap.RightSet
+	}{
+		{noX, imap.RightSet("c"), imap.RightSet("k")},
+		{noX, imap.RightSet("d"), imap.RightSet("te")},
+		{noX, imap.RightSet("lrswicd"), imap.RightSet("lrswikte")},
+		{noX, imap.RightSet("xc"), imap.RightSet("xk")},
+		{second, imap.RightSet("c"), imap.RightSet("k")},
+		{second, imap.RightSet("d"), imap.RightSet("xte")},
+		{second, imap.RightSet("lrswicd"), imap.RightSet("lrswikxte")},
+		// An empty declaration expands the virtual right to nothing.
+		{none, imap.RightSet("lrcd"), imap.RightSet("lr")},
+	}
+	for _, tc := range cases {
+		got := expandVirtualRights(tc.input, tc.vr)
+		if !got.Equal(tc.want) || len(got) != len(tc.want) {
+			t.Errorf("expandVirtualRights(%q, c=%q d=%q) = %q, want %q", tc.input, tc.vr.create, tc.vr.delete, got, tc.want)
+		}
+	}
+}
+
+// TestFormatRightsWithCompatFollowsDeclaration is the inverse: what GETACL and
+// MYRIGHTS append depends on the same declaration, so a backend that keeps `x`
+// out of `c` never renders `c` for an `x`, and the second family renders `d`
+// for it instead.
+func TestFormatRightsWithCompatFollowsDeclaration(t *testing.T) {
+	noX := newVirtualRights(imap.RightSet("k"), imap.RightSet("te"))
+	second := newVirtualRights(imap.RightSet("k"), imap.RightSet("xte"))
+	none := newVirtualRights(nil, nil)
+
+	cases := []struct {
+		vr    virtualRights
+		input imap.RightSet
+		want  string
+	}{
+		{noX, imap.RightSet("k"), "kc"},
+		{noX, imap.RightSet("x"), "x"},
+		{noX, imap.RightSet("kx"), "kxc"},
+		{noX, imap.RightSet("te"), "ted"},
+		{noX, imap.RightSet("lrswikxtea"), "lrswikxteacd"},
+		{second, imap.RightSet("x"), "xd"},
+		{second, imap.RightSet("k"), "kc"},
+		{none, imap.RightSet("kxte"), "kxte"},
+		// A virtual letter already present is not doubled.
+		{noX, imap.RightSet("kc"), "kc"},
+	}
+	for _, tc := range cases {
+		if got := formatRightsWithCompat(tc.input, tc.vr); got != tc.want {
+			t.Errorf("formatRightsWithCompat(%q, c=%q d=%q) = %q, want %q", tc.input, tc.vr.create, tc.vr.delete, got, tc.want)
+		}
+	}
+}
+
+// TestSessionDeclaredVirtualRightsReachAllThreeConsumers drives a session that
+// declares `c` = `k` and `d` = `t`+`e` through the handler and the three
+// writers, and checks the wire agrees with itself: SETACL expands `c` to `k`
+// only, GETACL and MYRIGHTS append `c` for `k` and not for `x`, and LISTRIGHTS
+// adds the `c` group when `k` is grantable and not when only `x` is.
+func TestSessionDeclaredVirtualRightsReachAllThreeConsumers(t *testing.T) {
+	newSession := func() *aclFamilySession {
+		return &aclFamilySession{create: imap.RightSet("k"), delete: imap.RightSet("te")}
+	}
+
+	setCases := []struct {
+		args string
+		want imap.RightSet
+	}{
+		{`INBOX bob c`, imap.RightSet("k")},
+		{`INBOX bob lrc`, imap.RightSet("lrk")},
+		{`INBOX bob +c`, imap.RightSet("k")},
+		{`INBOX bob kc`, imap.RightSet("k")},
+		{`INBOX bob lrswicd`, imap.RightSet("lrswikte")},
+		// An explicit `x` is the client's own and is passed through.
+		{`INBOX bob xc`, imap.RightSet("xk")},
+	}
+	for _, tc := range setCases {
+		t.Run(tc.args, func(t *testing.T) {
+			session := newSession()
+			conn := newACLTestConn(t, session, &bytes.Buffer{})
+			if err := conn.handleSetACL(argsDecoder(" " + tc.args)); err != nil {
+				t.Fatalf("handleSetACL: %v", err)
+			}
+			if !session.setRights.Equal(tc.want) || len(session.setRights) != len(tc.want) {
+				t.Errorf("session received rights %q, want %q", session.setRights, tc.want)
+			}
+		})
+	}
+
+	render := func(write func(c *Conn) error) string {
+		t.Helper()
+		var out bytes.Buffer
+		conn := newACLTestConn(t, newSession(), &out)
+		if err := write(conn); err != nil {
+			t.Fatalf("write: %v", err)
+		}
+		if err := conn.bw.Flush(); err != nil {
+			t.Fatalf("flush: %v", err)
+		}
+		return strings.TrimRight(out.String(), "\r\n")
+	}
+	lastQuoted := func(line string) string {
+		t.Helper()
+		j := strings.LastIndex(line, `"`)
+		i := strings.LastIndex(line[:j], `"`)
+		if i < 0 || j <= i {
+			t.Fatalf("no quoted string in %q", line)
+		}
+		return line[i+1 : j]
+	}
+
+	outCases := []struct {
+		held imap.RightSet
+		want string
+	}{
+		{imap.RightSet("lrk"), "lrkc"},
+		{imap.RightSet("lrx"), "lrx"},
+		{imap.RightSet("lrkx"), "lrkxc"},
+		{imap.RightSet("lrte"), "lrted"},
+		// An owner holding everything this server implements.
+		{imap.RightSet("lrswikxtea"), "lrswikxteacd"},
+	}
+	for _, tc := range outCases {
+		acl := render(func(c *Conn) error {
+			return c.writeGetACL(&imap.GetACLData{Mailbox: "INBOX", ACL: []imap.ACLEntry{{Identifier: "bob", Rights: tc.held}}})
+		})
+		my := render(func(c *Conn) error {
+			return c.writeMyRights(&imap.MyRightsData{Mailbox: "INBOX", Rights: tc.held})
+		})
+		for name, line := range map[string]string{"GETACL": acl, "MYRIGHTS": my} {
+			if got := lastQuoted(line); got != tc.want {
+				t.Errorf("%s for %q rendered %q, want %q: %s", name, tc.held, got, tc.want, line)
+			}
+		}
+	}
+
+	listCases := []struct {
+		optional []imap.RightSet
+		wantC    bool
+		wantD    bool
+	}{
+		{[]imap.RightSet{imap.RightSet("l"), imap.RightSet("k")}, true, false},
+		{[]imap.RightSet{imap.RightSet("l"), imap.RightSet("x")}, false, false},
+		{[]imap.RightSet{imap.RightSet("l"), imap.RightSet("t")}, false, true},
+		{[]imap.RightSet{imap.RightSet("l"), imap.RightSet("k"), imap.RightSet("t"), imap.RightSet("e")}, true, true},
+	}
+	for _, tc := range listCases {
+		line := render(func(c *Conn) error {
+			return c.writeListRights(&imap.ListRightsData{
+				Mailbox: "INBOX", Identifier: "bob", RequiredRights: imap.RightSet{}, OptionalRights: tc.optional,
+			})
+		})
+		if got := strings.Contains(line, ` "c"`); got != tc.wantC {
+			t.Errorf("LISTRIGHTS %v: %s; virtual c group present = %v, want %v", tc.optional, line, got, tc.wantC)
+		}
+		if got := strings.Contains(line, ` "d"`); got != tc.wantD {
+			t.Errorf("LISTRIGHTS %v: %s; virtual d group present = %v, want %v", tc.optional, line, got, tc.wantD)
+		}
+	}
+}
+
+// TestSessionWithoutDeclarationGetsTheDefaultFamily: a plain SessionACL is
+// served exactly as before this interface existed.
+func TestSessionWithoutDeclarationGetsTheDefaultFamily(t *testing.T) {
+	conn := newACLTestConn(t, &aclRecordingSession{}, &bytes.Buffer{})
+	vr := conn.virtualRights()
+	if !vr.create.Equal(imap.RightSet("kx")) || !vr.delete.Equal(imap.RightSet("te")) {
+		t.Errorf("default virtual rights c=%q d=%q, want c=kx d=te", vr.create, vr.delete)
+	}
+}

--- a/imapserver/capability.go
+++ b/imapserver/capability.go
@@ -152,8 +152,12 @@ func (c *Conn) availableCaps() []imap.Cap {
 		}
 
 		// Add ACL capability if the session supports it (RFC 4314). The
-		// extension also requires advertising the "RIGHTS=" capability listing
-		// the rights introduced by RFC 4314 (k, x, t, e); see Section 2.1.
+		// extension also requires advertising the "RIGHTS=" capability naming
+		// the rights the server implements beyond RFC 2086's. §6's formal
+		// syntax fixes its content ("new-rights ... MUST include t, e, x, and
+		// k"), so it is a constant and not derived from what a session lets a
+		// grant carry (SessionACLVirtualRights): a backend that never grants
+		// `x` still implements it, and still lists it here.
 		if _, ok := c.session.(SessionACL); ok {
 			caps = append(caps, imap.CapACL)
 			caps = append(caps, imap.Cap("RIGHTS="+imap.RightSetExtended.String()))

--- a/imapserver/cmd_acl.go
+++ b/imapserver/cmd_acl.go
@@ -1,8 +1,6 @@
 package imapserver
 
 import (
-	"strings"
-
 	"github.com/emersion/go-imap/v2"
 	"github.com/emersion/go-imap/v2/internal"
 	"github.com/emersion/go-imap/v2/internal/imapwire"
@@ -64,7 +62,7 @@ func (c *Conn) handleSetACL(dec *imapwire.Decoder) error {
 	}
 
 	identifier := imap.RightsIdentifier(identifierStr)
-	return session.SetACL(c.ctx, mailbox, identifier, modification, expandVirtualRights(rights))
+	return session.SetACL(c.ctx, mailbox, identifier, modification, expandVirtualRights(rights, c.virtualRights()))
 }
 
 func (c *Conn) handleDeleteACL(dec *imapwire.Decoder) error {
@@ -141,10 +139,11 @@ func (c *Conn) writeGetACL(data *imap.GetACLData) error {
 	enc := newResponseEncoder(c)
 	defer enc.end()
 
+	vr := c.virtualRights()
 	enc.Atom("*").SP().Atom("ACL").SP().Mailbox(data.Mailbox)
 	for i := range data.ACL {
 		entry := &data.ACL[i]
-		enc.SP().String(string(entry.Identifier)).SP().String(formatRightsWithCompat(entry.Rights))
+		enc.SP().String(string(entry.Identifier)).SP().String(formatRightsWithCompat(entry.Rights, vr))
 	}
 	return enc.CRLF()
 }
@@ -169,18 +168,19 @@ func (c *Conn) writeListRights(data *imap.ListRightsData) error {
 	// right, that obsolete right MUST be advertised. The members here are listed
 	// individually (each its own group, independently grantable), so the virtual
 	// right is returned by itself as its own group. §3.7 forbids listing any right
-	// more than once, so only add c/d when not already present. The members of
-	// `c` are `k` and `x`, those of `d` are `t` and `e`; see expandVirtualRights.
-	var all strings.Builder
-	all.WriteString(string(data.RequiredRights))
+	// more than once, so only add c/d when not already present. Which rights are
+	// members is the session's declaration (see virtualRights), the same one
+	// SETACL expands against.
+	var all imap.RightSet
+	all = append(all, data.RequiredRights...)
 	for i := range data.OptionalRights {
-		all.WriteString(string(data.OptionalRights[i]))
+		all = append(all, data.OptionalRights[i]...)
 	}
-	allRights := all.String()
-	if strings.ContainsAny(allRights, "kx") && !strings.ContainsRune(allRights, 'c') {
+	vr := c.virtualRights()
+	if anyRightIn(vr.create, all) && !containsRight(all, imap.RightCreate) {
 		enc.SP().String("c")
 	}
-	if strings.ContainsAny(allRights, "te") && !strings.ContainsRune(allRights, 'd') {
+	if anyRightIn(vr.delete, all) && !containsRight(all, imap.RightDelete) {
 		enc.SP().String("d")
 	}
 
@@ -193,7 +193,7 @@ func (c *Conn) writeMyRights(data *imap.MyRightsData) error {
 
 	enc.Atom("*").SP().Atom("MYRIGHTS").SP().
 		Mailbox(data.Mailbox).SP().
-		String(formatRightsWithCompat(data.Rights))
+		String(formatRightsWithCompat(data.Rights, c.virtualRights()))
 
 	return enc.CRLF()
 }
@@ -203,53 +203,102 @@ func formatRights(rm imap.RightModification, rs imap.RightSet) string {
 	return internal.FormatRights(rm, rs)
 }
 
+// virtualRights is the resolved membership of RFC 4314 §2.1.1's virtual `c`
+// and `d` rights for one connection. It is the single source that
+// expandVirtualRights, formatRightsWithCompat and writeListRights all read, so
+// what SETACL accepts on the session's behalf and what GETACL, MYRIGHTS and
+// LISTRIGHTS advertise on its behalf cannot drift apart.
+type virtualRights struct {
+	create imap.RightSet
+	delete imap.RightSet
+}
+
+// virtualRights returns the session's declaration when it makes one
+// (SessionACLVirtualRights) and the RFC's first family otherwise.
+func (c *Conn) virtualRights() virtualRights {
+	if s, ok := c.session.(SessionACLVirtualRights); ok {
+		create, delete := s.VirtualRights()
+		return newVirtualRights(create, delete)
+	}
+	return defaultVirtualRights()
+}
+
+func defaultVirtualRights() virtualRights {
+	return newVirtualRights(DefaultVirtualCreate, DefaultVirtualDelete)
+}
+
+// newVirtualRights normalizes a declaration: the virtual letters themselves
+// are not members of anything, a right is listed once, and a right named in
+// both sets is kept in `create` only. The last rule is what stops a backend
+// from putting `x` in both, which no RFC family does and which would make
+// every output append both `c` and `d` for it.
+func newVirtualRights(create, delete imap.RightSet) virtualRights {
+	var vr virtualRights
+	for _, r := range create {
+		if r != imap.RightCreate && r != imap.RightDelete && !containsRight(vr.create, r) {
+			vr.create = append(vr.create, r)
+		}
+	}
+	for _, r := range delete {
+		if r != imap.RightCreate && r != imap.RightDelete && !containsRight(vr.create, r) && !containsRight(vr.delete, r) {
+			vr.delete = append(vr.delete, r)
+		}
+	}
+	return vr
+}
+
 // expandVirtualRights maps the obsolete RFC 2086 rights a client may still name
-// (RFC 4314 §2.1.1) onto the rights this server actually has: `c` becomes `k`
-// `x`, and `d` becomes `t` `e`.
+// (RFC 4314 §2.1.1) onto their members, as the session declares them: by
+// default `c` becomes `k` `x` and `d` becomes `t` `e`.
 //
 // §2.1.1 describes two server families and lets each define the virtual
 // rights: servers whose RFC 2086 `c` controlled DELETE read `c` as `k`+`x` and
 // `d` as `e`+`t`; servers whose `d` controlled DELETE read `c` as `k` and `d` as
-// `e`+`t`+`x`. Either way `x` is a member of exactly one virtual right, so an
-// RFC 2086 client can still grant and see mailbox deletion. This server is of
-// the first family, as are Dovecot (unconditionally) and Cyrus (its default,
-// deleteright=c): the RFC's own worked examples expand `d` to `et`, and a
-// client written against either expects "SETACL ... d" to delegate deleting and
-// expunging MESSAGES and not the mailbox itself. Leaving `x` out of `c` as well
-// would put it in no virtual right at all, which the RFC does not describe and
-// which makes `x` unreachable for RFC 2086 clients.
+// `e`+`t`+`x`. The default is the first family, as are Dovecot (unconditionally)
+// and Cyrus (its default, deleteright=c): the RFC's own worked examples expand
+// `d` to `et`, and a client written against either expects "SETACL ... d" to
+// delegate deleting and expunging MESSAGES and not the mailbox itself. A
+// backend for which `x` is never grantable declares it a member of neither
+// (SessionACLVirtualRights), so that a client's `c` does not turn into a
+// request the backend must refuse over a letter the client never typed.
 //
-// formatRightsWithCompat and writeListRights are the inverse and must agree:
-// they append `c` when `k` or `x` is held (or grantable), and `d` when `t` or
-// `e` is, never `d` for `x` alone.
-func expandVirtualRights(rs imap.RightSet) imap.RightSet {
-	res := make(imap.RightSet, 0, len(rs))
+// A member the client also named explicitly is not doubled, and an explicit
+// non-member (an `x` under a backend that keeps it out of both) is passed
+// through as the client's own request.
+//
+// formatRightsWithCompat and writeListRights are the inverse and read the same
+// declaration: they append `c` when any create member is held (or grantable)
+// and `d` when any delete member is.
+func expandVirtualRights(rs imap.RightSet, vr virtualRights) imap.RightSet {
+	res := make(imap.RightSet, 0, len(rs)+len(vr.create)+len(vr.delete))
 	hasC := false
 	hasD := false
 	for _, r := range rs {
-		if r == imap.RightCreate {
+		switch r {
+		case imap.RightCreate:
 			hasC = true
-		} else if r == imap.RightDelete {
+		case imap.RightDelete:
 			hasD = true
-		} else {
+		default:
 			res = append(res, r)
 		}
 	}
 	if hasC {
-		for _, cr := range []imap.Right{imap.RightCreateChild, imap.RightDeleteMbox} {
-			if !containsRight(res, cr) {
-				res = append(res, cr)
-			}
-		}
+		res = appendMissing(res, vr.create)
 	}
 	if hasD {
-		for _, dr := range []imap.Right{imap.RightDeleteMsg, imap.RightExpunge} {
-			if !containsRight(res, dr) {
-				res = append(res, dr)
-			}
-		}
+		res = appendMissing(res, vr.delete)
 	}
 	return res
+}
+
+func appendMissing(rs, add imap.RightSet) imap.RightSet {
+	for _, r := range add {
+		if !containsRight(rs, r) {
+			rs = append(rs, r)
+		}
+	}
+	return rs
 }
 
 func containsRight(rs imap.RightSet, r imap.Right) bool {
@@ -261,27 +310,27 @@ func containsRight(rs imap.RightSet, r imap.Right) bool {
 	return false
 }
 
-// formatRightsWithCompat renders a right set for GETACL/MYRIGHTS with the
-// obsolete virtual rights appended (RFC 4314 §2.1.1): `c` when `k` or `x` is
-// held, `d` when `t` or `e` is held. `x` alone implies `c`, not `d`; it is a
-// member of the virtual create right here (see expandVirtualRights).
-func formatRightsWithCompat(rs imap.RightSet) string {
-	hasKX := false
-	hasTE := false
-	for _, r := range rs {
-		if r == imap.RightCreateChild || r == imap.RightDeleteMbox {
-			hasKX = true
-		}
-		if r == imap.RightDeleteMsg || r == imap.RightExpunge {
-			hasTE = true
+// anyRightIn reports whether any of members is present in rs.
+func anyRightIn(members, rs imap.RightSet) bool {
+	for _, m := range members {
+		if containsRight(rs, m) {
+			return true
 		}
 	}
+	return false
+}
 
+// formatRightsWithCompat renders a right set for GETACL/MYRIGHTS with the
+// obsolete virtual rights appended (RFC 4314 §2.1.1): `c` when any member of
+// the virtual create right is held, `d` when any member of the virtual delete
+// right is. Membership is the session's declaration, the same one
+// expandVirtualRights reads; by default `x` alone implies `c`, not `d`.
+func formatRightsWithCompat(rs imap.RightSet, vr virtualRights) string {
 	s := string(rs)
-	if hasKX && !strings.ContainsRune(s, 'c') {
+	if anyRightIn(vr.create, rs) && !containsRight(rs, imap.RightCreate) {
 		s += "c"
 	}
-	if hasTE && !strings.ContainsRune(s, 'd') {
+	if anyRightIn(vr.delete, rs) && !containsRight(rs, imap.RightDelete) {
 		s += "d"
 	}
 	return s


### PR DESCRIPTION
RFC 4314 section 2.1.1 leaves the membership of the obsolete c and d rights to the server, and describes two families: c = k+x with d = e+t, or c = k with d = e+t+x. imapserver hardcoded the first, which is right for Dovecot and Cyrus and wrong for a backend that implements x but never lets a grant carry it. Such a backend advertised c in LISTRIGHTS (k is grantable) while a client's "SETACL ... c" reached it as k x and was refused over the x - the same contradiction the earlier d fix removed, reintroduced on the other letter.

SessionACLVirtualRights is an optional extension of SessionACL whose one method returns both member sets. It is a single method on purpose: the expansion of an incoming c/d (SETACL), the c/d appended to GETACL and MYRIGHTS, and the c/d groups added to LISTRIGHTS now all read one resolved value per connection, so they cannot disagree. The declaration is normalized before use - the virtual letters and duplicates are dropped, and a right named in both sets stays in create, so x cannot be in both. A session that does not implement the interface gets the previous family unchanged (DefaultVirtualCreate, DefaultVirtualDelete); imapmemserver is untouched.

RIGHTS= is deliberately not derived from the declaration. Section 6's formal syntax fixes it ("new-rights ... MUST include t, e, x, and k"), so it names the rights the server implements, not the ones a grant may carry; the capability comment and its test now cite that section instead of overstating 2.1.

Tests: normalization, expansion and compat rendering are checked for the default family, the second family, a c = k declaration and an empty one; a handler-level test drives a declaring session through SETACL and the three writers and pins that the wire agrees with itself; the existing default-family tests are unchanged in substance.