### PR TITLE
imapwire: refuse an oversized literal as a syntax error, not a server fault

### DIFF
--- a/imapserver/literal_error_wire_test.go
+++ b/imapserver/literal_error_wire_test.go
@@ -1,0 +1,69 @@
+package imapserver_test
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+)
+
+// A literal the decoder refuses on sight -- a size beyond what the grammar's
+// sanity bound allows -- is the client's syntax, so the answer is BAD rather
+// than NO [SERVERBUG]. The announcement is rejected before any continuation
+// request, so a synchronizing literal never has a payload to skip.
+func TestOversizedLiteralAnnouncementIsBad(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		cmd  string
+	}{
+		{"beyond the sanity bound", `a2 SELECT {99999999999}`},
+		{"does not fit in int64", `a2 SELECT {99999999999999999999999}`},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			w := dialParseServer(t, nil)
+			fmt.Fprint(w.conn, tc.cmd+"\r\n")
+			got := w.until("a2")
+			if strings.Contains(got, "SERVERBUG") {
+				t.Errorf("oversized literal answered %q; want BAD", got)
+			}
+			if !strings.HasPrefix(got, "a2 BAD") {
+				t.Errorf("answer was %q; want BAD", got)
+			}
+		})
+	}
+}
+
+// The server's own size check still decides the response for a literal that is
+// merely larger than it accepts: that stays NO [TOOBIG], the typed error the
+// check returns, and is not folded into the syntax-error path.
+func TestBufferedLiteralOverServerLimitIsTooBig(t *testing.T) {
+	w := dialParseServer(t, nil)
+	fmt.Fprint(w.conn, "a2 SELECT {5000}\r\n")
+	got := w.until("a2")
+	if !strings.HasPrefix(got, "a2 NO ") || !strings.Contains(got, "[TOOBIG]") {
+		t.Errorf("answer was %q; want NO [TOOBIG]", got)
+	}
+}
+
+// The non-synchronizing form of the same announcement has an unvalidated
+// quantity of octets in flight behind it. The server cannot skip them, so it
+// ends the connection with BYE rather than parse the next command from inside
+// client data (RFC 9051 §2.2.1).
+func TestOversizedNonSyncLiteralClosesConnection(t *testing.T) {
+	w := dialParseServer(t, nil)
+	fmt.Fprint(w.conn, "a2 SELECT {99999999999+}\r\n")
+	for {
+		_ = w.conn.SetReadDeadline(time.Now().Add(3 * time.Second))
+		l, err := w.rd.ReadString('\n')
+		if err != nil {
+			t.Fatalf("connection ended without a BYE: %v", err)
+		}
+		l = strings.TrimRight(l, "\r\n")
+		if strings.HasPrefix(l, "* BYE") {
+			return
+		}
+		if strings.HasPrefix(l, "a2 ") {
+			t.Fatalf("got a tagged answer %q; want the connection closed with BYE", l)
+		}
+	}
+}

--- a/internal/imapwire/decoder.go
+++ b/internal/imapwire/decoder.go
@@ -824,7 +824,11 @@ func (dec *Decoder) Literal(ptr *string) bool {
 		}
 	} else if lit.Size() > absoluteMaxBufferedLiteral {
 		lit.cancel(nil)
-		return dec.returnErr(fmt.Errorf("imapwire: literal of %d bytes exceeds default buffered cap", lit.Size()))
+		// The peer sent more than is allowed here: a syntax error, which a
+		// server answers with BAD, not an internal failure.
+		return dec.returnErr(&DecoderExpectError{
+			Message: fmt.Sprintf("literal of %d bytes exceeds the %d byte limit", lit.Size(), absoluteMaxBufferedLiteral),
+		})
 	}
 	var sb strings.Builder
 	_, err := io.Copy(&sb, lit)
