### PR TITLE
imap: carry a number64 partial origin octet on both sides

### DIFF
--- a/imapclient/fetch.go
+++ b/imapclient/fetch.go
@@ -837,7 +837,7 @@ func (c *Client) handleFetch(seqNum uint32) error {
 						return fmt.Errorf("in section-binary: %w", err)
 					}
 					if offset != nil {
-						binSection.Partial = &imap.SectionPartial{Offset: int64(*offset)}
+						binSection.Partial = &imap.SectionPartial{Offset: *offset}
 					}
 					section = binSection
 				}
@@ -1451,18 +1451,21 @@ func readSectionSpec(dec *imapwire.Decoder) (*imap.FetchItemBodySection, error) 
 		return nil, err
 	}
 	if offset != nil {
-		section.Partial = &imap.SectionPartial{Offset: int64(*offset)}
+		section.Partial = &imap.SectionPartial{Offset: *offset}
 	}
 
 	return &section, nil
 }
 
-func readPartialOffset(dec *imapwire.Decoder) (*uint32, error) {
+// readPartialOffset reads the origin octet a server echoes after a partial
+// section. The request's offset is a number64 (RFC 9051 §9, partial), so a
+// server answering one at or above 2^32 has to echo more than 32 bits.
+func readPartialOffset(dec *imapwire.Decoder) (*int64, error) {
 	if !dec.Special('<') {
 		return nil, nil
 	}
-	var offset uint32
-	if !dec.ExpectNumber(&offset) || !dec.ExpectSpecial('>') {
+	var offset int64
+	if !dec.ExpectNumber64(&offset) || !dec.ExpectSpecial('>') {
 		return nil, dec.Err()
 	}
 	return &offset, nil

--- a/imapclient/partial_offset_test.go
+++ b/imapclient/partial_offset_test.go
@@ -1,0 +1,55 @@
+package imapclient_test
+
+import (
+	"testing"
+
+	"github.com/emersion/go-imap/v2"
+)
+
+// A server answering a number64 partial request echoes a number64 origin
+// octet (RFC 9051 §6.4.5 lets the request carry one). The client must read
+// it rather than fail the whole FETCH on a number wider than 32 bits.
+func TestFetchPartialOffsetWiderThan32Bits(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		resp string
+	}{
+		{"body", "* 1 FETCH (BODY[]<4294967301> \"\")\r\n"},
+		{"binary", "* 1 FETCH (BINARY[]<4294967301> \"\")\r\n"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			client := newCodeServer(t, tc.resp)
+			opts := &imap.FetchOptions{}
+			const offset = 1<<32 + 5
+			if tc.name == "body" {
+				opts.BodySection = []*imap.FetchItemBodySection{{Partial: &imap.SectionPartial{Offset: offset, Size: 10}}}
+			} else {
+				opts.BinarySection = []*imap.FetchItemBinarySection{{Partial: &imap.SectionPartial{Offset: offset, Size: 10}}}
+			}
+			msgs, err := client.Fetch(imap.SeqSetNum(1), opts).Collect()
+			if err != nil {
+				t.Fatalf("Fetch().Collect() = %v", err)
+			}
+			if len(msgs) != 1 {
+				t.Fatalf("got %d messages, want 1", len(msgs))
+			}
+			var got int64 = -1
+			if tc.name == "body" {
+				for _, s := range msgs[0].BodySection {
+					if s.Section.Partial != nil {
+						got = s.Section.Partial.Offset
+					}
+				}
+			} else {
+				for _, s := range msgs[0].BinarySection {
+					if s.Section.Partial != nil {
+						got = s.Section.Partial.Offset
+					}
+				}
+			}
+			if got != offset {
+				t.Errorf("parsed origin octet %d, want %d", got, offset)
+			}
+		})
+	}
+}

--- a/imapserver/fetch.go
+++ b/imapserver/fetch.go
@@ -543,8 +543,11 @@ func writeItemBodySection(enc *imapwire.Encoder, section *imap.FetchItemBodySect
 		}
 	}
 	enc.Special(']')
+	// The request carries a number64 offset (RFC 9051 §9, partial), so echo
+	// it whole: the client matches the response to its request by this
+	// number, and the low 32 bits of a larger offset name the wrong origin.
 	if partial := section.Partial; partial != nil {
-		enc.Special('<').Number(uint32(partial.Offset)).Special('>')
+		enc.Special('<').Number64(partial.Offset).Special('>')
 	}
 }
 
