### PR TITLE
imapserver: answer BAD for a parse failure, not NO [SERVERBUG]

### DIFF
--- a/imapserver/parse_error_wire_test.go
+++ b/imapserver/parse_error_wire_test.go
@@ -1,0 +1,129 @@
+package imapserver_test
+
+import (
+	"bufio"
+	"context"
+	"errors"
+	"fmt"
+	"net"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/emersion/go-imap/v2"
+	"github.com/emersion/go-imap/v2/imapserver"
+	"github.com/emersion/go-imap/v2/imapserver/imapmemserver"
+)
+
+// parseWire is a raw connection to a server: these cases are about the exact
+// status line, which a client library hides.
+type parseWire struct {
+	t    *testing.T
+	conn net.Conn
+	rd   *bufio.Reader
+}
+
+func dialParseServer(t *testing.T, newSession func(imapserver.Session) imapserver.Session) *parseWire {
+	t.Helper()
+	mem := imapmemserver.New()
+	u := imapmemserver.NewUser("u", "p")
+	if err := u.Create(context.Background(), "INBOX", nil); err != nil {
+		t.Fatal(err)
+	}
+	mem.AddUser(u)
+	srv := imapserver.New(&imapserver.Options{
+		NewSession: func(*imapserver.Conn) (imapserver.Session, *imapserver.GreetingData, error) {
+			s := imapserver.Session(mem.NewSession())
+			if newSession != nil {
+				s = newSession(s)
+			}
+			return s, nil, nil
+		},
+		InsecureAuth: true,
+		Caps:         imap.CapSet{imap.CapIMAP4rev1: struct{}{}},
+	})
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { ln.Close() })
+	go srv.Serve(ln) //nolint:errcheck
+
+	c, err := net.Dial("tcp", ln.Addr().String())
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { c.Close() })
+	w := &parseWire{t: t, conn: c, rd: bufio.NewReader(c)}
+	w.line()
+	fmt.Fprint(w.conn, "a1 LOGIN u p\r\n")
+	w.until("a1")
+	return w
+}
+
+func (w *parseWire) line() string {
+	w.t.Helper()
+	_ = w.conn.SetReadDeadline(time.Now().Add(3 * time.Second))
+	l, err := w.rd.ReadString('\n')
+	if err != nil {
+		w.t.Fatalf("read: %v", err)
+	}
+	return strings.TrimRight(l, "\r\n")
+}
+
+// until returns the tagged status line for tag.
+func (w *parseWire) until(tag string) string {
+	w.t.Helper()
+	for {
+		l := w.line()
+		if strings.HasPrefix(l, tag+" ") {
+			return l
+		}
+	}
+}
+
+// A command the grammar refuses is answered BAD, not NO [SERVERBUG]: a parse
+// failure arriving as a plain error tells the client the server is broken.
+func TestMalformedCommandIsBad(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		cmd  string
+	}{
+		{"sequence-set", `a2 SEARCH HEADER Subject fileinto test`},
+		{"mailbox name", `a2 SELECT "&"`},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			w := dialParseServer(t, nil)
+			fmt.Fprint(w.conn, tc.cmd+"\r\n")
+			got := w.until("a2")
+			if strings.Contains(got, "SERVERBUG") {
+				t.Errorf("malformed command answered %q; want BAD", got)
+			}
+			if !strings.HasPrefix(got, "a2 BAD") {
+				t.Errorf("answer was %q; want BAD", got)
+			}
+		})
+	}
+}
+
+// failingSelect answers a well-formed SELECT with a plain error, which is what a
+// server fault looks like to the connection loop.
+type failingSelect struct {
+	imapserver.Session
+}
+
+func (s *failingSelect) Select(context.Context, string, *imap.SelectOptions) (*imap.SelectData, error) {
+	return nil, errors.New("boom")
+}
+
+// A plain error from the handler is still NO [SERVERBUG]: this classifies parse
+// failures, it does not answer BAD to everything.
+func TestHandlerErrorIsServerBug(t *testing.T) {
+	w := dialParseServer(t, func(s imapserver.Session) imapserver.Session {
+		return &failingSelect{Session: s}
+	})
+	fmt.Fprint(w.conn, "a2 SELECT INBOX\r\n")
+	if got := w.until("a2"); !strings.Contains(got, "SERVERBUG") {
+		t.Errorf("handler error answered %q; want NO [SERVERBUG]", got)
+	}
+}

