### PR TITLE
imapserver: avoid int64 overflow in extractPartial (upstream #766)

### DIFF
--- a/imapserver/message.go
+++ b/imapserver/message.go
@@ -153,14 +153,15 @@ func extractPartial(b []byte, partial *imap.SectionPartial) []byte {
 		return b
 	}
 
-	end := partial.Offset + partial.Size
 	if partial.Offset > int64(len(b)) {
 		return nil
 	}
-	if end > int64(len(b)) {
-		end = int64(len(b))
+	// Offset+Size can overflow int64, so clamp the remaining length instead.
+	size := int64(len(b)) - partial.Offset
+	if partial.Size >= 0 && partial.Size < size {
+		size = partial.Size
 	}
-	return b[partial.Offset:end]
+	return b[partial.Offset : partial.Offset+size]
 }
 
 func ExtractBinarySection(r io.Reader, item *imap.FetchItemBinarySection) []byte {

--- a/imapserver/partial_test.go
+++ b/imapserver/partial_test.go
@@ -1,0 +1,27 @@
+package imapserver
+
+import (
+	"testing"
+
+	"github.com/emersion/go-imap/v2"
+)
+
+func TestExtractPartialOverflow(t *testing.T) {
+	b := []byte("hello world")
+	for _, tc := range []struct {
+		name    string
+		partial imap.SectionPartial
+		want    string
+	}{
+		{"overflow", imap.SectionPartial{Offset: 5, Size: 1<<63 - 1}, " world"},
+		{"negative-size", imap.SectionPartial{Offset: 5, Size: -1}, " world"},
+		{"normal", imap.SectionPartial{Offset: 2, Size: 3}, "llo"},
+		{"clamped", imap.SectionPartial{Offset: 6, Size: 100}, "world"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := string(extractPartial(b, &tc.partial)); got != tc.want {
+				t.Errorf("got %q, want %q", got, tc.want)
+			}
+		})
+	}
+}

--- a/imapserver/partial_wire_test.go
+++ b/imapserver/partial_wire_test.go
@@ -1,0 +1,62 @@
+package imapserver_test
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+)
+
+// A FETCH partial whose offset and size sum past int64 used to panic inside
+// extractPartial and drop the connection. The server must answer it like any
+// other over-long range: the remainder of the section from the offset.
+func TestFetchPartialOverflowAnswered(t *testing.T) {
+	w := dialParseServer(t, nil)
+
+	msg := "Subject: hi\r\n\r\nhello world\r\n"
+	fmt.Fprintf(w.conn, "a2 APPEND INBOX {%d}\r\n", len(msg))
+	if l := w.line(); !strings.HasPrefix(l, "+") {
+		t.Fatalf("APPEND continuation: got %q", l)
+	}
+	fmt.Fprint(w.conn, msg+"\r\n")
+	if got := w.until("a2"); !strings.HasPrefix(got, "a2 OK") {
+		t.Fatalf("APPEND: %q", got)
+	}
+	fmt.Fprint(w.conn, "a3 SELECT INBOX\r\n")
+	if got := w.until("a3"); !strings.HasPrefix(got, "a3 OK") {
+		t.Fatalf("SELECT: %q", got)
+	}
+
+	fmt.Fprint(w.conn, "a4 FETCH 1 BODY[]<5.9223372036854775807>\r\n")
+	want := msg[5:]
+	var sawData bool
+	for {
+		l := w.line()
+		if strings.HasPrefix(l, "a4 ") {
+			if !strings.HasPrefix(l, "a4 OK") {
+				t.Fatalf("FETCH answered %q; want OK", l)
+			}
+			break
+		}
+		if !strings.HasPrefix(l, "* 1 FETCH (") || !strings.Contains(l, " BODY[]<5> {") {
+			continue
+		}
+		sawData = true
+		if !strings.HasSuffix(l, fmt.Sprintf("{%d}", len(want))) {
+			t.Errorf("literal size in %q; want %d", l, len(want))
+		}
+		buf := make([]byte, len(want))
+		for n := 0; n < len(buf); {
+			m, err := w.rd.Read(buf[n:])
+			if err != nil {
+				t.Fatalf("read literal: %v", err)
+			}
+			n += m
+		}
+		if string(buf) != want {
+			t.Errorf("partial = %q; want %q", buf, want)
+		}
+	}
+	if !sawData {
+		t.Errorf("no BODY[]<5> data item in FETCH response")
+	}
+}


### PR DESCRIPTION
Ports emersion/go-imap#766 (author: youdie006) and adds a wire-level regression test.

## Problem

`extractPartial` computed `end := partial.Offset + partial.Size` before checking bounds. Both values come from `ExpectNumber64`, which accepts anything up to `MaxInt64`, so an authenticated client sending

```
a4 FETCH 1 BODY[]<5.9223372036854775807>
```

wraps `end` negative. Neither guard catches it: `Offset > len(b)` is false, and `end > len(b)` is false because `end` is negative. The slice expression then panics:

```
panic handling command: runtime error: slice bounds out of range [:-9223372036854775804]
```

The per-connection `recover()` in `conn.go` contains it, so the blast radius is one dropped connection plus a logged stack trace, not a process crash. Still worth closing.

## Fix

Clamp the remaining length instead of summing the two decoder inputs, so no addition can overflow:

```go
size := int64(len(b)) - partial.Offset
if partial.Size >= 0 && partial.Size < size {
    size = partial.Size
}
return b[partial.Offset : partial.Offset+size]
```

Behavior is unchanged for in-range input: an oversized `Size` clamps to the end of the buffer, and `Offset+size` can no longer exceed `len(b)`. The negative-`Size` branch is defensive only; `numberStr` accepts digits only so a negative value can't arrive from the wire.

## Tests

- `imapserver/partial_test.go` (from upstream): unit cases for overflow, negative size, normal, and clamped ranges.
- `imapserver/partial_wire_test.go` (new here): sends the crafted FETCH to a real server and checks the tagged OK and the returned remainder. Verified it panics on the parent commit and passes on this branch.

`gofmt`, `go vet ./...`, and `go test ./...` are clean.

## Noted, not changed

`writeSectionSpec` and `WriteBinarySection` echo the origin octet with `Number(uint32(partial.Offset))`. RFC 9051 defines that field as `number64`, and the client's `readPartialOffset` reads a `uint32` too. Only offsets at or above 2^32 are affected, which `extractPartial` already answers with an empty section, so it's left for a separate change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0189SvqM4u2NhzLrALvFrBY9

---
_Generated by [Claude Code](https://claude.ai/code/session_0189SvqM4u2NhzLrALvFrBY9)_