@@ -559,10 +562,10 @@ func (w *FetchResponseWriter) WriteBinarySection(section *imap.FetchItemBinarySe
 	enc.Atom("BINARY").Special('[')
 	writeSectionPart(enc, section.Part)
 	enc.Special(']')
-	// RFC 3516 §4.2.2: a partial BINARY response MUST echo the <origin octet>,
-	// e.g. BINARY[]<0> ~{n}. Mirror the BODY[...] path above.
+	// RFC 3516 §4.2 gives a partial BINARY the semantics of a partial BODY,
+	// so echo the origin octet the same way, e.g. BINARY[]<0> ~{n}.
 	if partial := section.Partial; partial != nil {
-		enc.Special('<').Number(uint32(partial.Offset)).Special('>')
+		enc.Special('<').Number64(partial.Offset).Special('>')
 	}
 	enc.SP()
 	enc.Special('~') // indicates literal8

--- a/imapserver/partial_offset_wire_test.go
+++ b/imapserver/partial_offset_wire_test.go
@@ -1,0 +1,137 @@
+package imapserver_test
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"strings"
+	"testing"
+
+	"github.com/emersion/go-imap/v2"
+	"github.com/emersion/go-imap/v2/imapclient"
+	"github.com/emersion/go-imap/v2/imapserver"
+	"github.com/emersion/go-imap/v2/imapserver/imapmemserver"
+)
+
+// RFC 9051 lets a client request a partial at a number64 offset. The origin
+// octet the server echoes must be that offset, not its low 32 bits: a client
+// matches the response to its request by that number, and an origin of 5
+// for a request at 2^32+5 claims the bytes start somewhere they do not.
+func TestFetchPartialOffsetEchoedInFull(t *testing.T) {
+	w := dialParseServer(t, nil)
+
+	msg := "Subject: hi\r\n\r\nhello world\r\n"
+	fmt.Fprintf(w.conn, "a2 APPEND INBOX {%d}\r\n", len(msg))
+	if l := w.line(); !strings.HasPrefix(l, "+") {
+		t.Fatalf("APPEND continuation: got %q", l)
+	}
+	fmt.Fprint(w.conn, msg+"\r\n")
+	if got := w.until("a2"); !strings.HasPrefix(got, "a2 OK") {
+		t.Fatalf("APPEND: %q", got)
+	}
+	fmt.Fprint(w.conn, "a3 SELECT INBOX\r\n")
+	if got := w.until("a3"); !strings.HasPrefix(got, "a3 OK") {
+		t.Fatalf("SELECT: %q", got)
+	}
+
+	for _, tc := range []struct {
+		tag, item, want string
+	}{
+		{"a4", "BODY[]<4294967301.10>", " BODY[]<4294967301> {0}"},
+		{"a5", "BODY[]<4294967296.10>", " BODY[]<4294967296> {0}"},
+		{"a6", "BINARY[]<4294967301.10>", " BINARY[]<4294967301> ~{0}"},
+	} {
+		t.Run(tc.item, func(t *testing.T) {
+			fmt.Fprintf(w.conn, "%s FETCH 1 %s\r\n", tc.tag, tc.item)
+			var data string
+			for {
+				l := w.line()
+				if strings.HasPrefix(l, tc.tag+" ") {
+					if !strings.HasPrefix(l, tc.tag+" OK") {
+						t.Fatalf("FETCH answered %q; want OK", l)
+					}
+					break
+				}
+				if strings.HasPrefix(l, "* 1 FETCH (") && strings.Contains(l, tc.item[:strings.IndexByte(tc.item, '<')]+"<") {
+					data = l
+				}
+			}
+			if !strings.HasSuffix(data, tc.want) {
+				t.Errorf("data item line %q; want it to end with %q", data, tc.want)
+			}
+		})
+	}
+}
+
+// The same offset through the client library: the client asks for a
+// number64 origin and must find the section the server sends back for it.
+func TestFetchPartialOffsetRoundTrip(t *testing.T) {
+	mem := imapmemserver.New()
+	u := imapmemserver.NewUser("u", "p")
+	if err := u.Create(context.Background(), "INBOX", nil); err != nil {
+		t.Fatal(err)
+	}
+	mem.AddUser(u)
+	srv := imapserver.New(&imapserver.Options{
+		NewSession: func(*imapserver.Conn) (imapserver.Session, *imapserver.GreetingData, error) {
+			return mem.NewSession(), nil, nil
+		},
+		InsecureAuth: true,
+		Caps:         imap.CapSet{imap.CapIMAP4rev1: {}, imap.CapIMAP4rev2: {}},
+	})
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { ln.Close() })
+	go srv.Serve(ln) //nolint:errcheck
+
+	conn, err := net.Dial("tcp", ln.Addr().String())
+	if err != nil {
+		t.Fatal(err)
+	}
+	c := imapclient.New(conn, nil)
+	t.Cleanup(func() { c.Close() })
+	if err := c.Login("u", "p").Wait(); err != nil {
+		t.Fatalf("LOGIN: %v", err)
+	}
+	msg := "Subject: hi\r\n\r\nhello world\r\n"
+	ac := c.Append("INBOX", int64(len(msg)), nil)
+	if _, err := ac.Write([]byte(msg)); err != nil {
+		t.Fatal(err)
+	}
+	if err := ac.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := ac.Wait(); err != nil {
+		t.Fatalf("APPEND: %v", err)
+	}
+	if _, err := c.Select("INBOX", nil).Wait(); err != nil {
+		t.Fatalf("SELECT: %v", err)
+	}
+
+	const offset = 1<<32 + 5
+	section := &imap.FetchItemBodySection{Partial: &imap.SectionPartial{Offset: offset, Size: 10}}
+	msgs, err := c.Fetch(imap.SeqSetNum(1), &imap.FetchOptions{BodySection: []*imap.FetchItemBodySection{section}}).Collect()
+	if err != nil {
+		t.Fatalf("FETCH: %v", err)
+	}
+	if len(msgs) != 1 {
+		t.Fatalf("got %d messages, want 1", len(msgs))
+	}
+	var found bool
+	for _, s := range msgs[0].BodySection {
+		if s.Section.Partial == nil {
+			t.Errorf("section came back without a partial")
+			continue
+		}
+		if s.Section.Partial.Offset == offset {
+			found = true
+		} else {
+			t.Errorf("section came back at offset %d, want %d", s.Section.Partial.Offset, offset)
+		}
+	}
+	if !found {
+		t.Errorf("no body section at offset %d in %d section(s)", offset, len(msgs[0].BodySection))
+	}
+}