--- a/imapserver/search.go
+++ b/imapserver/search.go
@@ -458,7 +458,11 @@ func readSearchKeyWithAtomDepth(c *Conn, criteria *imap.SearchCriteria, dec *ima
 	default:
 		seqSet, err := imapwire.ParseSeqSet(key)
 		if err != nil {
-			return err
+			// An unknown key reaches here as a sequence-set candidate; failing
+			// to parse it is the client's syntax, not a server fault.
+			return &imapwire.DecoderExpectError{
+				Message: fmt.Sprintf("invalid search-key %q", key),
+			}
 		}
 		criteria.SeqNum = append(criteria.SeqNum, seqSet)
 	}

--- a/internal/imapwire/decoder.go
+++ b/internal/imapwire/decoder.go
@@ -743,10 +743,15 @@ func (dec *Decoder) ExpectMailbox(ptr *string) bool {
 	}
 
 	name, err := utf7.Decode(name)
-	if err == nil {
-		*ptr = name
+	if err != nil {
+		// A name that is not modified UTF-7 is a malformed command: the loop
+		// answers BAD for an expect error, NO [SERVERBUG] for anything else.
+		return dec.returnErr(&DecoderExpectError{
+			Message: fmt.Sprintf("invalid mailbox name: %v", err),
+		})
 	}
-	return dec.returnErr(err)
+	*ptr = name
+	return true
 }
 
 func (dec *Decoder) ExpectUID(ptr *imap.UID) bool {
@@ -770,7 +775,10 @@ func (dec *Decoder) ExpectNumSet(kind NumKind, ptr *imap.NumSet) bool {
 	}
 	numSet, err := imapnum.ParseSet(s)
 	if err != nil {
-		return dec.returnErr(err)
+		// Same: the client sent what the grammar does not allow.
+		return dec.returnErr(&DecoderExpectError{
+			Message: fmt.Sprintf("invalid sequence-set: %v", err),
+		})
 	}
 
 	switch kind {


### PR DESCRIPTION
Cherry-pick of upstream emersion/go-imap#765 (commit 4e57c06, opened 2026-09-05; sr.ht CI green, no maintainer review yet). Picked with `-x`, original authorship kept.

## Problem

A malformed command is answered `NO [SERVERBUG] Internal server error` and logged as a server fault, when it is the client's syntax:

```
a1 SEARCH HEADER Subject "fileinto test"   -> OK
a1 SEARCH HEADER Subject fileinto test     -> NO [SERVERBUG] Internal server error
```

The connection loop already maps `*imapwire.DecoderExpectError` to `BAD [CLIENTBUG] Syntax error: ...` and everything else to `NO [SERVERBUG]`. Three parse failures returned a plain error and so fell into the second branch:

- `Decoder.ExpectNumSet`, when `imapnum.ParseSet` refuses the sequence-set
- `Decoder.ExpectMailbox`, when the name is not modified UTF-7
- `readSearchKeyWithAtom`'s default branch, which treats an unknown search key as a sequence-set candidate (the case real clients hit)

Each now returns a `DecoderExpectError`, so the answer is BAD with the syntax text. RFC 9051 §7.1.3: a tagged BAD reports a protocol-level error in the client's command.

## Fork adaptation

Test file only. Our `imapmemserver.User.Create` and `Session.Select` take a context, so the test's two calls were adjusted. Both source hunks applied unchanged.

## Verification

- Red control: PR tests against unpatched `sora` HEAD fail with `a2 NO [SERVERBUG] Internal server error` for both the sequence-set and mailbox-name cases.
- With the patch: `TestMalformedCommandIsBad` and `TestHandlerErrorIsServerBug` pass.
- `go test -race ./imapserver/... ./internal/imapwire/... ./imapclient/...` green.

## Notes

- `DecoderExpectError` does not wrap the cause, so `errors.Is(err, utf7.ErrInvalidUTF7)` no longer holds for these paths. Nothing in the fork, imapclient, or sora checks it.
- The decoder is shared with imapclient, so a malformed server response now yields a different error string on the client side. Only the text changes; the imapclient suite is green.
- Left alone, as upstream did: the default buffered-literal cap still returns a plain error and so is still answered `NO [SERVERBUG]`. Separate follow-up.

Sora follow-up: bump the `replace` pin in go.mod to this commit.
