### PR TITLE
imapserver: BAD for a memberless virtual right; drop memserver's duplicate c/d expansion

### DIFF
--- a/imapserver/acl.go
+++ b/imapserver/acl.go
@@ -82,8 +82,10 @@ type SessionACLVirtualRights interface {
 	SessionACL
 
 	// VirtualRights returns the members of the virtual `c` (create) and `d`
-	// (delete) rights, in that order. Either may be empty, in which case that
-	// virtual right expands to nothing and is never advertised.
+	// (delete) rights, in that order. Either may be empty, in which case the
+	// server does not have that virtual right: a client naming it in SETACL is
+	// refused with BAD (RFC 4314 §3.1, unrecognized right), and it is never
+	// appended to GETACL, MYRIGHTS or LISTRIGHTS.
 	VirtualRights() (create, delete imap.RightSet)
 }
 

--- a/imapserver/acl_capability_test.go
+++ b/imapserver/acl_capability_test.go
@@ -122,7 +122,11 @@ func TestExpandVirtualRights(t *testing.T) {
 	}
 
 	for _, tc := range tests {
-		got := expandVirtualRights(tc.input, defaultVirtualRights())
+		got, err := expandVirtualRights(tc.input, defaultVirtualRights())
+		if err != nil {
+			t.Errorf("expandVirtualRights(%q): %v", tc.input, err)
+			continue
+		}
 		if !got.Equal(tc.want) {
 			t.Errorf("expandVirtualRights(%q) = %q, want %q", tc.input, got, tc.want)
 		}

--- a/imapserver/acl_virtual_delete_test.go
+++ b/imapserver/acl_virtual_delete_test.go
@@ -19,12 +19,14 @@ type aclRecordingSession struct {
 	Session
 	setRights imap.RightSet
 	setMod    imap.RightModification
+	calls     int
 }
 
 func (s *aclRecordingSession) GetACL(ctx context.Context, mailbox string) (*imap.GetACLData, error) {
 	return nil, nil
 }
 func (s *aclRecordingSession) SetACL(ctx context.Context, mailbox string, id imap.RightsIdentifier, mod imap.RightModification, rights imap.RightSet) error {
+	s.calls++
 	s.setMod, s.setRights = mod, rights
 	return nil
 }

--- a/imapserver/acl_virtual_rights_session_test.go
+++ b/imapserver/acl_virtual_rights_session_test.go
@@ -2,6 +2,7 @@ package imapserver
 
 import (
 	"bytes"
+	"errors"
 	"strings"
 	"testing"
 
@@ -60,7 +61,6 @@ func TestNewVirtualRightsNormalizes(t *testing.T) {
 func TestExpandVirtualRightsFollowsDeclaration(t *testing.T) {
 	noX := newVirtualRights(imap.RightSet("k"), imap.RightSet("te"))
 	second := newVirtualRights(imap.RightSet("k"), imap.RightSet("xte"))
-	none := newVirtualRights(nil, nil)
 
 	cases := []struct {
 		vr    virtualRights
@@ -74,14 +74,70 @@ func TestExpandVirtualRightsFollowsDeclaration(t *testing.T) {
 		{second, imap.RightSet("c"), imap.RightSet("k")},
 		{second, imap.RightSet("d"), imap.RightSet("xte")},
 		{second, imap.RightSet("lrswicd"), imap.RightSet("lrswikxte")},
-		// An empty declaration expands the virtual right to nothing.
-		{none, imap.RightSet("lrcd"), imap.RightSet("lr")},
 	}
 	for _, tc := range cases {
-		got := expandVirtualRights(tc.input, tc.vr)
+		got, err := expandVirtualRights(tc.input, tc.vr)
+		if err != nil {
+			t.Errorf("expandVirtualRights(%q, c=%q d=%q): %v", tc.input, tc.vr.create, tc.vr.delete, err)
+			continue
+		}
 		if !got.Equal(tc.want) || len(got) != len(tc.want) {
 			t.Errorf("expandVirtualRights(%q, c=%q d=%q) = %q, want %q", tc.input, tc.vr.create, tc.vr.delete, got, tc.want)
 		}
+	}
+}
+
+// TestMemberlessVirtualRightIsRefused pins RFC 4314 §3.1 for a virtual right
+// the session declares without members: it is not a right this server has, so
+// naming it is a client bug (BAD), never an empty expansion. Before the fix
+// "SETACL INBOX bob c" under such a declaration reached the session as an empty
+// Replace and silently revoked bob's entry. Explicit member letters are
+// unaffected, and a declaration that empties only one virtual right refuses
+// only that one.
+func TestMemberlessVirtualRightIsRefused(t *testing.T) {
+	none := newVirtualRights(nil, nil)
+	noDelete := newVirtualRights(imap.RightSet("kx"), nil)
+
+	cases := []struct {
+		vr      virtualRights
+		input   imap.RightSet
+		want    imap.RightSet
+		wantBad bool
+	}{
+		{none, imap.RightSet("c"), nil, true},
+		{none, imap.RightSet("lrd"), nil, true},
+		{none, imap.RightSet("lrkx"), imap.RightSet("lrkx"), false},
+		{noDelete, imap.RightSet("lrc"), imap.RightSet("lrkx"), false},
+		{noDelete, imap.RightSet("lrd"), nil, true},
+	}
+	for _, tc := range cases {
+		got, err := expandVirtualRights(tc.input, tc.vr)
+		if tc.wantBad {
+			var imapErr *imap.Error
+			if !errors.As(err, &imapErr) || imapErr.Type != imap.StatusResponseTypeBad {
+				t.Errorf("expandVirtualRights(%q, c=%q d=%q) = %q, %v; want a BAD error", tc.input, tc.vr.create, tc.vr.delete, got, err)
+			}
+			continue
+		}
+		if err != nil {
+			t.Errorf("expandVirtualRights(%q, c=%q d=%q): %v", tc.input, tc.vr.create, tc.vr.delete, err)
+			continue
+		}
+		if !got.Equal(tc.want) || len(got) != len(tc.want) {
+			t.Errorf("expandVirtualRights(%q, c=%q d=%q) = %q, want %q", tc.input, tc.vr.create, tc.vr.delete, got, tc.want)
+		}
+	}
+
+	// Through the handler: the session must not be called at all.
+	session := &aclFamilySession{}
+	conn := newACLTestConn(t, session, &bytes.Buffer{})
+	err := conn.handleSetACL(argsDecoder(" INBOX bob lrc"))
+	var imapErr *imap.Error
+	if !errors.As(err, &imapErr) || imapErr.Type != imap.StatusResponseTypeBad {
+		t.Fatalf("handleSetACL under an empty declaration returned %v, want BAD", err)
+	}
+	if session.calls != 0 {
+		t.Errorf("session.SetACL was called %d time(s) with rights %q; a refused SETACL must not reach the backend", session.calls, session.setRights)
 	}
 }
 

--- a/imapserver/cmd_acl.go
+++ b/imapserver/cmd_acl.go
@@ -62,7 +62,11 @@ func (c *Conn) handleSetACL(dec *imapwire.Decoder) error {
 	}
 
 	identifier := imap.RightsIdentifier(identifierStr)
-	return session.SetACL(c.ctx, mailbox, identifier, modification, expandVirtualRights(rights, c.virtualRights()))
+	expanded, err := expandVirtualRights(rights, c.virtualRights())
+	if err != nil {
+		return err
+	}
+	return session.SetACL(c.ctx, mailbox, identifier, modification, expanded)
 }
 
 func (c *Conn) handleDeleteACL(dec *imapwire.Decoder) error {
@@ -266,10 +270,16 @@ func newVirtualRights(create, delete imap.RightSet) virtualRights {
 // non-member (an `x` under a backend that keeps it out of both) is passed
 // through as the client's own request.
 //
+// A virtual right the session declares with no members is not a right this
+// server has at all, and RFC 4314 §3.1 requires an unrecognized right to draw a
+// BAD rather than be ignored: naming it returns a client-bug error, so that
+// "SETACL ... c" against such a backend cannot quietly turn into an empty
+// replacement that revokes the identifier's entry.
+//
 // formatRightsWithCompat and writeListRights are the inverse and read the same
 // declaration: they append `c` when any create member is held (or grantable)
 // and `d` when any delete member is.
-func expandVirtualRights(rs imap.RightSet, vr virtualRights) imap.RightSet {
+func expandVirtualRights(rs imap.RightSet, vr virtualRights) (imap.RightSet, error) {
 	res := make(imap.RightSet, 0, len(rs)+len(vr.create)+len(vr.delete))
 	hasC := false
 	hasD := false
@@ -284,12 +294,18 @@ func expandVirtualRights(rs imap.RightSet, vr virtualRights) imap.RightSet {
 		}
 	}
 	if hasC {
+		if len(vr.create) == 0 {
+			return nil, newClientBugError("The c right is not supported")
+		}
 		res = appendMissing(res, vr.create)
 	}
 	if hasD {
+		if len(vr.delete) == 0 {
+			return nil, newClientBugError("The d right is not supported")
+		}
 		res = appendMissing(res, vr.delete)
 	}
-	return res
+	return res, nil
 }
 
 func appendMissing(rs, add imap.RightSet) imap.RightSet {

--- a/imapserver/imapmemserver/session.go
+++ b/imapserver/imapmemserver/session.go
@@ -664,18 +664,10 @@ func (sess *UserSession) SetACL(ctx context.Context, name string, identifier ima
 		}
 	}
 
-	// Apply modification
+	// Apply modification. The obsolete virtual rights `c` and `d` never reach
+	// here: imapserver expands them against the session's declaration (or the
+	// default family) before calling SetACL, so there is one mapping, not two.
 	currentRights := mbox.acl[identifier]
-
-	// Handle obsolete rights for backwards compatibility (RFC 4314 §2.1.1):
-	// `c` is `k`+`x` and `d` is `t`+`e`, the same reading as imapserver's
-	// expandVirtualRights, so the two layers agree.
-	if strings.Contains(string(rights), "c") {
-		rights = rights.Add(imap.RightSet("kx"))
-	}
-	if strings.Contains(string(rights), "d") {
-		rights = rights.Add(imap.RightSet("te"))
-	}
 
 	before := mbox.acl[imap.RightsIdentifier(sess.user.username)]
 


### PR DESCRIPTION
Follow-ups to #53.

**Memberless virtual right → BAD.** A session may declare `c` or `d` with no members. That meant "this server doesn't have the virtual right", but the expansion treated it as "expands to nothing": `SETACL INBOX bob c` under an empty create set reached the backend as an empty Replace and silently revoked bob's entry. RFC 4314 §3.1 requires an unrecognized right to draw a `BAD`, so `expandVirtualRights` now returns a client-bug error for a virtual right with an empty declared set, and `handleSetACL` returns it before touching the session. Explicit member letters are unaffected; a declaration that empties only one virtual right refuses only that one. Interface doc updated.

**imapmemserver duplicate expansion removed.** Its `SetACL` still had its own `c`→`kx` / `d`→`te` mapping. It was dead (imapserver expands before calling `SetACL`) and a second copy of the mapping #53 made singular.

Tests: `TestMemberlessVirtualRightIsRefused` pins the `BAD` at the expansion and at the handler (session records it was not called); fails with the guard removed and the signature kept. Full suite and `-race` on `imapserver/...` green. Default-family behaviour (sora) unchanged.