### PR DESCRIPTION
Follow-up to #57, which noted this and left it for a separate change.

## Verified first

**Grammar.** RFC 9051 §9 defines the request as `partial = "<" number64 "." nz-number64 ">"` (0 to 2^63-1) but the response as `"BODY" section ["<" number ">"] SP nstring`, where `number` is 32-bit. The errata page for 9051 has three verified entries and none touch this, so the published grammar stands and cannot express an echo for an offset at or above 2^32. RFC 3516 has no origin octet in its BINARY response grammar at all; §4.2 gives a partial BINARY "the same semantics as a partial FETCH BODY", which is why this server echoes one.

**Server, on the wire.** Against a memserver before this change:

```
C: a4 FETCH 1 BODY[]<4294967301.10>
S: * 1 FETCH (UID 1 BODY[]<5> {0}
C: a5 FETCH 1 BODY[]<4294967296.10>
S: * 1 FETCH (UID 1 BODY[]<0> {0}
C: a6 FETCH 1 BINARY[]<4294967301.10>
S: * 1 FETCH (UID 1 BINARY[]<5> ~{0}
```

The low 32 bits are echoed, so the response claims the bytes start at 5 or 0 when the client asked for 2^32+5 or 2^32.

**Client library, round trip.** `imapclient` asking the server for offset 2^32+5 got a section back at offset 5, and `FindBodySection` could not match it to the request.

**Client parser.** A server echoing `BODY[]<4294967301>` (this one once fixed, or any other) failed the whole FETCH:

```
in response-data: in section-spec: imapwire: expected number, got ">"
```

## Change

- `imapserver/fetch.go`: `writeSectionSpec` and `WriteBinarySection` echo the offset with `Number64` instead of `Number(uint32(...))`. Byte-identical on the wire for offsets below 2^32. Corrects the comment that cited a nonexistent RFC 3516 §4.2.2.
- `imapclient/fetch.go`: `readPartialOffset` reads a `number64`; its two callers drop the widening cast.

Echoing the truth is the only answer that does not lie to the client that asked. An IMAP4rev1 client cannot send an offset above 32 bits (its request grammar is `number`), so nothing changes for it.

## Tests

Each fails on the parent commit and passes here.

- `imapserver/partial_offset_wire_test.go`: raw-wire echo of `<4294967301>` and `<4294967296>` for BODY and BINARY; plus an `imapclient` round trip against the memserver that finds its section at 2^32+5.
- `imapclient/partial_offset_test.go`: a fake server echoing a 64-bit origin for BODY and BINARY parses cleanly and yields the right offset.

`gofmt`, `go vet ./...`, and `go test ./...` are clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0189SvqM4u2NhzLrALvFrBY9

---
_Generated by [Claude Code](https://claude.ai/code/session_0189SvqM4u2NhzLrALvFrBY9)_