@@ -847,12 +851,22 @@ func (dec *Decoder) LiteralReader() (lit *LiteralReader, nonSync, ok bool) {
 	// than 1 GiB in a single literal without orchestration outside the
 	// protocol.
 	const absoluteMaxLiteralSize = 1 << 30
-	if size < 0 || size > absoluteMaxLiteralSize {
-		dec.returnErr(fmt.Errorf("imapwire: literal size %d out of bounds", size))
-		return nil, false, false
-	}
 	if dec.side == ConnSideServer {
 		nonSync = dec.acceptByte('+')
+	}
+	if size < 0 || size > absoluteMaxLiteralSize {
+		// Refused on sight, so the peer's syntax: an expect error, which a
+		// server answers with BAD. The octets of a non-synchronizing literal
+		// are on the wire regardless, in a quantity nobody validated, and the
+		// announcement is consumed past the point where DiscardLine could
+		// recognise it -- the stream cannot be resynchronised.
+		if nonSync {
+			dec.desynced = true
+		}
+		dec.returnErr(&DecoderExpectError{
+			Message: fmt.Sprintf("literal size %d out of bounds", size),
+		})
+		return nil, false, false
 	}
 	if !dec.ExpectSpecial('}') || !dec.ExpectCRLF() {
 		return nil, false, false

--- a/internal/imapwire/decoder_literal_errors_test.go
+++ b/internal/imapwire/decoder_literal_errors_test.go
@@ -1,0 +1,61 @@
+package imapwire
+
+import (
+	"bufio"
+	"errors"
+	"strings"
+	"testing"
+)
+
+func newServerDecoder(input string) *Decoder {
+	return NewDecoder(bufio.NewReader(strings.NewReader(input)), ConnSideServer)
+}
+
+func expectErrorRecorded(t *testing.T, dec *Decoder) {
+	t.Helper()
+	var expectErr *DecoderExpectError
+	if err := dec.Err(); !errors.As(err, &expectErr) {
+		t.Fatalf("recorded error is %T (%v); want *DecoderExpectError", err, err)
+	}
+}
+
+// Without a CheckBufferedLiteralFunc the decoder applies its own cap on
+// literals it must buffer. Exceeding it is the peer's syntax, so the recorded
+// error is a DecoderExpectError -- the type a server maps to BAD -- and not a
+// plain error that reads as an internal failure.
+func TestLiteralDefaultCapIsExpectError(t *testing.T) {
+	dec := newServerDecoder("{5000000}\r\n")
+	var s string
+	if dec.Literal(&s) {
+		t.Fatal("Literal accepted a literal over the default cap")
+	}
+	expectErrorRecorded(t, dec)
+}
+
+// A literal size beyond the sanity bound is refused on sight. The refusal is a
+// syntax error, and what it does to the stream depends on the literal's kind:
+// a synchronizing literal was never sent, so the connection recovers; a
+// non-synchronizing one has an unvalidated quantity of octets in flight, so the
+// stream cannot be resynchronised.
+func TestLiteralSizeOutOfBounds(t *testing.T) {
+	for _, tc := range []struct {
+		name     string
+		input    string
+		desynced bool
+	}{
+		{"synchronizing", "{99999999999}\r\n", false},
+		{"non-synchronizing", "{99999999999+}\r\n", true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			dec := newServerDecoder(tc.input)
+			if _, _, ok := dec.LiteralReader(); ok {
+				t.Fatal("LiteralReader accepted a size beyond the bound")
+			}
+			expectErrorRecorded(t, dec)
+			dec.DiscardLine()
+			if got := dec.Desynchronized(); got != tc.desynced {
+				t.Errorf("Desynchronized() = %v, want %v", got, tc.desynced)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Follow-up to #55 (upstream emersion/go-imap#765), which left the literal paths alone.

## Problem

Two literal refusals still reached the connection loop as plain errors, so they were answered `NO [SERVERBUG] Internal server error` and logged as server faults:

- `LiteralReader`, when the announced size is beyond the 1 GiB sanity bound (`a2 SELECT {99999999999}`)
- `Literal`, when no `CheckBufferedLiteralFunc` is set and the literal is over the 4 MiB default buffered cap (only reachable outside `imapserver`, which always installs its own check)

Both are the peer's syntax and now record a `DecoderExpectError`, so a server answers `BAD` with the syntax text. The server's own size check is unaffected: it returns typed errors, and `NO [TOOBIG]` stays `NO [TOOBIG]` (guarded by a test).

## Resynchronisation

An out-of-bounds **non-synchronizing** announcement also left the stream unrecoverable without saying so. The digits were consumed before the refusal, so `DiscardLine` saw only `+}` and could not recognise the announcement; the payload, of a size nobody validated, would have been parsed as the next command. The refusal now parses the `+` first and marks the stream desynchronised, so the server ends the connection with `* BYE Unable to resynchronize command stream` (RFC 9051 §2.2.1), the same outcome as for a refused non-sync literal too large to skip. The synchronizing form was never sent, so that connection stays usable and gets a tagged `BAD`.

## Verification

- Red before the fix: `{99999999999}` answered `NO [SERVERBUG]`; the default-cap error was a plain `*errors.errorString`.
- New tests: decoder-level (`TestLiteralDefaultCapIsExpectError`, `TestLiteralSizeOutOfBounds` sync/non-sync with `Desynchronized()`), wire-level (`TestOversizedLiteralAnnouncementIsBad`, `TestOversizedNonSyncLiteralClosesConnection`, and the `NO [TOOBIG]` guard).
- `go test -race ./imapserver/... ./internal/imapwire/... ./imapclient/...` green, including the existing `TestCommandErrorLiteralRecovery` table.

Sora follow-up: bump the `replace` pin and extend the sora-level guard with the `{99999999999}` case.
